### PR TITLE
docs: cut v1.1.0 release notes, record tags, log merge in HANDOFF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.1.0] — 2026-05-24
+
+First post-cutover feature release. Tagged `v1.1.0` at the PR #2 merge; bundles
+the canonical plugin skill-set revision, the project adaptation overlay (ADAPT),
+and the return of change management as the GATE-SPEC framework-spec gate
+(CHG-D1) plus its formal governance record (CHG-D2). Framework spec **0.1.0 →
+0.3.1**.
+
 ### Changed
 - **Plugin layer-model migration (PLM).** Migrated the entire Claude Code
   plugin skill corpus (125 skills) from the legacy **12-layer** SDD model to the

--- a/docs/TAGGING.md
+++ b/docs/TAGGING.md
@@ -104,6 +104,10 @@ names and make `git tag -l '<prefix>/*'` an effective per-stream filter.
 | `v0.5.0` | Phase 4 close | Conformance & Independence milestone |
 | `v1.0.0` | Phase 5 close | Cutover milestone — multi-platform project complete |
 | `claude-code-plugin/v0.2.0` | Plugin 8-layer migration close | Claude Code plugin — full 8-layer SDD model (46 skills, 9-agent roster) + marketplace install |
+| `framework/v0.2.0` | ADAPT close (`f22fe6a`) | Framework spec — project adaptation overlay (ADAPTATION surface, D-0019) |
+| `framework/v0.3.0` | CHG-D1 close (`f8e8bf5`) | Framework spec — GATE-SPEC framework-spec change gate (D-0020) |
+| `framework/v0.3.1` | CHG-D2 (`3753de2`) | Framework spec — governance decision register, GD-01 |
+| `v1.1.0` | PR #2 merge (`3974daa`) | Post-cutover feature release — skill-set revision + adaptation overlay + CHG GATE-SPEC |
 
 > Phase 1 tags (`v0.1.0`, `v0.2.0`, `framework/v0.1.0`) are published
 > on the remote. Phase 2 tags (`v0.3.0`, `hermes/v0.1.0`), Phase 3
@@ -116,6 +120,10 @@ names and make `git tag -l '<prefix>/*'` an effective per-stream filter.
 > `plans/P4-T5-PLAN.md` §Approach.6 for the exact local-clone
 > commands. Verify any tag's publication via
 > `git ls-remote --tags origin`.
+>
+> The post-cutover tags (`framework/v0.2.0`, `framework/v0.3.0`,
+> `framework/v0.3.1`, and the project milestone `v1.1.0`) are **published** on
+> the remote, created from a local clone at the PR #2 merge.
 
 ## In-container push restrictions
 

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -1,5 +1,29 @@
 # Session Handoff
 
+> **✅ MERGED TO MAIN — PR #2 (2026-05-24).** The whole post-v1.0.0 line landed
+> on `main` (merge commit `3974daa`): canonical 54-skill plugin set, ADAPT
+> overlay, **CHG-D1 / GATE-SPEC**, **CHG-D2 / GD-01**. All four PR checks were
+> green pre-merge — including the **Framework-spec change gate**, GATE-SPEC's
+> first real enforcement (E005 VERSION + E008 CHANGELOG + E006/E007 conformance)
+> on a live PR. `main` is the integration line; `claude/skill-revision` is merged
+> (safe to delete). Framework spec **0.3.1**; conformance 43; the `workflows`
+> permission is now granted (so `.github/workflows/**` is pushable in-container).
+>
+> **Remaining (user-only):**
+> - **Branch protection on `framework/**`** (repo → Settings → Branches) — the
+>   human-approval half of GATE-SPEC. The automated half now enforces via the
+>   `chg-gate.yml` workflow; the human sign-off exists only once this rule is set.
+> - **Release tags** — annotated; tag pushes still 403 in-container (separate
+>   from the workflows scope, see `docs/TAGGING.md`), so push from a local clone:
+>   ```sh
+>   git tag -a framework/v0.2.0 f22fe6a -m "Framework spec v0.2.0 — adaptation overlay (ADAPT, D-0019)"
+>   git tag -a framework/v0.3.0 f8e8bf5 -m "Framework spec v0.3.0 — GATE-SPEC framework-spec change gate (CHG-D1, D-0020)"
+>   git tag -a framework/v0.3.1 3753de2 -m "Framework spec v0.3.1 — governance decision register (CHG-D2, GD-01)"
+>   git push origin framework/v0.2.0 framework/v0.3.0 framework/v0.3.1
+>   ```
+>   Optional project milestone tag: `git tag -a v1.1.0 3974daa -m "Post-cutover feature release — adaptation overlay + CHG GATE-SPEC" && git push origin v1.1.0`.
+> - Delete the merged `claude/skill-revision` branch.
+
 > **✅ CHG-D2 COMPLETE — framework governance decision register (2026-05-23).**
 > Established `framework/governance/DECISIONS.md` — the spec's own durable home
 > for decisions about the spec + its governance — and recorded the CHG
@@ -158,10 +182,10 @@ Timestamps are ISO 8601 UTC (`YYYY-MM-DDThh:mm:ssZ`).
 
 | Field         | Value                                      |
 |---------------|--------------------------------------------|
-| Last updated  | 2026-05-23T00:00:00Z                       |
-| Working branch| `claude/skill-revision` (user-confirmed)   |
-| Current phase | Post-migration features on `claude/skill-revision`: **ADAPT** (D-0019), **CHG-D1 / GATE-SPEC** (D-0020), **CHG-D2** (GD-01) all complete. Framework spec **0.3.1**; 54 skills; conformance **43**; `plm_lint` clean. |
-| Next task     | **None in-container** — the CHG ROADMAP items are done. **User-only:** relocate `plans/workflows-pending/*.yml` → `.github/workflows/`; branch protection on `framework/**` (the human-approval half of GATE-SPEC); push `framework/v0.3.1` + release tags from a local clone. |
+| Last updated  | 2026-05-24T00:00:00Z                       |
+| Working branch| `main` (PR #2 merged; `claude/skill-revision` merged, safe to delete) |
+| Current phase | Post-cutover features all landed on `main` (merge `3974daa`): **ADAPT** (D-0019), **CHG-D1 / GATE-SPEC** (D-0020), **CHG-D2 / GD-01**. Framework spec **0.3.1**; 54 skills; conformance **43**; GATE-SPEC CI enforcing on PRs. |
+| Next task     | **None pending in-container.** **User-only:** branch protection on `framework/**`; push the framework `v0.2.0/v0.3.0/v0.3.1` tags (+ optional `v1.1.0`) from a local clone (see top blockquote). |
 
 ## Progress
 


### PR DESCRIPTION
## Summary

Doc tidy-ups following the PR #2 merge and the `v1.1.0` tagging — three small,
docs-only changes (no `framework/` or platform code touched):

- **`CHANGELOG.md`** — cut `## [Unreleased]` → `## [1.1.0] — 2026-05-24` (with a
  fresh empty `[Unreleased]` on top), now that `v1.1.0` is tagged at the PR #2
  merge. The accumulated entries (PLM, ADAPT, CHG-D1, CHG-D2) become the v1.1.0
  release notes.
- **`docs/TAGGING.md`** — add the four published post-cutover tags
  (`framework/v0.2.0`, `framework/v0.3.0`, `framework/v0.3.1`, project `v1.1.0`)
  to the "Current tags" table + a publication note.
- **`plans/HANDOFF.md`** — record the PR #2 merge, GATE-SPEC's first live
  enforcement, and the remaining user-only items (branch protection, branch
  cleanup) for the next session. *(This is the `0a5723e` commit carried over.)*

## Verification

- Conformance suite green (these are docs outside `framework/`, so unaffected).
- The GATE-SPEC gate no-ops on this PR (no `framework/` change → no VERSION/CHANGELOG
  coupling to enforce).

## Test plan

- [ ] CI green (conformance; GATE-SPEC no-op; plugin/Hermes jobs skip — no
      platform paths touched).
- [ ] CHANGELOG renders with `[1.1.0]` as the top released section.

https://claude.ai/code/session_013duDkfbMr9Xhe15movDVxf

---
_Generated by [Claude Code](https://claude.ai/code/session_013duDkfbMr9Xhe15movDVxf)_