### PR TITLE
feat: automated review triggers — on_author hook + pre_merge CI gate (DOC-CHECK Phases 1–4)

### DIFF
--- a/.github/workflows/doc-review.yml
+++ b/.github/workflows/doc-review.yml
@@ -1,0 +1,63 @@
+name: Document review gate
+
+# pre_merge trigger point (framework/governance/REVIEW_REMEDIATION_FLOW.md):
+# the deterministic structural gate for SDD instance documents. Runs the
+# sdd_doc_lint unit tests, smoke-checks the fixtures, and lints any docs/ tree.
+# A consuming project uses this same workflow to gate its own docs/ on PRs;
+# here it self-tests against the linter's fixtures (this repo has no docs/ tree).
+
+on:
+  push:
+    paths:
+      - 'docs/**'
+      - 'tools/sdd_doc_lint/**'
+      - '.github/workflows/doc-review.yml'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'tools/sdd_doc_lint/**'
+      - '.github/workflows/doc-review.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  doc-review:
+    name: SDD document structural gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install -r tests/conformance/requirements.txt
+
+      - name: Unit-test the linter
+        run: PYTHONPATH=tools python -m unittest discover -s tools/sdd_doc_lint/tests -v
+
+      - name: Smoke — valid fixtures must lint clean
+        run: PYTHONPATH=tools python -m sdd_doc_lint tools/sdd_doc_lint/fixtures/valid
+
+      - name: Negative — broken fixtures must fail the gate
+        run: |
+          if PYTHONPATH=tools python -m sdd_doc_lint tools/sdd_doc_lint/fixtures/broken; then
+            echo "::error::broken fixtures unexpectedly passed the gate"; exit 1
+          else
+            echo "broken fixtures failed as expected — gate works"
+          fi
+
+      - name: Gate SDD documents under docs/
+        run: |
+          if [ -d docs ]; then
+            PYTHONPATH=tools python -m sdd_doc_lint docs
+          else
+            echo "no docs/ tree in this repo — nothing to gate (consumers point this at their docs/)"
+          fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,8 +55,9 @@ repos:
         # Hermes agent-skills/prompts/skills are vendored/parsed content — exclude
         # from style-linting (framework/ is already excluded globally). Done via
         # pre-commit exclude because markdownlint-cli ignores .markdownlintignore
-        # when pre-commit passes file paths explicitly.
-        exclude: '^platforms/hermes/(agent-skills|prompts|skills)/'
+        # when pre-commit passes file paths explicitly. sdd_doc_lint fixtures are
+        # deliberately-malformed sample docs for the doc-linter's own tests.
+        exclude: '^(platforms/hermes/(agent-skills|prompts|skills)|tools/sdd_doc_lint/fixtures)/'
 
   # ---- YAML ------------------------------------------------------------------
   - repo: https://github.com/adrienverge/yamllint

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -86,6 +86,26 @@ shared spec (D-0020), with the same three-way enforcer split:
 | Static checks (E006, E007) | shared conformance suite | shared conformance suite |
 | Human approval (E004 sign-off) | branch protection on `framework/**` | branch protection on `framework/**` |
 
+## Review / remediation / gate triggers (both platforms)
+
+Both platforms implement the spec's review→remediation→gate loop and its
+trigger points (`framework/governance/REVIEW_REMEDIATION_FLOW.md`). Each binds
+the engine-agnostic points to its own capabilities; *how* a point is checked is
+the platform's choice (the spec only requires that findings, the readiness score,
+and the remediation path are surfaced).
+
+| Trigger point | Plugin | Hermes |
+|---------------|--------|--------|
+| `on_author` (write-time) | `PostToolUse` hook (`hooks/sdd-doc-review.sh`) — advisory nudge to `doc-<layer>-audit` + best-effort `sdd_doc_lint` findings | server-side `validation/` + scoring tool on demand |
+| `on_gate_fail` | `doc-<layer>-fixer` skill | `UCRem_*` remediation prompts |
+| `pre_promotion` | `gate-check` / the readiness ≥90 gate before the next `doc-<layer>` | scoring gate before the next layer |
+| `pre_merge` (PR-time) | `doc-review.yml` running `tools/sdd_doc_lint` (blocking, deterministic) | same `doc-review.yml` shared check |
+
+The **write-time** point is advisory (a nudge, never blocks the edit); the
+**PR-time** point is the blocking deterministic gate. The full semantic
+readiness *score* stays the LLM `-audit` skill / Hermes scorer — `sdd_doc_lint`
+is the fast structural subset beneath it.
+
 ## Platform-specific extras
 
 ### Hermes-only

--- a/plans/DOC-CHECK-PLAN.md
+++ b/plans/DOC-CHECK-PLAN.md
@@ -4,7 +4,7 @@
 |------------|--------------------------------|
 | Task       | DOC-CHECK                      |
 | Depends on | framework spec `0.6.0`; the per-layer `-audit`/`-fixer` skills + Hermes validation runtime (both exist) |
-| Status     | IN PROGRESS — Phase 0 (spec loop model, `0.7.0`) implemented on `claude/doc-check-automation`; Phases 1–4 (tooling/hook/CI) follow after it merges |
+| Status     | IN PROGRESS — Phase 0 merged (PR #17, spec `0.7.0`); Phases 1–4 (linter/hook/CI/parity) implemented on `claude/doc-check-triggers` |
 | Feeds      | an engine-agnostic review→remediation→gate loop in the spec, with write-time (#1) + PR-time (#2) triggers, both platforms |
 
 ## Objective
@@ -175,3 +175,40 @@ four trigger points (low cost, prevents silent omission).
   (same pattern as `SECURITY_REVIEW.md` in PR #12); optional trigger-point-name
   guard noted as low-cost. No change.
 + No further findings — implementable.
+
+## Implementation log
+
+### Phase 0 — merged (PR #17, 2026-05-25)
+
+`framework/governance/REVIEW_REMEDIATION_FLOW.md` (light contract: loop + four
+trigger points), spec `0.6.0 → 0.7.0`, registered in governance README +
+`test_governance` `EXPECTED_FILES`.
+
+### Phases 1–4 — 2026-05-25 (branch `claude/doc-check-triggers`)
+
++ **Phase 1** — `tools/sdd_doc_lint/` stdlib linter (PyYAML to read the registry):
+  trace-tag/ID forms, required cumulative tags, `@threshold:` format, EARS
+  `THE…SHALL` grammar, placeholder leakage. Valid + broken fixtures; 3-test
+  unit suite. Fixed a false-positive (threshold keys vs element IDs). Fixtures
+  excluded from markdownlint.
++ **Phase 2** — plugin `on_author` hook: `hooks/hooks.json` (PostToolUse
+  Write|Edit) + `hooks/sdd-doc-review.sh` (advisory nudge to `doc-<layer>-audit`,
+  best-effort `sdd_doc_lint` findings, always exit 0). Verified across non-SDD /
+  no-linter / linter-present cases. Hook schema confirmed via the
+  `claude-code-guide` agent (`hooks/hooks.json`, `${CLAUDE_PLUGIN_ROOT}`,
+  `tool_input.file_path`, `hookSpecificOutput.additionalContext`).
++ **Phase 3** — `.github/workflows/doc-review.yml` (`pre_merge`): unit-tests the
+  linter, smoke-passes valid fixtures, asserts broken fixtures fail the gate,
+  lints `docs/` (none here → no-op). All steps simulated green locally.
++ **Phase 4** — `docs/PARITY.md` per-trigger mapping table; plugin + Hermes
+  READMEs document their trigger-point bindings; Hermes adopts the shared
+  `doc-review.yml` for `pre_merge` parity.
++ **Design note (consumer runtime):** the deterministic linter runs cleanly in
+  **CI** (repo checked out) — that is the reliable `pre_merge` gate. The
+  **write-time hook is advisory** (nudge always works; linter findings are
+  best-effort when importable) because reliably running a deterministic linter
+  inside an arbitrary consumer's live session would need bundling/duplication.
+  This matches D3 (hook advisory, CI blocking). Bundling the linter into the
+  plugin / a consumer-install story is a possible follow-up.
++ **Verification:** conformance still **49/49** (platform/tooling changes don't
+  touch `framework/`); no spec bump; `pre-commit` clean on changed files.

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -1,5 +1,21 @@
 # Session Handoff
 
+> **🔵 DOC-CHECK PHASES 1–4 READY — automated review triggers (2026-05-25).**
+> Branch **`claude/doc-check-triggers`** (cut from `main` after Phase 0 / PR #17
+> merged). Plan: `plans/DOC-CHECK-PLAN.md`. Implements the platform automation
+> over the spec's trigger points: **Phase 1** `tools/sdd_doc_lint/` (stdlib
+> structural linter — IDs/tags/threshold/EARS-grammar/placeholders, registry-driven;
+> valid+broken fixtures + 3 unit tests); **Phase 2** plugin `on_author` advisory
+> hook (`hooks/hooks.json` + `sdd-doc-review.sh`, nudges `doc-<layer>-audit` +
+> best-effort linter, never blocks); **Phase 3** `.github/workflows/doc-review.yml`
+> blocking `pre_merge` gate (self-tested via fixtures); **Phase 4** PARITY +
+> plugin/Hermes README trigger mappings. **Platform/tooling only — no `framework/`
+> change, no spec bump** (stays `0.7.0`); conformance **49**; pre-commit clean.
+> **Design note:** the deterministic gate is reliable in **CI**; the **write-time
+> hook is advisory** (linter best-effort) since running a linter in an arbitrary
+> consumer's live session would need bundling — a possible follow-up. **Next:**
+> open the Phases 1–4 PR.
+>
 > **🔵 DOC-CHECK PHASE 0 READY — review/remediation/gate loop in the spec (2026-05-25).**
 > Branch **`claude/doc-check-automation`**. Plan: `plans/DOC-CHECK-PLAN.md`
 > (framework-first; decisions: light contract + spec/hook/CI). **Phase 0** models

--- a/platforms/claude-code-plugin/README.md
+++ b/platforms/claude-code-plugin/README.md
@@ -14,11 +14,22 @@ no MCP backend.
 | Skills (utilities) | 18 | `doc-flow`, `doc-naming`, `doc-ref`, `doc-review`, `doc-validator`, `project-init`, `project-adopt`, `project-profile`, `knowledge-extractor`, `gate-check`, `trace-check`, `charts-flow`, `adr-roadmap`, `context-analyzer`, `quality-advisor`, `skill-recommender`, `workflow-optimizer`, `security-audit`. |
 | Agents | 9 | AI Team specialist roster — `requirements-analyst`, `pm-orchestrator`, `solutions-architect`, `test-architect`, `software-engineer`, `devops-release-engineer`, `code-reviewer`, `security-engineer`, `traceability-auditor` (SDD lifecycle: spec lane → execution lane → read-only quality gates). See `agents/README.md`. |
 | Commands | 1 | `/aidoc-flow:save-plan` — capture current conversation plan to a timestamped file. |
+| Hooks | 1 | `hooks/sdd-doc-review.sh` — a `PostToolUse` advisory nudge (see below). |
 | **Total skills** | **54** | |
 
 The plugin auto-registers everything via Claude Code's directory
 conventions (`skills/`, `agents/`, `commands/`); no per-skill enumeration in
 the manifest.
+
+### Review trigger (`on_author`)
+
+`hooks/hooks.json` registers a `PostToolUse` hook on `Write`/`Edit`. When an SDD
+instance document (`docs/<NN>_<X>/…` or a `<TYPE>-NN` file) is written, it nudges
+you to run the matching `doc-<layer>-audit` (and, if `sdd_doc_lint` is importable,
+appends deterministic structural findings). It is **advisory** — it never blocks
+the edit. This is the plugin's binding of the framework's `on_author` trigger
+point (`framework/governance/REVIEW_REMEDIATION_FLOW.md`); the blocking `pre_merge`
+gate is the shared `doc-review.yml` workflow running `tools/sdd_doc_lint`.
 
 ## Install
 

--- a/platforms/claude-code-plugin/hooks/hooks.json
+++ b/platforms/claude-code-plugin/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/sdd-doc-review.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/platforms/claude-code-plugin/hooks/sdd-doc-review.sh
+++ b/platforms/claude-code-plugin/hooks/sdd-doc-review.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# on_author trigger point (framework/governance/REVIEW_REMEDIATION_FLOW.md).
+#
+# PostToolUse(Write|Edit) advisory hook: when an SDD instance document is
+# written/edited, nudge the matching review skill (and, best-effort, surface
+# deterministic structural findings if sdd_doc_lint is importable). Strictly
+# ADVISORY — it never blocks the edit and always exits 0. The blocking
+# deterministic gate is the pre_merge CI check (doc-review.yml), not this hook.
+
+# Degrade silently if jq is unavailable (hooks parse stdin JSON with jq).
+command -v jq >/dev/null 2>&1 || exit 0
+
+input="$(cat)"
+file_path="$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null)"
+[ -z "$file_path" ] && exit 0
+
+base="$(basename "$file_path")"
+
+# Detect the SDD layer: docs/0N_<ARTIFACT>/ path, or a <ARTIFACT>-NN filename.
+artifact=""
+if [[ "$file_path" =~ /docs/[0-9]{2}_([A-Za-z]+)/ ]]; then
+  artifact="${BASH_REMATCH[1]}"
+elif [[ "$base" =~ ^([A-Za-z]+)-[0-9] ]]; then
+  artifact="${BASH_REMATCH[1]}"
+fi
+artifact="$(printf '%s' "$artifact" | tr '[:lower:]' '[:upper:]')"
+
+case "$artifact" in
+  BRD|PRD|EARS|BDD|ADR|SPEC|TDD|IPLAN) ;;
+  *) exit 0 ;;  # not an SDD instance document — nothing to advise
+esac
+
+layer="$(printf '%s' "$artifact" | tr '[:upper:]' '[:lower:]')"
+msg="Edited a ${artifact} document (${base}). Per the framework review→remediation→gate loop (on_author): run /aidoc-flow:doc-${layer}-audit to score readiness before promoting downstream; if it scores below the gate, /aidoc-flow:doc-${layer}-fixer remediates."
+
+# Best-effort deterministic structural check (only if the linter is importable).
+if command -v python3 >/dev/null 2>&1 && python3 -c "import sdd_doc_lint" >/dev/null 2>&1; then
+  if ! findings="$(python3 -m sdd_doc_lint "$file_path" 2>&1)"; then
+    msg="${msg}"$'\n\nStructural findings (sdd_doc_lint):\n'"${findings}"
+  fi
+fi
+
+jq -n --arg ctx "$msg" \
+  '{hookSpecificOutput: {hookEventName: "PostToolUse", additionalContext: $ctx}}'
+exit 0

--- a/platforms/hermes/README.md
+++ b/platforms/hermes/README.md
@@ -81,6 +81,17 @@ Hermes declares conformance to framework spec `0.1.0`; the
 framework's own version is at `../../framework/VERSION`. The Phase 4
 conformance suite enforces this declaration matches.
 
+### Review / remediation / gate triggers
+
+Hermes binds the spec's review→remediation→gate trigger points
+(`../../framework/governance/REVIEW_REMEDIATION_FLOW.md`) to its existing
+runtime: server-side `validation/` + scoring covers `on_author` (on-demand
+validate/score) and `pre_promotion` (the readiness gate before the next layer);
+the `UCRem_*` remediation prompts cover `on_gate_fail`. For the `pre_merge`
+(PR-time) point, a Hermes-based project uses the shared `doc-review.yml`
+workflow running `tools/sdd_doc_lint` — the same deterministic structural gate
+the plugin uses — so both platforms gate documents identically in CI.
+
 ## Platform info
 
 | Field | Value |

--- a/tools/sdd_doc_lint/__init__.py
+++ b/tools/sdd_doc_lint/__init__.py
@@ -1,0 +1,172 @@
+"""sdd_doc_lint — deterministic structural check for SDD instance documents.
+
+The platform-tier implementation of the framework's `on_author` / `pre_merge`
+trigger-point check (see `framework/governance/REVIEW_REMEDIATION_FLOW.md`). It
+runs the *structural* subset of a review — ID/tag forms, required upstream tags,
+`@threshold:` format, EARS grammar, placeholder leakage — driven by
+`framework/registry/LAYER_REGISTRY.yaml`. The semantic readiness score stays the
+LLM `-audit` skill; this is the fast, repeatable gate beneath it.
+
+Text-based on purpose: the checks work on an instance document whether it is
+authored as Markdown or YAML.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REGISTRY = REPO_ROOT / "framework" / "registry" / "LAYER_REGISTRY.yaml"
+
+LAYER_TAGS = ("brd", "prd", "ears", "bdd", "adr", "spec", "tdd", "iplan")
+
+_TAG = re.compile(r"@(" + "|".join(LAYER_TAGS) + r")\s*:\s*([^\s|]+)")
+_THRESHOLD = re.compile(r"@threshold:\s*([^\s|]+)")
+_THEN_CONNECTIVE = re.compile(r"THEN\s*\[")
+_PLACEHOLDERS = [
+    re.compile(r"\bTBD\b"),
+    re.compile(r"\bTODO\b"),
+    re.compile(r"\bFIXME\b"),
+    re.compile(r"\b[A-Z]{2,8}-XXX\b"),
+    re.compile(r"\bXX+\b"),
+]
+# Candidate IDs whose prefix is a known artifact (avoids flagging unrelated tokens).
+_KNOWN = "BRD|PRD|EARS|BDD|ADR|SPEC|TDD|IPLAN"
+_DOC_ID = re.compile(rf"\b({_KNOWN})-([A-Za-z0-9]+)\b")
+_ELEM_ID = re.compile(rf"\b({_KNOWN})((?:\.[A-Za-z0-9]+)+)\b")
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: str
+    line: int
+    code: str
+    message: str
+    severity: str = "error"
+
+    def __str__(self) -> str:
+        return f"{self.path}:{self.line}: [{self.severity.upper()} {self.code}] {self.message}"
+
+
+def _load_registry():
+    data = yaml.safe_load(REGISTRY.read_text(encoding="utf-8"))
+    layers = {layer["artifact"]: layer for layer in data["layers"]}
+    pats = data["id_patterns"]
+    return layers, re.compile(pats["document"]), re.compile(pats["element"])
+
+
+def detect_layer(path: Path, layers: dict) -> str | None:
+    """Return the artifact code for an SDD instance doc, or None if not one."""
+    parts = [p.upper() for p in path.parts]
+    # docs/0N_<ARTIFACT>/...
+    for part in parts:
+        m = re.fullmatch(r"\d{2}_([A-Z]+)", part)
+        if m and m.group(1) in layers:
+            return m.group(1)
+    # filename prefix <ARTIFACT>-NN_...
+    m = re.match(rf"({_KNOWN})-", path.name.upper())
+    if m and m.group(1) in layers:
+        return m.group(1)
+    return None
+
+
+def lint_text(text: str, artifact: str, rel: str, layers, doc_re, elem_re) -> list[Finding]:
+    findings: list[Finding] = []
+    lines = text.splitlines()
+    seen_tags: set[str] = set()
+
+    for i, line in enumerate(lines, 1):
+        # Trace tags: collect which upstream layers are referenced + validate the id form.
+        for m in _TAG.finditer(line):
+            seen_tags.add(m.group(1))
+            val = m.group(2)
+            if not (doc_re.match(val) or elem_re.match(val)):
+                findings.append(
+                    Finding(rel, i, "ID01", f"malformed trace-tag id '@{m.group(1)}: {val}'")
+                )
+        # Threshold tags: TYPE.NUM.key dotted form. Record their spans so the
+        # element-id scan below does not mistake a threshold key for an element id.
+        threshold_spans = []
+        for m in _THRESHOLD.finditer(line):
+            threshold_spans.append(m.span(1))
+            val = m.group(1)
+            if not re.match(r"^[A-Z]+\.[A-Za-z0-9]+(?:\.[A-Za-z0-9]+)+$", val):
+                findings.append(
+                    Finding(rel, i, "TH01", f"malformed @threshold: '{val}' (want TYPE.NN.key)")
+                )
+
+        def _in_threshold(span):
+            return any(s[0] <= span[0] and span[1] <= s[1] for s in threshold_spans)
+
+        # Inline document IDs (TYPE-NN) of known artifacts must match the doc form.
+        for m in _DOC_ID.finditer(line):
+            tok = m.group(0)
+            if not doc_re.match(tok):
+                findings.append(Finding(rel, i, "ID02", f"malformed document id '{tok}'"))
+        # Inline element IDs (TYPE.a.b.c…) of known artifacts must match the element form.
+        for m in _ELEM_ID.finditer(line):
+            tok = m.group(0)
+            if _in_threshold(m.span()):
+                continue  # a threshold key, not an element id
+            if tok.count(".") >= 3 and not elem_re.match(tok):
+                findings.append(Finding(rel, i, "ID03", f"malformed element id '{tok}'"))
+        # Placeholder leakage.
+        for pat in _PLACEHOLDERS:
+            if pat.search(line):
+                findings.append(
+                    Finding(
+                        rel, i, "PH01", f"placeholder/unfilled token: '{pat.search(line).group(0)}'"
+                    )
+                )
+        # EARS grammar: no THEN-connective.
+        if artifact == "EARS" and _THEN_CONNECTIVE.search(line):
+            findings.append(
+                Finding(
+                    rel,
+                    i,
+                    "EARS01",
+                    "EARS uses 'THE … SHALL …', not a 'THEN [response]' connective",
+                )
+            )
+
+    # Required upstream tags present (document-level, reported at line 0).
+    required = layers[artifact].get("required_tags", []) or []
+    for tag in required:
+        if tag not in seen_tags:
+            findings.append(
+                Finding(
+                    rel,
+                    0,
+                    "TAG01",
+                    f"{artifact} requires upstream tag '@{tag}:' (cumulative traceability)",
+                )
+            )
+    return findings
+
+
+def lint_file(path: Path, layers, doc_re, elem_re) -> list[Finding]:
+    artifact = detect_layer(path, layers)
+    if artifact is None:
+        return []
+    try:
+        rel = path.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        rel = path.as_posix()
+    return lint_text(path.read_text(encoding="utf-8"), artifact, rel, layers, doc_re, elem_re)
+
+
+def lint_path(target: Path) -> list[Finding]:
+    """Lint a file or recurse a directory; returns all findings."""
+    layers, doc_re, elem_re = _load_registry()
+    findings: list[Finding] = []
+    if target.is_dir():
+        for p in sorted(target.rglob("*")):
+            if p.is_file() and p.suffix.lower() in (".md", ".yaml", ".yml"):
+                findings.extend(lint_file(p, layers, doc_re, elem_re))
+    elif target.is_file():
+        findings.extend(lint_file(target, layers, doc_re, elem_re))
+    return findings

--- a/tools/sdd_doc_lint/__main__.py
+++ b/tools/sdd_doc_lint/__main__.py
@@ -1,0 +1,43 @@
+"""CLI: python -m sdd_doc_lint <path> [<path> ...]
+
+Exit 0 = no error-level findings; 1 = error findings; 2 = usage error.
+Run from the repository root (it resolves the framework registry relative to the
+package). Intended to back the `on_author` (advisory) and `pre_merge` (blocking)
+trigger points — see framework/governance/REVIEW_REMEDIATION_FLOW.md.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from . import lint_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    if not argv:
+        print("usage: python -m sdd_doc_lint <path> [<path> ...]", file=sys.stderr)
+        return 2
+
+    findings = []
+    for arg in argv:
+        findings.extend(lint_path(Path(arg)))
+
+    errors = [f for f in findings if f.severity == "error"]
+    for f in sorted(findings, key=lambda x: (x.path, x.line, x.code)):
+        stream = sys.stderr if f.severity == "error" else sys.stdout
+        print(str(f), file=stream)
+
+    if errors:
+        print(
+            f"\nsdd-doc-lint: {len(errors)} error(s) across {len({f.path for f in errors})} file(s).",
+            file=sys.stderr,
+        )
+        return 1
+    print("sdd-doc-lint: no structural findings.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/sdd_doc_lint/fixtures/broken/docs/03_EARS/EARS-02_bad.md
+++ b/tools/sdd_doc_lint/fixtures/broken/docs/03_EARS/EARS-02_bad.md
@@ -1,0 +1,16 @@
+# EARS-02: Broken sample (intentional violations for the linter test)
+
+## Document Control
+
+- Status: TBD
+
+## Requirements
+
+EARS.02.03.ZZZZ — Event-driven:
+WHEN a user clicks submit THEN [validate the form].
+@brd: BRD-2
+
+EARS.02.3.c4d8 — malformed element id (single-digit section).
+@adr: ADR-01.03.deadbeef
+
+@threshold: not_a_threshold_key

--- a/tools/sdd_doc_lint/fixtures/valid/docs/03_EARS/EARS-01_login.md
+++ b/tools/sdd_doc_lint/fixtures/valid/docs/03_EARS/EARS-01_login.md
@@ -1,0 +1,24 @@
+# EARS-01: Login Requirements
+
+## Document Control
+
+- Status: In Review
+- Traceability: @brd: BRD.01.07.a7f3 | @prd: PRD.01.09.1dbc
+
+## Requirements
+
+EARS.01.03.c4d8 — Event-driven:
+WHEN a user submits valid credentials,
+THE system SHALL establish a session WITHIN 200ms.
+@brd: BRD.01.07.a7f3 | @prd: PRD.01.09.1dbc
+
+EARS.01.03.b2e1 — Optional / feature-gated:
+WHERE multi-factor authentication is enabled,
+THE system SHALL require a second factor.
+@brd: BRD.01.07.a7f3 | @prd: PRD.01.09.1dbc
+@threshold: PRD.01.auth.attempts.max
+
+EARS.01.03.f0a9 — Unwanted:
+IF the credentials are invalid,
+THE system SHALL reject the attempt WITHIN 100ms.
+@brd: BRD.01.07.a7f3 | @prd: PRD.01.09.1dbc

--- a/tools/sdd_doc_lint/tests/test_lint.py
+++ b/tools/sdd_doc_lint/tests/test_lint.py
@@ -1,0 +1,34 @@
+"""Unit test for sdd_doc_lint. Run with `tools/` on the path:
+
+PYTHONPATH=tools python3 -m unittest discover -s tools/sdd_doc_lint/tests
+"""
+
+import unittest
+from pathlib import Path
+
+from sdd_doc_lint import lint_path
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+
+
+class DocLint(unittest.TestCase):
+    def test_valid_fixtures_have_no_findings(self):
+        findings = lint_path(FIXTURES / "valid")
+        self.assertEqual([str(f) for f in findings], [], "valid fixtures should be clean")
+
+    def test_broken_fixtures_trip_each_check(self):
+        findings = lint_path(FIXTURES / "broken")
+        codes = {f.code for f in findings}
+        for expected in ("TAG01", "PH01", "ID01", "ID02", "ID03", "EARS01", "TH01"):
+            self.assertIn(
+                expected, codes, f"broken fixtures should trip {expected}; got {sorted(codes)}"
+            )
+
+    def test_non_sdd_file_is_ignored(self):
+        # A file the path/name doesn't classify as an SDD instance doc → no findings.
+        findings = lint_path(Path(__file__))
+        self.assertEqual(findings, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

**DOC-CHECK Phases 1–4** — implement the platform automation over the spec's
review→remediation→gate trigger points (the contract landed in PR #17, spec
`0.7.0`). Plan: `plans/DOC-CHECK-PLAN.md`.

**Platform/tooling only — no `framework/` change, no spec bump.** GATE-SPEC is a
no-op for this PR.

### Phase 1 — deterministic structural check (`tools/sdd_doc_lint/`)
A stdlib linter (PyYAML to read `LAYER_REGISTRY.yaml`) implementing the
*structural* subset of a review: trace-tag/document/element **ID forms**,
required **cumulative upstream tags** per layer, **`@threshold:` format**, **EARS
`THE…SHALL` grammar** (no `THEN` connective), and **placeholder/`TBD` leakage**.
Text-based, so it works on Markdown or YAML instances. Ships valid + deliberately
-broken **fixtures** and a 3-test unit suite. The semantic ≥90 readiness *score*
stays the LLM `-audit` skill — this is the fast structural gate beneath it.

### Phase 2 — `on_author` plugin hook (advisory)
`platforms/claude-code-plugin/hooks/{hooks.json,sdd-doc-review.sh}` — a
`PostToolUse(Write|Edit)` hook that, when an SDD instance doc is written, nudges
the matching `doc-<layer>-audit` (and appends `sdd_doc_lint` findings if the
linter is importable). **Strictly advisory — never blocks the edit, always exits
0.** Hook schema verified against current Claude Code docs (`hooks/hooks.json`,
`${CLAUDE_PLUGIN_ROOT}`, `tool_input.file_path`, `hookSpecificOutput.additionalContext`).

### Phase 3 — `pre_merge` CI gate (blocking)
`.github/workflows/doc-review.yml` — unit-tests the linter, smoke-checks the
valid fixtures, asserts the broken fixtures **fail** the gate, and lints any
`docs/` tree. Self-tests here via fixtures (this repo has no `docs/` tree); a
consuming project points it at its own `docs/`.

### Phase 4 — both-platform trigger mapping
`docs/PARITY.md` gains a per-trigger comparison table; the plugin + Hermes READMEs
document their trigger-point bindings (Hermes maps its `validation/` runtime +
`UCRem_*` prompts to `on_author`/`on_gate_fail`/`pre_promotion` and adopts the
shared `doc-review.yml` for `pre_merge` parity).

### Design note (consumer runtime)
The deterministic linter runs reliably in **CI** (repo checked out) → that's the
blocking `pre_merge` gate. The **write-time hook is advisory** (nudge always
works; linter findings best-effort when importable) because reliably running a
linter inside an arbitrary consumer's live session would need bundling/
duplication. This matches plan decision D3 (hook advisory, CI blocking). Bundling
the linter into the plugin / a consumer-install story is a possible follow-up.

## Test plan
- [x] `PYTHONPATH=tools python3 -m unittest discover -s tools/sdd_doc_lint/tests` — **3/3 green**
- [x] linter: valid fixtures exit 0; broken fixtures exit 1 with all check codes (TAG01/PH01/ID01-03/EARS01/TH01)
- [x] hook: silent on non-SDD; nudge-only without the linter; nudge+findings with it; **always exit 0**
- [x] `doc-review.yml` steps simulated locally — unit test, valid smoke, negative gate, `docs/` no-op all pass
- [x] conformance still **49/49** (no `framework/` change); `pre-commit` clean (yaml/json/markdown); fixtures excluded from markdownlint
- [ ] CI green on the PR (incl. the new Document review gate)

https://claude.ai/code/session_013duDkfbMr9Xhe15movDVxf

---
_Generated by [Claude Code](https://claude.ai/code/session_013duDkfbMr9Xhe15movDVxf)_