### PR TITLE
fix(hermes): align EARS pattern tables to framework canonical model (FRWK-REVIEW #4b follow-up)

### DIFF
--- a/plans/FRWK-REVIEW-4b-EARS-MODEL-PLAN.md
+++ b/plans/FRWK-REVIEW-4b-EARS-MODEL-PLAN.md
@@ -217,3 +217,17 @@ statement model — which is how the drift accumulated).
 - **Deferred (tracked):** Hermes vendored `agent-skills`/`prompts` EARS tables
   (6-pattern, mixed `THEN`) — a platform follow-up, not a framework-spec change.
 - **Pending:** open PR.
+
+### 2026-05-25 — deferred Hermes follow-up done (branch `claude/hermes-ears-align`)
+
+- Aligned the Hermes vendored EARS pattern surfaces to the framework's canonical
+  5-pattern / `the [system] shall` model (no `THEN`; "complex" = composition):
+  `skills/personas/requirements_specialist.md`,
+  `agent-skills/.../sdd-review-personas/SKILL.md`, and the EARS prompt templates
+  `prompts/templates/{creation/UCC_PROMPT_EARS, creation/UCC_OUTPUT_SCHEMA,
+  review/UCR_PROMPT_EARS, remediation/UCRem_PROMPT_EARS}.md` (tables → 5 rows +
+  composition note; `IF…THEN`/`IF-THEN` → `IF … the system shall`; dropped the
+  `Complex` row + `CX` type code). Platform-only — no `framework/` change, no spec
+  bump; recorded in `platforms/hermes/CHANGELOG.md`. Conformance still 49/49.
+  **Still separate:** the prompts' legacy type-code element-ID scheme
+  (`EARS.NN.<code>.<seq>`) vs the framework hash IDs — a larger, distinct cleanup.

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -1,5 +1,20 @@
 # Session Handoff
 
+> **🔵 HERMES EARS ALIGNMENT READY — deferred #4b follow-up (2026-05-25).** Branch
+> **`claude/hermes-ears-align`** (cut from `main`). Closed the one item deferred
+> from FRWK-REVIEW #4b: aligned the Hermes **vendored** EARS pattern surfaces to
+> the framework's canonical 5-pattern / `the [system] shall` model (no `THEN`;
+> "complex" = composition). Edited 6 files — the two persona docs
+> (`requirements_specialist`, `sdd-review-personas`) and the EARS prompt templates
+> (`UCC_PROMPT_EARS`, `UCC_OUTPUT_SCHEMA`, `UCR_PROMPT_EARS`, `UCRem_PROMPT_EARS`):
+> tables → 5 rows + composition note; `IF…THEN`/`IF-THEN` → `IF … the system
+> shall`; dropped the standalone `Complex` row + `CX` type code. **Platform-only**
+> — no `framework/` change, no spec bump (spec stays `0.6.0`); recorded in
+> `platforms/hermes/CHANGELOG.md`. Conformance **49/49**; lint clean (vendored
+> content skips markdownlint). **Still separate (not done):** the prompts' legacy
+> type-code element-ID scheme (`EARS.NN.<code>.<seq>`) vs the framework hash IDs —
+> a larger, distinct cleanup. **Next:** open the PR.
+>
 > **🔵 FRWK-REVIEW #4b READY — EARS statement-model reconciliation (2026-05-25).**
 > The deferred EARS finding, implemented on branch **`claude/frwk-review-4b-ears-model`**
 > (pushed, cut from `main` after the FRWK-REVIEW PRs). Plan:

--- a/platforms/hermes/CHANGELOG.md
+++ b/platforms/hermes/CHANGELOG.md
@@ -14,6 +14,23 @@ this platform adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Changed
+
+- **EARS pattern alignment** — brought the Hermes vendored EARS pattern tables
+  into line with the framework's canonical statement model (framework spec
+  `0.6.0`, FRWK-REVIEW #4b). The persona docs (`skills/personas/requirements_specialist.md`,
+  `agent-skills/.../sdd-review-personas/SKILL.md`) and the EARS prompt templates
+  (`prompts/templates/{creation/UCC_PROMPT_EARS,creation/UCC_OUTPUT_SCHEMA,
+  review/UCR_PROMPT_EARS,remediation/UCRem_PROMPT_EARS}.md`) had drifted to a
+  6-pattern model with a mixed `IF…THEN` connective. Now: the five canonical
+  patterns (Ubiquitous, Event/`WHEN`, State/`WHILE`, Optional/`WHERE`,
+  Unwanted/`IF`) in the uniform `the [system] shall …` form (no `THEN`); "complex"
+  reframed as *composition* of the base patterns (the standalone `Complex` row +
+  the `CX` type code removed). Doc-only; no runtime behavior change.
+  *(Note: the prompts' legacy type-code element-ID scheme — `EARS.NN.<code>.<seq>`
+  vs the framework's hash-based `EARS.NN.SS.xxxx` — is a separate, pre-existing
+  divergence, out of scope here.)*
+
 ## [0.1.1] — 2026-05-21
 
 Patch — corrects a stale install instruction. Conforms to framework

--- a/platforms/hermes/agent-skills/spec-driven-development/sdd-review-personas/SKILL.md
+++ b/platforms/hermes/agent-skills/spec-driven-development/sdd-review-personas/SKILL.md
@@ -460,15 +460,19 @@ Verify the category tag is correct. Suggest correction if misassigned.
 | Event-Driven | WHEN | WHEN [event], the [system] shall [action] |
 | State-Driven | WHILE | WHILE [state], the [system] shall [action] |
 | Optional | WHERE | WHERE [condition], the [system] shall [action] |
-| Unwanted | IF-THEN | IF [condition], THEN the [system] shall NOT [action] |
-| Complex | WHILE+WHEN | WHILE [state], WHEN [event], the [system] shall [action] |
+| Unwanted | IF | IF [condition], the [system] shall [response] |
+
+> Multi-condition ("complex") requirements *compose* the base patterns
+> (e.g. `WHILE [state], WHEN [event], the [system] shall [action]`) — composition,
+> not a separate pattern. This framework uses `the [system] shall …` uniformly
+> (no `THEN` connective).
 
 ### Pattern Selection Rules
 
 - **WHEN** = Event (discrete occurrence, point in time)
 - **WHILE** = State (continuous condition, duration)
 - **WHERE** = Feature/Configuration (optional capability)
-- **IF-THEN** = Exception/Prohibition (unwanted behavior)
+- **IF** = Exception / unwanted behavior (the system shall [response])
 
 ### INCOSE Atomic Structure Requirements
 

--- a/platforms/hermes/prompts/templates/creation/UCC_OUTPUT_SCHEMA.md
+++ b/platforms/hermes/prompts/templates/creation/UCC_OUTPUT_SCHEMA.md
@@ -132,7 +132,7 @@ custom_fields:
 - Event-Driven: "When [event], the [system] shall [action]"
 - State-Driven: "While [state], the [system] shall [action]"
 - Optional: "Where [feature included], the [system] shall [action]"
-- Unwanted: "If [condition], then the [system] shall [action]"
+- Unwanted: "If [condition], the [system] shall [action]"
 
 ---
 

--- a/platforms/hermes/prompts/templates/creation/UCC_PROMPT_EARS.md
+++ b/platforms/hermes/prompts/templates/creation/UCC_PROMPT_EARS.md
@@ -51,10 +51,14 @@ Where {feature is enabled}, the {system} shall {action}.
 ### Unwanted Behavior Requirements
 
 ```
-If {unwanted condition}, then the {system} shall {response}.
+If {unwanted condition}, the {system} shall {response}.
 ```
 
-### Complex Requirements
+### Complex (Composed) Requirements
+
+Multi-condition requirements *compose* the base patterns — this is composition,
+not a separate pattern. Keep each statement atomic; type a composed requirement
+by its primary pattern code (e.g. `EV` or `ST`).
 
 ```
 While {state}, when {event}, the {system} shall {action}.
@@ -75,7 +79,6 @@ Categories:
 - `ST` = State-driven
 - `OP` = Optional
 - `UW` = Unwanted behavior
-- `CX` = Complex
 
 Example: `EARS.01.EV.15` = EARS-01, Event-driven requirement #15
 

--- a/platforms/hermes/prompts/templates/remediation/UCRem_PROMPT_EARS.md
+++ b/platforms/hermes/prompts/templates/remediation/UCRem_PROMPT_EARS.md
@@ -44,8 +44,12 @@ Valid EARS patterns:
 | **Event-Driven** | When [event], the [system] shall [action] | Triggered behavior |
 | **State-Driven** | While [state], the [system] shall [action] | Conditional behavior |
 | **Optional** | Where [feature], the [system] shall [action] | Feature-dependent |
-| **Unwanted** | If [condition], then the [system] shall [action] | Exception handling |
-| **Complex** | Combination of above patterns | Multi-condition |
+| **Unwanted** | If [condition], the [system] shall [action] | Exception handling |
+
+> Multi-condition ("complex") requirements *compose* the base patterns
+> (e.g. `While [state], when [event], the [system] shall [action]`) — composition,
+> not a separate pattern. This framework uses `the [system] shall …` uniformly
+> (no `then` connective).
 
 ---
 

--- a/platforms/hermes/prompts/templates/review/UCR_PROMPT_EARS.md
+++ b/platforms/hermes/prompts/templates/review/UCR_PROMPT_EARS.md
@@ -25,7 +25,7 @@ You are an AI Expert Board conducting a Unified Context Review (UCR) of an EARS 
 
 Before claiming an item is PRESENT, verify it meets ALL criteria:
 
-1. **Syntactically correct** - Follows EARS pattern exactly (WHEN/WHILE/WHERE/IF-THEN)
+1. **Syntactically correct** - Follows EARS pattern exactly (WHEN/WHILE/WHERE/IF + THE…SHALL)
 2. **Atomic** - One requirement per statement, no compound requirements
 3. **Unambiguous** - No vague terms ("quickly", "efficiently", "user-friendly")
 4. **Measurable** - Verifiable criteria present
@@ -69,8 +69,12 @@ Every finding MUST include:
 | **Event-Driven** | WHEN [event], the [system] shall [action] | WHEN user submits form, the system shall validate inputs |
 | **State-Driven** | WHILE [state], the [system] shall [action] | WHILE transaction pending, the system shall display status |
 | **Optional** | WHERE [condition], the [system] shall [action] | WHERE user is admin, the system shall display audit logs |
-| **Unwanted** | IF [condition], THEN the [system] shall NOT [action] | IF session expired, THEN the system shall NOT process request |
-| **Complex** | WHILE [state], WHEN [event], the [system] shall [action] | WHILE logged in, WHEN timeout occurs, the system shall prompt reauthentication |
+| **Unwanted** | IF [condition], the [system] shall [response] | IF session expired, the system shall reject the request |
+
+> Multi-condition ("complex") requirements *compose* the base patterns
+> (e.g. `WHILE [state], WHEN [event], the [system] shall [action]`) — composition,
+> not a separate pattern. This framework uses `the [system] shall …` uniformly
+> (no `THEN` connective).
 
 ---
 
@@ -82,7 +86,7 @@ Every finding MUST include:
 
 Focus on:
 
-- **Pattern compliance**: Is WHEN/WHILE/WHERE/IF-THEN used CORRECTLY?
+- **Pattern compliance**: Is WHEN/WHILE/WHERE/IF used CORRECTLY?
 - **Atomicity**: Is there EXACTLY one requirement per statement?
 - **Language precision**: Are "shall" (not "should/may/might") used CONSISTENTLY?
 - **Measurability**: Is EVERY requirement verifiable with a specific test?
@@ -199,7 +203,7 @@ Output format:
 
 Focus on:
 
-- **UNWANTED patterns**: Are IF-THEN negative requirements PRESENT?
+- **UNWANTED patterns**: Are IF (unwanted-behavior) requirements PRESENT?
 - **Boundary conditions**: Are edge cases SPECIFIED as requirements?
 - **Error states**: Are failure behaviors DEFINED?
 - **Concurrency**: Are race conditions ADDRESSED?

--- a/platforms/hermes/skills/personas/requirements_specialist.md
+++ b/platforms/hermes/skills/personas/requirements_specialist.md
@@ -18,15 +18,19 @@ You are the formal requirements expert, specializing in EARS (Easy Approach to R
 | **Event-Driven** | WHEN | WHEN [event], the [system] shall [action] |
 | **State-Driven** | WHILE | WHILE [state], the [system] shall [action] |
 | **Optional** | WHERE | WHERE [condition], the [system] shall [action] |
-| **Unwanted** | IF-THEN | IF [condition], THEN the [system] shall NOT [action] |
-| **Complex** | WHILE+WHEN | WHILE [state], WHEN [event], the [system] shall [action] |
+| **Unwanted** | IF | IF [condition], the [system] shall [response] |
+
+> Multi-condition ("complex") requirements *compose* the base patterns
+> (e.g. `WHILE [state], WHEN [event], the [system] shall [action]`) — composition,
+> not a separate pattern. This framework uses `the [system] shall …` uniformly
+> (no `THEN` connective).
 
 ### Pattern Selection Rules
 
 - **WHEN** = Event (discrete occurrence, point in time)
 - **WHILE** = State (continuous condition, duration)
 - **WHERE** = Feature/Configuration (optional capability)
-- **IF-THEN** = Exception/Prohibition (unwanted behavior)
+- **IF** = Exception / unwanted behavior (the system shall [response])
 
 ## INCOSE Best Practices
 


### PR DESCRIPTION
## Summary

Closes the one item deferred from **FRWK-REVIEW #4b** — aligning the Hermes
*vendored* EARS pattern surfaces to the framework's canonical statement model
(framework spec `0.6.0`, merged in PR #15).

The Hermes EARS tables had drifted to a **6-pattern** model with a mixed
`IF…THEN` connective. This brings them to the framework's canonical model:
- The **five** patterns — Ubiquitous, Event-driven (`WHEN`), State-driven
  (`WHILE`), Optional (`WHERE`), Unwanted (`IF`) — in the uniform
  `the [system] shall …` form (no `THEN` connective).
- "Complex" reframed as **composition** of the base patterns (the standalone
  `Complex` table row and the `CX` type code removed; a composition note added).

### Files (6 vendored Hermes docs + the platform changelog)
- `skills/personas/requirements_specialist.md` — pattern table + selection rules.
- `agent-skills/spec-driven-development/sdd-review-personas/SKILL.md` — same.
- `prompts/templates/creation/UCC_PROMPT_EARS.md` — prose patterns + type-code legend.
- `prompts/templates/creation/UCC_OUTPUT_SCHEMA.md` — pattern list.
- `prompts/templates/review/UCR_PROMPT_EARS.md` — pattern table + `IF-THEN` prose labels.
- `prompts/templates/remediation/UCRem_PROMPT_EARS.md` — pattern table.
- `platforms/hermes/CHANGELOG.md` — `[Unreleased]` entry.

### Scope / what this is *not*
- **Platform-only doc alignment.** No `framework/` change → no spec bump
  (spec stays `0.6.0`); GATE-SPEC is a no-op for this PR.
- **Out of scope (separate, pre-existing divergence):** the prompts' legacy
  type-code element-ID scheme (`EARS.NN.<code>.<seq>`) vs the framework's
  hash-based `EARS.NN.SS.xxxx`. That's a larger cleanup, not part of the EARS
  *pattern-model* alignment this finding called for.

## Test plan
- [x] `python3 -m unittest discover -s tests/conformance` — **49/49 green** (platform docs don't affect the suite)
- [x] No `THEN`/`IF-THEN` EARS connective and no standalone `Complex`/`CX` pattern remains in the Hermes tree (grep clean)
- [x] All five patterns still named in each edited surface
- [x] `pre-commit` clean (vendored Hermes content is excluded from markdownlint by design)
- [ ] CI green on the PR

https://claude.ai/code/session_013duDkfbMr9Xhe15movDVxf

---
_Generated by [Claude Code](https://claude.ai/code/session_013duDkfbMr9Xhe15movDVxf)_