### PR TITLE
docs: refresh project docs to post-cutover (v1.1.0) state

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ conformance suite at `tests/conformance/`.
 
 | Platform | Engine | Release |
 |----------|--------|---------|
-| **Hermes AI** | MCP server | `hermes/v0.1.0` (`platforms/hermes/`) |
+| **Hermes AI** | MCP server | `hermes/v0.1.1` (`platforms/hermes/`) |
 | **Claude Code plugin** | Native Claude Code (skills / agents / commands) | `claude-code-plugin/v0.2.0` (`platforms/claude-code-plugin/`) |
 
 See [`docs/PARITY.md`](docs/PARITY.md) for the capability comparison and a
@@ -41,10 +41,30 @@ From Claude Code:
 /plugin install aidoc-flow@aidoc-flow-framework
 ```
 
+## Status
+
+The migration is complete (cutover shipped as `v1.0.0`); the project is now in
+**post-cutover development** — latest project release `v1.1.0`, framework spec
+`0.3.x`. Post-v1.0 work to date: the project adaptation overlay, the GATE-SPEC
+change-management gate (`framework/governance/chg/`), and the pre-commit + CI
+security tooling (CodeQL, bandit, detect-secrets, pip-audit, Dependabot).
+
+## Contributing
+
+Enable the pre-commit hooks before committing:
+
+```sh
+pip install pre-commit && pre-commit install
+```
+
+See `.pre-commit-config.yaml` for the hook set and [`SECURITY.md`](SECURITY.md)
+for the vulnerability-reporting policy.
+
 ## Documentation
 
-- `ROADMAP.md` — phased delivery plan (Phase 0 → cutover `v1.0.0`).
+- `ROADMAP.md` — delivery plan and post-v1.0 work (migration complete at `v1.0.0`).
 - `CHANGELOG.md` — project-level changelog.
+- `SECURITY.md` — security policy and vulnerability reporting.
 - `docs/REPO_STRUCTURE.md` — repository layout (as-built).
 - `docs/PROJECT.md` — versioning, branching, milestones, conformance, change management.
 - `docs/TAGGING.md` — git-tag policy (release + bookmark tags).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,10 +3,10 @@
 | Field            | Value                                                        |
 |------------------|--------------------------------------------------------------|
 | Project          | AI Doc Flow Framework (multi-platform)                       |
-| Status           | **Migration complete** — Phase 5 done (`v1.0.0`); new project ready to replace `main` |
-| Working branch   | `claude/multi-platform-migration-AamWB`                      |
-| Origin           | Forked from `main` (`ucx_framework` v0.20.4)                 |
-| Cutover target   | v1.0.0 — new project replaces `main`                         |
+| Status           | **Migration complete** (cutover shipped as `v1.0.0`); post-cutover development — latest project release `v1.1.0` |
+| Development      | `main` + short-lived `claude/*` feature branches (the migration branch is merged and deleted) |
+| Origin           | Forked from `ucx_framework` v0.20.4 (preserved on `legacy-ucx-v3.2-read-only`) |
+| Cutover          | `v1.0.0` — done; `main` is the multi-platform project        |
 | Created          | 2026-05-18                                                   |
 
 ## Goal
@@ -97,6 +97,25 @@ Change Management for the full policy.
 |------|---------------------|---------|
 | ~~**CHG-D1 — CHG implementation model**~~ ✅ **DONE (2026-05-23, D-0020)** | CHG implemented as **skills + CI/CD**, both platforms, against the shared spec. Added **GATE-SPEC**, the *meta* gate governing `framework/` spec changes (orthogonal to the artifact gates). Record-level checks (E001–E004) run in the plugin `gate-check`/`doc-chg` skills and the Hermes `validation/chg_rules.py`; diff-aware checks (E005 VERSION bump, E008 CHANGELOG) ship as `tests/chg/spec_gate.py` + a staged CI workflow; static checks (E006 spec-version match, E007 suite green) are the conformance suite; the human sign-off (E004) is GitHub branch protection / required reviewers — a skill never self-approves. Unblocks `knowledge-extractor` spec promotion. | Done |
 | ~~**CHG-D2 — CHG as a `framework/` decision**~~ ✅ **DONE (2026-05-23)** | Established `framework/governance/DECISIONS.md` — the spec's own durable decision register — and recorded CHG-D1 there as **GD-01** (engine-agnostic). The migration log's spec-affecting decisions now graduate here; D-0013 + D-0019 are listed pending. Recording it was itself a GATE-SPEC change (framework spec 0.3.0 → 0.3.1). | Done |
+
+## Post-v1.0 — Shipped
+
+Delivered after the cutover (project release `v1.1.0`; framework spec `0.1.0 →
+0.3.1`):
+
+- **Canonical plugin skill set** — the corpus was pruned/recreated to one
+  standard (P3-T6/T7) and grew to **54 skills** with the CHG family,
+  `gate-check`, `project-adopt`, `project-profile`, and `knowledge-extractor`.
+- **Project adaptation overlay** (ADAPT, D-0019) — `framework/governance/
+  ADAPTATION.md` + `ADAPTATION_SURFACE.yaml` (a closed knob set) and the
+  `project-profile` / `knowledge-extractor` skills.
+- **Change management returned** (CHG-D1/D2 above) — **GATE-SPEC**, the
+  framework-spec change gate, enforced by skills + CI + branch protection;
+  recorded as **GD-01** in `framework/governance/DECISIONS.md`.
+- **Pre-commit + security tooling** — `.pre-commit-config.yaml` (ruff, bandit,
+  markdownlint, yamllint, detect-secrets, pip-audit, conformance) and CI
+  workflows for pre-commit, **CodeQL**, and the GATE-SPEC gate; `SECURITY.md`;
+  refreshed `.github/` metadata (CODEOWNERS, dependabot, labeler — INFRA-1).
 
 ## Post-v1.0 — Planned Capabilities
 

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -5,11 +5,12 @@ AI Doc Flow framework — **Hermes** (MCP server) and the **Claude
 Code plugin** — so users picking between them see the capability
 shape on each side.
 
-> Status: as of `v1.0.0` / `hermes/v0.1.1` /
-> `claude-code-plugin/v0.2.0` (2026-05-23; both platforms on the
-> 8-layer model; plugin skill set revised to the canonical 46 —
-> task P3-T6). Updates land when a platform ships a structurally
-> different capability, not per-PR.
+> Status: as of project `v1.1.0` / `hermes/v0.1.1` /
+> `claude-code-plugin/v0.2.0` (2026-05-24; both platforms on the
+> 8-layer model; plugin skill set is the canonical **54** — the P3-T6
+> base plus the CHG family + `gate-check` + `project-adopt` (P3-T7) and
+> `project-profile` + `knowledge-extractor` (ADAPT)). Updates land when
+> a platform ships a structurally different capability, not per-PR.
 
 Both platforms pass the shared conformance suite at
 [`../tests/conformance/`](../tests/conformance/) and consume the

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -34,18 +34,20 @@ project from legacy `ucx_framework` v0.20.4). Cutover ships `v1.0.0`.
 
 ## 3. Branching & Tagging
 
-- **Working branch:** `claude/multi-platform-migration-AamWB`. All migration
-  work lands here.
-- **Milestone tags:** each completed phase is tagged (`v0.1.0` … `v0.5.0`,
-  then `v1.0.0` at cutover).
-- **Cutover:** at Phase 5 the new project replaces `main`. The pre-migration
-  `main` (the legacy `ucx_framework`) is preserved beforehand on the
-  protected, read-only branch **`legacy-ucx-v3.2-read-only`**, so the
-  replacement is lossless.
-- **`main` was protected (locked / read-only) for the duration of the
-  migration** — all migration work happened on
-  `claude/multi-platform-migration-AamWB`; `main` is replaced (force-updated
-  to the migration branch) only at the Phase 5 cutover.
+- **Development:** `main` is the multi-platform project (since the `v1.0.0`
+  cutover). Work lands via short-lived `claude/*` feature branches → PR → `main`;
+  the migration branch `claude/multi-platform-migration-AamWB` has been merged
+  and deleted.
+- **Milestone tags:** each migration phase was tagged (`v0.1.0` … `v0.5.0`,
+  then `v1.0.0` at cutover); post-v1.0 releases tag from `main` (e.g. `v1.1.0`,
+  `framework/v0.3.1`).
+- **Cutover (done):** at Phase 5 the new project replaced `main`. The
+  pre-migration `main` (legacy `ucx_framework`) is preserved on the protected,
+  read-only branch **`legacy-ucx-v3.2-read-only`**, so the replacement was
+  lossless.
+- **Branch protection:** changes to `framework/**` require code-owner review
+  plus the `Framework-spec change gate` status check — the human half of
+  GATE-SPEC (§6).
 - Platforms tag their own releases independently.
 
 ### Tag namespaces
@@ -87,7 +89,8 @@ The gated CHG process is **not** applied to migration work. Interim controls:
 - Pull-request review on the working branch.
 - Conventional commit messages.
 - `CHANGELOG.md` updated per change.
-- Significant decisions recorded as markdown ADRs in `docs/architecture/`.
+- Significant decisions recorded in the decision log `plans/DECISIONS.md`;
+  spec-affecting ones graduate to `framework/governance/DECISIONS.md`.
 
 ### After cutover — CHG re-introduced
 
@@ -123,6 +126,6 @@ gates) — see `framework/governance/chg/gates/GATE-SPEC_FRAMEWORK.md`.
   verifies the approval form but is never the authority that grants approval.
 
 Implemented twice against the same `framework/` spec — the Claude Code plugin
-(skills + a staged CI workflow) and Hermes (server-side `validation/chg_rules.py`)
-— validated by the shared conformance suite. The remaining follow-up is **CHG-D2**
-(record this as a formal `framework/governance/` decision).
+(skills + CI workflow) and Hermes (server-side `validation/chg_rules.py`) —
+validated by the shared conformance suite. **CHG-D2** is done: the model is
+recorded as **GD-01** in `framework/governance/DECISIONS.md`.

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -1,9 +1,10 @@
 # Repository Structure — AI Doc Flow Framework (Multi-Platform)
 
-> Status: **as-built (post-migration).** Created 2026-05-18; the repository
-> converged to this layout through Phases 1–5. The `legacy/` tree has been
-> removed (preserved as the protected `legacy-ucx-v3.2-read-only` branch);
-> the new project replaces `main` at the Phase 5 cutover (`v1.0.0`).
+> Status: **as-built (post-cutover).** Created 2026-05-18; the repository
+> converged to this layout through Phases 1–5 and replaced `main` at the
+> `v1.0.0` cutover. The `legacy/` tree was removed (preserved on the protected
+> `legacy-ucx-v3.2-read-only` branch). Post-v1.0 additions (CI + security
+> tooling, the GATE-SPEC change gate, the adaptation overlay) are reflected below.
 
 ## Principles
 
@@ -20,39 +21,45 @@
 ```
 aidoc-flow-framework/
 ├── README.md                       Project overview, platform matrix
-├── ROADMAP.md                      Phased delivery plan (project-level)
+├── ROADMAP.md                      Delivery plan + post-v1.0 work
 ├── CHANGELOG.md                    Project-level changelog (Keep a Changelog)
+├── SECURITY.md                     Security policy / vulnerability reporting
 ├── LICENSE
+├── .pre-commit-config.yaml         Pre-commit hooks (lint / format / security)
+├── ruff.toml · .markdownlint.json · .markdownlintignore · .yamllint · .secrets.baseline
+├── .github/
+│   ├── workflows/                  CI: conformance, hermes, plugin, pre-commit, codeql, chg-gate, labeler
+│   ├── CODEOWNERS · dependabot.yml · labeler.yml
+│   └── ISSUE_TEMPLATE/ · PULL_REQUEST_TEMPLATE.md
 ├── docs/
 │   ├── REPO_STRUCTURE.md            This file
-│   ├── PROJECT.md                   Project management: versioning, branches, milestones
-│   └── architecture/                Decision records (MADR markdown)
+│   ├── PROJECT.md                   Versioning, branches, milestones, change management
+│   ├── PARITY.md                    Hermes ↔ plugin capability comparison
+│   ├── TAGGING.md                   Git-tag policy
+│   └── STARTUP_HANDOFF.md
 │
 ├── framework/                       SHARED engine-agnostic specification (the contract)
 │   ├── VERSION                      Framework spec SemVer
 │   ├── layers/                      01_BRD … 08_IPLAN: definitions, templates, schemas
-│   ├── governance/                  Governance rules, CHG overlay, gate definitions
+│   ├── governance/                  Rules; CHG overlay (gates incl. GATE-SPEC);
+│   │                                ADAPTATION surface; DECISIONS.md (GD register)
 │   └── registry/LAYER_REGISTRY.yaml
 │
 ├── platforms/
 │   ├── hermes/                      PLATFORM A — Hermes AI (MCP-server engine)
-│   │   ├── VERSION
-│   │   ├── CHANGELOG.md
-│   │   ├── README.md
-│   │   └── src/ tests/ ...
+│   │   ├── FRAMEWORK_SPEC_VERSION   Spec version it conforms to
+│   │   └── VERSION · CHANGELOG.md · README.md · src/ · tests/
 │   │
 │   └── claude-code-plugin/          PLATFORM B — Claude Code plugin (native engine)
-│       ├── .claude-plugin/plugin.json
-│       ├── VERSION
-│       ├── CHANGELOG.md
-│       ├── README.md
-│       ├── skills/                  doc-* skill set (the engine)
-│       ├── commands/                slash commands
-│       ├── agents/                  subagents
-│       └── hooks/
+│       ├── .claude-plugin/          plugin.json + marketplace.json
+│       ├── FRAMEWORK_SPEC_VERSION   Spec version it conforms to
+│       └── VERSION · README.md · skills/ · commands/ · agents/
 │
-└── tests/
-    └── conformance/                 Shared suite both platforms must pass
+├── tests/
+│   ├── conformance/                 Shared suite both platforms must pass
+│   └── chg/                         GATE-SPEC diff-aware guard (spec_gate.py)
+│
+└── plans/                           Migration record: per-task plans, DECISIONS.md, HANDOFF.md, …
 ```
 
 ## Legacy → Target Mapping (historical record)


### PR DESCRIPTION
## Summary

Refreshes the **project-level docs** to the post-cutover (`v1.1.0`) state, fixing the stale/incorrect references found in review. No `framework/` files touched (GATE-SPEC no-ops); `framework/README.md` is fixed in a separate GATE-SPEC patch PR.

**Factually-wrong fixes:**
- Removed the **deleted migration branch** as the "working branch" (`ROADMAP.md`, `docs/PROJECT.md` §3).
- Cutover framed as **done** (was "ready to replace `main`") across ROADMAP / PROJECT / REPO_STRUCTURE.
- Dropped the **nonexistent `docs/architecture/`** ref; decisions live in `plans/DECISIONS.md` + `framework/governance/DECISIONS.md` (REPO_STRUCTURE, PROJECT §6).
- **CHG-D2** marked done (was "remaining") in PROJECT §6.
- README **Hermes `v0.1.0` → `v0.1.1`** (matches PARITY).
- PARITY status note skill count **46 → 54**.

**Completeness fixes:**
- README: added **Status** + **Contributing** (pre-commit) sections and `SECURITY.md` to the docs list.
- ROADMAP: new **"Post-v1.0 — Shipped"** section (canonical 54-skill set, ADAPT, CHG/GATE-SPEC, pre-commit + security/INFRA-1).
- REPO_STRUCTURE: layout now shows `.github/`, `plans/`, `SECURITY.md`, lint configs, `tests/chg/`, and `governance/` ADAPTATION + DECISIONS.

## Verification

- `pre-commit` (markdownlint, etc.) clean; conformance green; GATE-SPEC no-op (no `framework/` change).

https://claude.ai/code/session_013duDkfbMr9Xhe15movDVxf

---
_Generated by [Claude Code](https://claude.ai/code/session_013duDkfbMr9Xhe15movDVxf)_