### PR TITLE
feat(platforms): vendor the doc-linter into plugin + Hermes (PLATFORM-ALIGN Part A)

### DIFF
--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -1,5 +1,18 @@
 # Session Handoff
 
+> **🔵 PLATFORM-ALIGN PART A READY — vendor the doc-linter (2026-05-25).** Branch
+> **`claude/platform-align`**. Plan: `plans/PLATFORM-ALIGN-PLAN.md` (all parts
+> approved). **Part A done:** `tools/sdd_doc_lint` made location-independent
+> (upward-search for `framework/registry/` + `--registry`/`$SDD_REGISTRY`; CLI exit
+> 2 when no registry); **byte-identical copies vendored** into both platforms
+> (`platforms/*/sdd_doc_lint/`), kept in sync by `sync-vendored.sh` + a conformance
+> drift-guard (suite **50**); the plugin `on_author` hook now runs the vendored
+> linter reliably (advisory, exit-0, skips with no `framework/`). Platform/tooling
+> only — no spec bump. `pre-commit` clean. **Next:** open PR-1; after it merges,
+> **Part B** (cut from `main`): B1 prompt IDs type-code→4-seg hash, B2 Hermes
+> runtime regex 3→4-seg + tests, B3 **remove** the 12 SYS/REQ/CTR/TSPEC legacy-layer
+> prompts + their runtime coupling, Hermes `VERSION` bump.
+>
 > **🔵 DOC-CHECK PHASES 1–4 READY — automated review triggers (2026-05-25).**
 > Branch **`claude/doc-check-triggers`** (cut from `main` after Phase 0 / PR #17
 > merged). Plan: `plans/DOC-CHECK-PLAN.md`. Implements the platform automation

--- a/plans/PLATFORM-ALIGN-PLAN.md
+++ b/plans/PLATFORM-ALIGN-PLAN.md
@@ -1,0 +1,183 @@
+# PLATFORM-ALIGN Plan — vendor the doc-linter + migrate Hermes IDs to the framework hash form
+
+| Field      | Value                          |
+|------------|--------------------------------|
+| Task       | PLATFORM-ALIGN                 |
+| Depends on | DOC-CHECK (PRs #17/#18 merged); framework spec `0.7.0`; the 4-segment element-ID standard (`LAYER_REGISTRY.yaml` `id_patterns`) |
+| Status     | PLANNED — 2026-05-25 (awaiting approval) |
+| Feeds      | a consumer-runnable doc-linter on both platforms (Part A); Hermes element-IDs aligned to the framework hash form + legacy-layer prompts handled (Part B) |
+
+## Objective
+
+Two platform follow-ups flagged after DOC-CHECK:
+
+- **Part A (#1) — vendor `sdd_doc_lint` into both platforms** so the plugin's
+  `on_author` hook (and a Hermes-side equivalent) can run the deterministic
+  structural check at consumer runtime, not just best-effort.
+- **Part B (#2) — migrate Hermes element-IDs to the framework 4-segment hash
+  form** (`TYPE.NN.SS.xxxx`), across the 8-layer prompts *and* the runtime
+  regexes + their tests, and **handle the off-model legacy-layer prompts**
+  (SYS/REQ/CTR/TSPEC).
+
+Both are **platform/tooling changes — no `framework/` edit, no GATE-SPEC bump.**
+Part B changes Hermes runtime behavior ⇒ a Hermes platform version bump.
+
+## Current state (grounding)
+
+- The canonical linter is `tools/sdd_doc_lint/` (used by the conformance/CI side).
+  It resolves the registry via `REPO_ROOT = parents[2]` — a **hardcoded relative
+  path** that only works from that location.
+- The plugin hook runs the linter **best-effort** (`python3 -c "import sdd_doc_lint"`);
+  in a real consumer it is almost never importable → hook is nudge-only in practice.
+- **Three element-ID schemes** coexist in Hermes:
+  1. framework canonical **4-segment** `TYPE.NN.SS.xxxx` (e.g. `EARS.01.03.c4d8`);
+  2. Hermes **runtime 3-segment** `TYPE.NN.xxxx` — `validation/cross_section.py:18-19`
+     (`_ELEMENT_ID_RE`, `_ELEMENT_ID_INLINE_RE`) and `remediation/runner.py:640`
+     (`_ID_PATTERN`), with tests in `tests/unit/test_cross_section.py`,
+     `tests/unit/test_remediation_runner.py`;
+  3. legacy **type-code** `TYPE.NN.<CODE>.<seq>` (UB/EV/ST/OP/UW/CX/FR…) in the
+     prompts (`UCC/UCR/UCRem_PROMPT_{EARS,BDD,…}` + the legacy-layer prompts).
+- **12 legacy-layer prompt files** (SYS/REQ/CTR/TSPEC × creation/review/remediation)
+  for layers absent from the 8-layer framework. They have **runtime coupling**
+  (e.g. `validation/runner.py:334` has a `ctr` branch; prompts load per-layer
+  from `templates/{creation,review,remediation}/`).
+
+## Scope
+
+**In:** Part A (vendor linter + make it location-independent + drift guard +
+wire the hook to the vendored copy + Hermes-side entry). Part B (prompt IDs →
+4-seg hash; runtime regex 3-seg → 4-seg + tests; legacy-layer prompts handled).
+
+**Out:** changing the framework spec or the registry `id_patterns` (already
+correct at 4-segment); the finding-ID schemes (`P0-hash`, `ACT-hash` in
+`reporting/contracts.py` — those are finding/action IDs, not element IDs);
+re-implementing the LLM audits.
+
+## Part A — vendor the linter into both platforms
+
+### Decisions (recommendations)
+
+- **A-D1 — canonical source.** Keep `tools/sdd_doc_lint/` canonical (conformance
+  - CI use it). Vendor **byte-identical** copies into
+  `platforms/claude-code-plugin/sdd_doc_lint/` and
+  `platforms/hermes/sdd_doc_lint/` (or a `tools/`/`scripts/` subdir within each).
+- **A-D2 — location independence (prerequisite for byte-identical copies).**
+  Refactor registry resolution: instead of `parents[2]`, **search upward from the
+  CWD (and from the module file) for `framework/registry/LAYER_REGISTRY.yaml`**,
+  with an optional `--registry PATH` / `SDD_REGISTRY` override. Then the same code
+  runs unchanged from any vendored location (it finds the consumer's `framework/`).
+- **A-D3 — drift guard.** A conformance test asserts the two vendored copies are
+  **byte-identical** to the canonical `tools/sdd_doc_lint/` (`__init__.py`,
+  `__main__.py`) — prevents divergence (the D-0013 single-source ethos applied to
+  a deliberate vendoring). A `make`/script target re-syncs them.
+- **A-D4 — wiring.** The plugin hook calls the vendored copy via
+  `PYTHONPATH="${CLAUDE_PLUGIN_ROOT}"` (so `import sdd_doc_lint` resolves
+  out-of-box). Hermes exposes it (CLI entry or a thin `validation` call).
+
+### Steps
+
+1. Refactor the canonical linter's registry resolution to upward-search + override
+   (A-D2); re-run its unit tests + the fixtures.
+2. Vendor byte-identical copies into both platforms; add the drift-guard
+   conformance test (A-D3).
+3. Update the plugin hook to set `PYTHONPATH` to the vendored copy (drop the
+   best-effort import guard → deterministic findings now reliably available);
+   keep advisory/exit-0.
+4. Hermes: add a CLI/use entry for the vendored linter; note it in the README.
+
+## Part B — Hermes element-IDs → framework 4-segment hash
+
+### B1 — prompts (8-layer)
+
+Migrate type-code element-ID examples + the `UB/EV/ST/OP/UW/CX` legends in the
+8-layer prompts (`UCC/UCR/UCRem_PROMPT_{EARS,BDD,...}`, `UCC_OUTPUT_SCHEMA`) to the
+4-segment hash form `TYPE.NN.SS.xxxx` (e.g. `EARS.01.EV.05` → `EARS.01.03.c4d8`).
+Remove the type-code legend (the hash form has no per-pattern code).
+
+### B2 — runtime regexes + tests
+
+Change the Hermes element-ID validators from 3-segment to 4-segment:
+
+- `validation/cross_section.py:18-19` `^[A-Z]{2,8}\.\d{2,}\.[0-9a-f]{4,8}$`
+  → `^[A-Z]{2,8}\.\d{2,}\.\d{2,}\.[0-9a-f]{4,8}$`;
+- `remediation/runner.py:640` `_ID_PATTERN` likewise;
+- update `tests/unit/test_cross_section.py` + `tests/unit/test_remediation_runner.py`
+  fixtures/assertions to the 4-segment form;
+- run the full Hermes pytest suite — it must stay green (this is the risk gate).
+
+### B3 — legacy-layer prompts (SYS/REQ/CTR/TSPEC) — "handle them too"
+
+Investigate runtime coupling first (the `validation/runner.py` `ctr` branch, the
+per-layer prompt loader, `tool_registry`), then **remove** the 12 off-model prompt
+files **and** their runtime handling — *only* if nothing in the 8-layer flow
+depends on them. If a clean removal isn't safe (hidden coupling), **deprecate**
+in place (a header note that the layer is not part of the 8-layer framework) and
+record the residual coupling as a tracked item. Decision **B-D1** resolved at
+implementation time from the coupling check.
+
+### Versioning
+
+Part B changes Hermes runtime behavior + removes prompts ⇒ bump
+`platforms/hermes/VERSION` (minor or major per the removal's blast radius) +
+Hermes CHANGELOG. No framework/spec change.
+
+## Sequencing
+
+- **PR-1 = Part A** (vendor linter) — independent, lower-risk, unblocks the
+  hook's deterministic check.
+- **PR-2 = Part B** (Hermes IDs + legacy prompts) — cut after PR-1; the bigger,
+  runtime+test-touching change with the B-D1 removal decision.
+
+## Verification
+
+- Part A: canonical + both vendored copies pass `python -m sdd_doc_lint` on the
+  fixtures from each location; drift guard green; conformance suite green; the
+  plugin hook (manual test) now emits deterministic findings, still exit 0.
+- Part B: full Hermes pytest suite green after the regex/test changes; no
+  type-code element IDs remain in the 8-layer prompts (grep clean); no 3-segment
+  element-ID regex remains in `src/`; legacy-layer prompts removed/deprecated with
+  no broken layer→prompt loads; `validate`/`remediate` smoke run on a 4-seg doc.
+- `pre-commit run --all-files` clean (Hermes vendored content excluded from
+  markdownlint as today).
+
+## Risks
+
+| # | Risk | Mitigation |
+|---|------|------------|
+| R1 | Vendoring duplicates the linter → drift | Byte-identical copies + a conformance drift guard (A-D3) + a re-sync script; canonical stays `tools/`. |
+| R2 | Registry not found from a vendored location | Upward-search + `--registry`/env override (A-D2); test from each location. |
+| R3 | 3→4-segment regex change breaks Hermes tests/behavior | Update tests in lockstep; run the full pytest suite as the gate; the 4-seg form is a superset-stricter match, so audit any doc fixtures using 3-seg IDs. |
+| R4 | Removing legacy-layer prompts breaks runtime (CTR branch, loader) | B3 investigates coupling first; remove only if safe, else deprecate-in-place + track (B-D1). |
+| R5 | Hermes version/semver | Bump `platforms/hermes/VERSION` + CHANGELOG; classify minor vs major by whether prompt removal is breaking for consumers. |
+| R6 | Scope creep (Part B touching the whole prompt corpus) | Limit B1 to element-ID forms + the type-code legend; do not rewrite prompt prose. |
+
+## Review log
+
+> ≥2 passes before implementation (CLAUDE.md).
+
+### Pass 1 — 2026-05-25
+
+- **Vendoring needs location-independence first.** Byte-identical copies are
+  impossible while the linter hardcodes `parents[2]` for the registry — added
+  A-D2 (upward-search + override) as a prerequisite, enabling A-D3's identical-copy
+  drift guard.
+- **Three ID schemes, not two.** Surfaced the Hermes runtime's *3-segment* regex
+  as distinct from both the legacy type-code prompts and the framework 4-segment
+  form; Part B must fix the runtime regex + tests (B2), not just prompt examples.
+- **Legacy prompts have runtime coupling.** `validation/runner.py` has a `ctr`
+  branch and prompts load per-layer — so B3 is "investigate then remove-or-deprecate,"
+  not a blind file delete (R4, B-D1).
+- **Split the PRs.** Part A (low-risk) lands before Part B (runtime+tests).
+
+### Pass 2 — 2026-05-25
+
+- **Don't touch finding-ID schemes.** Scoped out `P0-hash`/`ACT-hash` in
+  `reporting/contracts.py` — those are finding/action IDs, not element IDs;
+  conflating them would break reporting. Added to Scope-Out.
+- **Hermes semver.** Part B is runtime-behavior-changing + removes prompt files ⇒
+  a Hermes VERSION bump (R5); framework spec untouched (no GATE-SPEC).
+- **Prose-rewrite guard.** B1 is strictly element-ID-form + legend; the EARS
+  pattern prose was already aligned in the prior Hermes PR, so B1 won't re-touch it
+  (R6). No change.
+- No further findings — implementable pending approval (B-D1 resolved at impl time
+  from the coupling check).

--- a/plans/PLATFORM-ALIGN-PLAN.md
+++ b/plans/PLATFORM-ALIGN-PLAN.md
@@ -4,7 +4,7 @@
 |------------|--------------------------------|
 | Task       | PLATFORM-ALIGN                 |
 | Depends on | DOC-CHECK (PRs #17/#18 merged); framework spec `0.7.0`; the 4-segment element-ID standard (`LAYER_REGISTRY.yaml` `id_patterns`) |
-| Status     | APPROVED — 2026-05-25 (implement ALL parts: A vendor+location-independence+guard; B1 prompts; B2 runtime regex+tests; B3 **remove** legacy-layer prompts; 2-PR sequence) |
+| Status     | IN PROGRESS — Part A implemented (PR-1, branch `claude/platform-align`); Part B (Hermes IDs + legacy-prompt removal) pending, cut after PR-1 merges |
 | Feeds      | a consumer-runnable doc-linter on both platforms (Part A); Hermes element-IDs aligned to the framework hash form + legacy-layer prompts handled (Part B) |
 
 ## Objective
@@ -205,3 +205,22 @@ framework/spec change.
   (rationale recorded under Versioning).
 - **Sequencing unchanged:** PR-1 = Part A, PR-2 = Part B (cut after A merges).
 - No further findings — proceeding to implement Part A.
+
+## Implementation log
+
+### Part A — 2026-05-25 (PR-1, branch `claude/platform-align`)
+
+- Made `tools/sdd_doc_lint` **location-independent** (upward-search for
+  `framework/registry/` + `$SDD_REGISTRY`/`--registry`; CLI exits 2 when the
+  registry is unavailable). Vendored **byte-identical** copies into
+  `platforms/claude-code-plugin/sdd_doc_lint/` and `platforms/hermes/sdd_doc_lint/`;
+  `tools/sdd_doc_lint/sync-vendored.sh` re-syncs them; a conformance guard
+  (`tests/conformance/platforms/test_doc_lint_vendoring.py`) enforces the match
+  (suite **49 → 50**). The plugin `on_author` hook now derives its plugin root and
+  runs the vendored linter on `PYTHONPATH` — deterministic findings are reliable
+  (not best-effort), still advisory/exit-0, and skip silently with no `framework/`.
+  Both platform READMEs document the vendoring. Verified: linter tests + fixtures
+  pass from canonical and vendored locations; registry-unavailable → exit 2 (clean,
+  no traceback); hook end-to-end emits nudge + findings; `pre-commit` clean.
+- **Next:** Part B (B1 prompt IDs, B2 runtime regex 3→4 + tests, B3 remove
+  legacy-layer prompts + coupling, Hermes VERSION bump) — PR-2 after PR-1 merges.

--- a/plans/PLATFORM-ALIGN-PLAN.md
+++ b/plans/PLATFORM-ALIGN-PLAN.md
@@ -4,7 +4,7 @@
 |------------|--------------------------------|
 | Task       | PLATFORM-ALIGN                 |
 | Depends on | DOC-CHECK (PRs #17/#18 merged); framework spec `0.7.0`; the 4-segment element-ID standard (`LAYER_REGISTRY.yaml` `id_patterns`) |
-| Status     | PLANNED — 2026-05-25 (awaiting approval) |
+| Status     | APPROVED — 2026-05-25 (implement ALL parts: A vendor+location-independence+guard; B1 prompts; B2 runtime regex+tests; B3 **remove** legacy-layer prompts; 2-PR sequence) |
 | Feeds      | a consumer-runnable doc-linter on both platforms (Part A); Hermes element-IDs aligned to the framework hash form + legacy-layer prompts handled (Part B) |
 
 ## Objective
@@ -105,21 +105,32 @@ Change the Hermes element-ID validators from 3-segment to 4-segment:
   fixtures/assertions to the 4-segment form;
 - run the full Hermes pytest suite — it must stay green (this is the risk gate).
 
-### B3 — legacy-layer prompts (SYS/REQ/CTR/TSPEC) — "handle them too"
+### B3 — legacy-layer prompts (SYS/REQ/CTR/TSPEC) — **remove** (B-D1 resolved)
 
-Investigate runtime coupling first (the `validation/runner.py` `ctr` branch, the
-per-layer prompt loader, `tool_registry`), then **remove** the 12 off-model prompt
-files **and** their runtime handling — *only* if nothing in the 8-layer flow
-depends on them. If a clean removal isn't safe (hidden coupling), **deprecate**
-in place (a header note that the layer is not part of the 8-layer framework) and
-record the residual coupling as a tracked item. Decision **B-D1** resolved at
-implementation time from the coupling check.
+**Decision: remove.** Delete the 12 off-model prompt files (SYS/REQ/CTR/TSPEC ×
+creation/review/remediation) **and** their runtime coupling — they are not part of
+the 8-layer framework (the framework absorbed SYS→SPEC, REQ→EARS, CTR→SPEC,
+TSPEC→TDD; the plugin already retired them). Method:
+
+1. Map the coupling first: the `validation/runner.py` `ctr` branch + any
+   SYS/REQ/CTR/TSPEC arms in the per-layer prompt loader / `tool_registry` /
+   layer-name allowlists.
+2. Remove the prompt files + the dead runtime arms together, so the layer→prompt
+   loader only resolves the 8 framework layers.
+3. Update/trim any Hermes tests that assert the legacy layers.
+4. If the coupling check reveals a legacy layer still backs a *currently
+   advertised* Hermes capability (not expected), stop and escalate rather than
+   break it — but the default is full removal.
 
 ### Versioning
 
-Part B changes Hermes runtime behavior + removes prompts ⇒ bump
-`platforms/hermes/VERSION` (minor or major per the removal's blast radius) +
-Hermes CHANGELOG. No framework/spec change.
+Part B changes Hermes runtime behavior + removes the off-model legacy-layer
+prompts ⇒ **bump `platforms/hermes/VERSION` (minor)** + a Hermes CHANGELOG
+`Removed`/`Changed` entry. Minor (not major): the removed layers were never part
+of the conformant 8-layer surface, so no 8-layer consumer capability is lost; the
+4-segment ID move aligns Hermes to the framework it already declares conformance
+to. (Escalate to major only if step B3.4 finds an advertised dependency.) No
+framework/spec change.
 
 ## Sequencing
 
@@ -179,5 +190,18 @@ Hermes CHANGELOG. No framework/spec change.
 - **Prose-rewrite guard.** B1 is strictly element-ID-form + legend; the EARS
   pattern prose was already aligned in the prior Hermes PR, so B1 won't re-touch it
   (R6). No change.
-- No further findings — implementable pending approval (B-D1 resolved at impl time
-  from the coupling check).
+- No further findings — implementable pending approval.
+
+### Pass 3 — 2026-05-25 (decisions firmed for implementation)
+
+- **All parts in scope, no deferrals.** Per the go-ahead: Part A (vendor +
+  location-independence + drift guard + hook wiring), Part B1 (prompt IDs), B2
+  (runtime regex 3→4 segment + tests), and B3 (**remove** legacy-layer prompts +
+  coupling) are all in scope.
+- **B-D1 resolved = remove** (was "remove-or-deprecate"). Default is full removal
+  of the 12 SYS/REQ/CTR/TSPEC prompts + their runtime arms; escalate only if a
+  legacy layer is found to back a currently-advertised capability.
+- **Hermes semver fixed = minor** + a `Removed`/`Changed` CHANGELOG entry
+  (rationale recorded under Versioning).
+- **Sequencing unchanged:** PR-1 = Part A, PR-2 = Part B (cut after A merges).
+- No further findings — proceeding to implement Part A.

--- a/platforms/claude-code-plugin/README.md
+++ b/platforms/claude-code-plugin/README.md
@@ -25,11 +25,18 @@ the manifest.
 
 `hooks/hooks.json` registers a `PostToolUse` hook on `Write`/`Edit`. When an SDD
 instance document (`docs/<NN>_<X>/…` or a `<TYPE>-NN` file) is written, it nudges
-you to run the matching `doc-<layer>-audit` (and, if `sdd_doc_lint` is importable,
-appends deterministic structural findings). It is **advisory** — it never blocks
-the edit. This is the plugin's binding of the framework's `on_author` trigger
-point (`framework/governance/REVIEW_REMEDIATION_FLOW.md`); the blocking `pre_merge`
-gate is the shared `doc-review.yml` workflow running `tools/sdd_doc_lint`.
+you to run the matching `doc-<layer>-audit` and appends deterministic structural
+findings from the **vendored `sdd_doc_lint/`** (shipped at the plugin root; the
+hook puts it on `PYTHONPATH`, so it runs without any consumer setup — it finds the
+project's `framework/registry/` by upward search, and silently skips if none is
+present). It is **advisory** — it never blocks the edit. This is the plugin's
+binding of the framework's `on_author` trigger point
+(`framework/governance/REVIEW_REMEDIATION_FLOW.md`); the blocking `pre_merge`
+gate is the shared `doc-review.yml` workflow running the same linter.
+
+The vendored `sdd_doc_lint/` is a byte-identical copy of the canonical
+`tools/sdd_doc_lint/` (kept in sync by `tools/sdd_doc_lint/sync-vendored.sh`, a
+conformance guard enforces the match).
 
 ## Install
 

--- a/platforms/claude-code-plugin/hooks/sdd-doc-review.sh
+++ b/platforms/claude-code-plugin/hooks/sdd-doc-review.sh
@@ -33,9 +33,15 @@ esac
 layer="$(printf '%s' "$artifact" | tr '[:upper:]' '[:lower:]')"
 msg="Edited a ${artifact} document (${base}). Per the framework review→remediation→gate loop (on_author): run /aidoc-flow:doc-${layer}-audit to score readiness before promoting downstream; if it scores below the gate, /aidoc-flow:doc-${layer}-fixer remediates."
 
-# Best-effort deterministic structural check (only if the linter is importable).
-if command -v python3 >/dev/null 2>&1 && python3 -c "import sdd_doc_lint" >/dev/null 2>&1; then
-  if ! findings="$(python3 -m sdd_doc_lint "$file_path" 2>&1)"; then
+# Deterministic structural check via the vendored linter. The plugin ships
+# sdd_doc_lint at its root, so derive the plugin root from this script's path
+# and put it on PYTHONPATH (works regardless of the CLAUDE_PLUGIN_ROOT env var).
+# Exit codes: 1 = structural findings (append); 0 = clean; 2 = registry not
+# found (e.g. no framework/ in the project) → skip silently.
+plugin_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." 2>/dev/null && pwd)"
+if command -v python3 >/dev/null 2>&1 && [ -n "$plugin_root" ]; then
+  findings="$(PYTHONPATH="${plugin_root}${PYTHONPATH:+:$PYTHONPATH}" python3 -m sdd_doc_lint "$file_path" 2>&1)"
+  if [ "$?" -eq 1 ]; then
     msg="${msg}"$'\n\nStructural findings (sdd_doc_lint):\n'"${findings}"
   fi
 fi

--- a/platforms/claude-code-plugin/sdd_doc_lint/__init__.py
+++ b/platforms/claude-code-plugin/sdd_doc_lint/__init__.py
@@ -1,0 +1,193 @@
+"""sdd_doc_lint — deterministic structural check for SDD instance documents.
+
+The platform-tier implementation of the framework's `on_author` / `pre_merge`
+trigger-point check (see `framework/governance/REVIEW_REMEDIATION_FLOW.md`). It
+runs the *structural* subset of a review — ID/tag forms, required upstream tags,
+`@threshold:` format, EARS grammar, placeholder leakage — driven by
+`framework/registry/LAYER_REGISTRY.yaml`. The semantic readiness score stays the
+LLM `-audit` skill; this is the fast, repeatable gate beneath it.
+
+Text-based on purpose: the checks work on an instance document whether it is
+authored as Markdown or YAML.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+_REGISTRY_REL = Path("framework") / "registry" / "LAYER_REGISTRY.yaml"
+
+
+def find_registry(start: Path | None = None) -> Path:
+    """Locate ``framework/registry/LAYER_REGISTRY.yaml`` without assuming the
+    package's location, so a vendored copy works from any platform.
+
+    Order: ``$SDD_REGISTRY`` → search upward from the CWD → search upward from
+    this module → the canonical repo layout (``parents[2]``).
+    """
+    env = os.environ.get("SDD_REGISTRY")
+    if env:
+        return Path(env)
+    seeds = [start or Path.cwd(), Path(__file__).resolve().parent]
+    for seed in seeds:
+        for base in [seed, *seed.resolve().parents]:
+            candidate = base / _REGISTRY_REL
+            if candidate.is_file():
+                return candidate
+    return Path(__file__).resolve().parents[2] / _REGISTRY_REL
+
+
+LAYER_TAGS = ("brd", "prd", "ears", "bdd", "adr", "spec", "tdd", "iplan")
+
+_TAG = re.compile(r"@(" + "|".join(LAYER_TAGS) + r")\s*:\s*([^\s|]+)")
+_THRESHOLD = re.compile(r"@threshold:\s*([^\s|]+)")
+_THEN_CONNECTIVE = re.compile(r"THEN\s*\[")
+_PLACEHOLDERS = [
+    re.compile(r"\bTBD\b"),
+    re.compile(r"\bTODO\b"),
+    re.compile(r"\bFIXME\b"),
+    re.compile(r"\b[A-Z]{2,8}-XXX\b"),
+    re.compile(r"\bXX+\b"),
+]
+# Candidate IDs whose prefix is a known artifact (avoids flagging unrelated tokens).
+_KNOWN = "BRD|PRD|EARS|BDD|ADR|SPEC|TDD|IPLAN"
+_DOC_ID = re.compile(rf"\b({_KNOWN})-([A-Za-z0-9]+)\b")
+_ELEM_ID = re.compile(rf"\b({_KNOWN})((?:\.[A-Za-z0-9]+)+)\b")
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: str
+    line: int
+    code: str
+    message: str
+    severity: str = "error"
+
+    def __str__(self) -> str:
+        return f"{self.path}:{self.line}: [{self.severity.upper()} {self.code}] {self.message}"
+
+
+def _load_registry(registry: Path | None = None):
+    registry = registry or find_registry()
+    data = yaml.safe_load(registry.read_text(encoding="utf-8"))
+    layers = {layer["artifact"]: layer for layer in data["layers"]}
+    pats = data["id_patterns"]
+    return layers, re.compile(pats["document"]), re.compile(pats["element"])
+
+
+def detect_layer(path: Path, layers: dict) -> str | None:
+    """Return the artifact code for an SDD instance doc, or None if not one."""
+    parts = [p.upper() for p in path.parts]
+    # docs/0N_<ARTIFACT>/...
+    for part in parts:
+        m = re.fullmatch(r"\d{2}_([A-Z]+)", part)
+        if m and m.group(1) in layers:
+            return m.group(1)
+    # filename prefix <ARTIFACT>-NN_...
+    m = re.match(rf"({_KNOWN})-", path.name.upper())
+    if m and m.group(1) in layers:
+        return m.group(1)
+    return None
+
+
+def lint_text(text: str, artifact: str, rel: str, layers, doc_re, elem_re) -> list[Finding]:
+    findings: list[Finding] = []
+    lines = text.splitlines()
+    seen_tags: set[str] = set()
+
+    for i, line in enumerate(lines, 1):
+        # Trace tags: collect which upstream layers are referenced + validate the id form.
+        for m in _TAG.finditer(line):
+            seen_tags.add(m.group(1))
+            val = m.group(2)
+            if not (doc_re.match(val) or elem_re.match(val)):
+                findings.append(
+                    Finding(rel, i, "ID01", f"malformed trace-tag id '@{m.group(1)}: {val}'")
+                )
+        # Threshold tags: TYPE.NUM.key dotted form. Record their spans so the
+        # element-id scan below does not mistake a threshold key for an element id.
+        threshold_spans = []
+        for m in _THRESHOLD.finditer(line):
+            threshold_spans.append(m.span(1))
+            val = m.group(1)
+            if not re.match(r"^[A-Z]+\.[A-Za-z0-9]+(?:\.[A-Za-z0-9]+)+$", val):
+                findings.append(
+                    Finding(rel, i, "TH01", f"malformed @threshold: '{val}' (want TYPE.NN.key)")
+                )
+
+        def _in_threshold(span):
+            return any(s[0] <= span[0] and span[1] <= s[1] for s in threshold_spans)
+
+        # Inline document IDs (TYPE-NN) of known artifacts must match the doc form.
+        for m in _DOC_ID.finditer(line):
+            tok = m.group(0)
+            if not doc_re.match(tok):
+                findings.append(Finding(rel, i, "ID02", f"malformed document id '{tok}'"))
+        # Inline element IDs (TYPE.a.b.c…) of known artifacts must match the element form.
+        for m in _ELEM_ID.finditer(line):
+            tok = m.group(0)
+            if _in_threshold(m.span()):
+                continue  # a threshold key, not an element id
+            if tok.count(".") >= 3 and not elem_re.match(tok):
+                findings.append(Finding(rel, i, "ID03", f"malformed element id '{tok}'"))
+        # Placeholder leakage.
+        for pat in _PLACEHOLDERS:
+            if pat.search(line):
+                findings.append(
+                    Finding(
+                        rel, i, "PH01", f"placeholder/unfilled token: '{pat.search(line).group(0)}'"
+                    )
+                )
+        # EARS grammar: no THEN-connective.
+        if artifact == "EARS" and _THEN_CONNECTIVE.search(line):
+            findings.append(
+                Finding(
+                    rel,
+                    i,
+                    "EARS01",
+                    "EARS uses 'THE … SHALL …', not a 'THEN [response]' connective",
+                )
+            )
+
+    # Required upstream tags present (document-level, reported at line 0).
+    required = layers[artifact].get("required_tags", []) or []
+    for tag in required:
+        if tag not in seen_tags:
+            findings.append(
+                Finding(
+                    rel,
+                    0,
+                    "TAG01",
+                    f"{artifact} requires upstream tag '@{tag}:' (cumulative traceability)",
+                )
+            )
+    return findings
+
+
+def lint_file(path: Path, layers, doc_re, elem_re) -> list[Finding]:
+    artifact = detect_layer(path, layers)
+    if artifact is None:
+        return []
+    try:
+        rel = path.resolve().relative_to(Path.cwd().resolve()).as_posix()
+    except ValueError:
+        rel = path.as_posix()
+    return lint_text(path.read_text(encoding="utf-8"), artifact, rel, layers, doc_re, elem_re)
+
+
+def lint_path(target: Path, registry: Path | None = None) -> list[Finding]:
+    """Lint a file or recurse a directory; returns all findings."""
+    layers, doc_re, elem_re = _load_registry(registry)
+    findings: list[Finding] = []
+    if target.is_dir():
+        for p in sorted(target.rglob("*")):
+            if p.is_file() and p.suffix.lower() in (".md", ".yaml", ".yml"):
+                findings.extend(lint_file(p, layers, doc_re, elem_re))
+    elif target.is_file():
+        findings.extend(lint_file(target, layers, doc_re, elem_re))
+    return findings

--- a/platforms/claude-code-plugin/sdd_doc_lint/__main__.py
+++ b/platforms/claude-code-plugin/sdd_doc_lint/__main__.py
@@ -1,0 +1,57 @@
+"""CLI: python -m sdd_doc_lint [--registry PATH] <path> [<path> ...]
+
+Exit 0 = no error-level findings; 1 = error findings; 2 = usage error.
+The framework registry is located automatically (upward search for
+``framework/registry/LAYER_REGISTRY.yaml``, or ``$SDD_REGISTRY`` / ``--registry``),
+so the same code runs from the canonical repo or a vendored platform copy.
+Backs the ``on_author`` (advisory) and ``pre_merge`` (blocking) trigger points —
+see framework/governance/REVIEW_REMEDIATION_FLOW.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from . import lint_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="sdd_doc_lint")
+    parser.add_argument("paths", nargs="+", help="file(s) or directory(ies) to lint")
+    parser.add_argument(
+        "--registry",
+        type=Path,
+        default=None,
+        help="path to LAYER_REGISTRY.yaml (else $SDD_REGISTRY or an upward search)",
+    )
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+
+    findings = []
+    try:
+        for arg in args.paths:
+            findings.extend(lint_path(Path(arg), registry=args.registry))
+    except OSError as exc:
+        # Registry not found/readable (e.g. run outside a framework/ project).
+        # Exit 2 (not 1) so callers can tell "could not run" from "found errors".
+        print(f"sdd-doc-lint: registry unavailable ({exc}); skipping.", file=sys.stderr)
+        return 2
+
+    errors = [f for f in findings if f.severity == "error"]
+    for f in sorted(findings, key=lambda x: (x.path, x.line, x.code)):
+        stream = sys.stderr if f.severity == "error" else sys.stdout
+        print(str(f), file=stream)
+
+    if errors:
+        print(
+            f"\nsdd-doc-lint: {len(errors)} error(s) across {len({f.path for f in errors})} file(s).",
+            file=sys.stderr,
+        )
+        return 1
+    print("sdd-doc-lint: no structural findings.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/platforms/hermes/README.md
+++ b/platforms/hermes/README.md
@@ -89,8 +89,12 @@ runtime: server-side `validation/` + scoring covers `on_author` (on-demand
 validate/score) and `pre_promotion` (the readiness gate before the next layer);
 the `UCRem_*` remediation prompts cover `on_gate_fail`. For the `pre_merge`
 (PR-time) point, a Hermes-based project uses the shared `doc-review.yml`
-workflow running `tools/sdd_doc_lint` — the same deterministic structural gate
-the plugin uses — so both platforms gate documents identically in CI.
+workflow running the deterministic `sdd_doc_lint` — the same structural gate the
+plugin uses — so both platforms gate documents identically in CI. A
+byte-identical copy of the linter is vendored at `sdd_doc_lint/` (kept in sync
+with the canonical `tools/sdd_doc_lint/` by `sync-vendored.sh`, enforced by a
+conformance guard); run it from the platform root with
+`PYTHONPATH=. python -m sdd_doc_lint <docs-path>`.
 
 ## Platform info
 

--- a/platforms/hermes/sdd_doc_lint/__init__.py
+++ b/platforms/hermes/sdd_doc_lint/__init__.py
@@ -1,0 +1,193 @@
+"""sdd_doc_lint — deterministic structural check for SDD instance documents.
+
+The platform-tier implementation of the framework's `on_author` / `pre_merge`
+trigger-point check (see `framework/governance/REVIEW_REMEDIATION_FLOW.md`). It
+runs the *structural* subset of a review — ID/tag forms, required upstream tags,
+`@threshold:` format, EARS grammar, placeholder leakage — driven by
+`framework/registry/LAYER_REGISTRY.yaml`. The semantic readiness score stays the
+LLM `-audit` skill; this is the fast, repeatable gate beneath it.
+
+Text-based on purpose: the checks work on an instance document whether it is
+authored as Markdown or YAML.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+_REGISTRY_REL = Path("framework") / "registry" / "LAYER_REGISTRY.yaml"
+
+
+def find_registry(start: Path | None = None) -> Path:
+    """Locate ``framework/registry/LAYER_REGISTRY.yaml`` without assuming the
+    package's location, so a vendored copy works from any platform.
+
+    Order: ``$SDD_REGISTRY`` → search upward from the CWD → search upward from
+    this module → the canonical repo layout (``parents[2]``).
+    """
+    env = os.environ.get("SDD_REGISTRY")
+    if env:
+        return Path(env)
+    seeds = [start or Path.cwd(), Path(__file__).resolve().parent]
+    for seed in seeds:
+        for base in [seed, *seed.resolve().parents]:
+            candidate = base / _REGISTRY_REL
+            if candidate.is_file():
+                return candidate
+    return Path(__file__).resolve().parents[2] / _REGISTRY_REL
+
+
+LAYER_TAGS = ("brd", "prd", "ears", "bdd", "adr", "spec", "tdd", "iplan")
+
+_TAG = re.compile(r"@(" + "|".join(LAYER_TAGS) + r")\s*:\s*([^\s|]+)")
+_THRESHOLD = re.compile(r"@threshold:\s*([^\s|]+)")
+_THEN_CONNECTIVE = re.compile(r"THEN\s*\[")
+_PLACEHOLDERS = [
+    re.compile(r"\bTBD\b"),
+    re.compile(r"\bTODO\b"),
+    re.compile(r"\bFIXME\b"),
+    re.compile(r"\b[A-Z]{2,8}-XXX\b"),
+    re.compile(r"\bXX+\b"),
+]
+# Candidate IDs whose prefix is a known artifact (avoids flagging unrelated tokens).
+_KNOWN = "BRD|PRD|EARS|BDD|ADR|SPEC|TDD|IPLAN"
+_DOC_ID = re.compile(rf"\b({_KNOWN})-([A-Za-z0-9]+)\b")
+_ELEM_ID = re.compile(rf"\b({_KNOWN})((?:\.[A-Za-z0-9]+)+)\b")
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: str
+    line: int
+    code: str
+    message: str
+    severity: str = "error"
+
+    def __str__(self) -> str:
+        return f"{self.path}:{self.line}: [{self.severity.upper()} {self.code}] {self.message}"
+
+
+def _load_registry(registry: Path | None = None):
+    registry = registry or find_registry()
+    data = yaml.safe_load(registry.read_text(encoding="utf-8"))
+    layers = {layer["artifact"]: layer for layer in data["layers"]}
+    pats = data["id_patterns"]
+    return layers, re.compile(pats["document"]), re.compile(pats["element"])
+
+
+def detect_layer(path: Path, layers: dict) -> str | None:
+    """Return the artifact code for an SDD instance doc, or None if not one."""
+    parts = [p.upper() for p in path.parts]
+    # docs/0N_<ARTIFACT>/...
+    for part in parts:
+        m = re.fullmatch(r"\d{2}_([A-Z]+)", part)
+        if m and m.group(1) in layers:
+            return m.group(1)
+    # filename prefix <ARTIFACT>-NN_...
+    m = re.match(rf"({_KNOWN})-", path.name.upper())
+    if m and m.group(1) in layers:
+        return m.group(1)
+    return None
+
+
+def lint_text(text: str, artifact: str, rel: str, layers, doc_re, elem_re) -> list[Finding]:
+    findings: list[Finding] = []
+    lines = text.splitlines()
+    seen_tags: set[str] = set()
+
+    for i, line in enumerate(lines, 1):
+        # Trace tags: collect which upstream layers are referenced + validate the id form.
+        for m in _TAG.finditer(line):
+            seen_tags.add(m.group(1))
+            val = m.group(2)
+            if not (doc_re.match(val) or elem_re.match(val)):
+                findings.append(
+                    Finding(rel, i, "ID01", f"malformed trace-tag id '@{m.group(1)}: {val}'")
+                )
+        # Threshold tags: TYPE.NUM.key dotted form. Record their spans so the
+        # element-id scan below does not mistake a threshold key for an element id.
+        threshold_spans = []
+        for m in _THRESHOLD.finditer(line):
+            threshold_spans.append(m.span(1))
+            val = m.group(1)
+            if not re.match(r"^[A-Z]+\.[A-Za-z0-9]+(?:\.[A-Za-z0-9]+)+$", val):
+                findings.append(
+                    Finding(rel, i, "TH01", f"malformed @threshold: '{val}' (want TYPE.NN.key)")
+                )
+
+        def _in_threshold(span):
+            return any(s[0] <= span[0] and span[1] <= s[1] for s in threshold_spans)
+
+        # Inline document IDs (TYPE-NN) of known artifacts must match the doc form.
+        for m in _DOC_ID.finditer(line):
+            tok = m.group(0)
+            if not doc_re.match(tok):
+                findings.append(Finding(rel, i, "ID02", f"malformed document id '{tok}'"))
+        # Inline element IDs (TYPE.a.b.c…) of known artifacts must match the element form.
+        for m in _ELEM_ID.finditer(line):
+            tok = m.group(0)
+            if _in_threshold(m.span()):
+                continue  # a threshold key, not an element id
+            if tok.count(".") >= 3 and not elem_re.match(tok):
+                findings.append(Finding(rel, i, "ID03", f"malformed element id '{tok}'"))
+        # Placeholder leakage.
+        for pat in _PLACEHOLDERS:
+            if pat.search(line):
+                findings.append(
+                    Finding(
+                        rel, i, "PH01", f"placeholder/unfilled token: '{pat.search(line).group(0)}'"
+                    )
+                )
+        # EARS grammar: no THEN-connective.
+        if artifact == "EARS" and _THEN_CONNECTIVE.search(line):
+            findings.append(
+                Finding(
+                    rel,
+                    i,
+                    "EARS01",
+                    "EARS uses 'THE … SHALL …', not a 'THEN [response]' connective",
+                )
+            )
+
+    # Required upstream tags present (document-level, reported at line 0).
+    required = layers[artifact].get("required_tags", []) or []
+    for tag in required:
+        if tag not in seen_tags:
+            findings.append(
+                Finding(
+                    rel,
+                    0,
+                    "TAG01",
+                    f"{artifact} requires upstream tag '@{tag}:' (cumulative traceability)",
+                )
+            )
+    return findings
+
+
+def lint_file(path: Path, layers, doc_re, elem_re) -> list[Finding]:
+    artifact = detect_layer(path, layers)
+    if artifact is None:
+        return []
+    try:
+        rel = path.resolve().relative_to(Path.cwd().resolve()).as_posix()
+    except ValueError:
+        rel = path.as_posix()
+    return lint_text(path.read_text(encoding="utf-8"), artifact, rel, layers, doc_re, elem_re)
+
+
+def lint_path(target: Path, registry: Path | None = None) -> list[Finding]:
+    """Lint a file or recurse a directory; returns all findings."""
+    layers, doc_re, elem_re = _load_registry(registry)
+    findings: list[Finding] = []
+    if target.is_dir():
+        for p in sorted(target.rglob("*")):
+            if p.is_file() and p.suffix.lower() in (".md", ".yaml", ".yml"):
+                findings.extend(lint_file(p, layers, doc_re, elem_re))
+    elif target.is_file():
+        findings.extend(lint_file(target, layers, doc_re, elem_re))
+    return findings

--- a/platforms/hermes/sdd_doc_lint/__main__.py
+++ b/platforms/hermes/sdd_doc_lint/__main__.py
@@ -1,0 +1,57 @@
+"""CLI: python -m sdd_doc_lint [--registry PATH] <path> [<path> ...]
+
+Exit 0 = no error-level findings; 1 = error findings; 2 = usage error.
+The framework registry is located automatically (upward search for
+``framework/registry/LAYER_REGISTRY.yaml``, or ``$SDD_REGISTRY`` / ``--registry``),
+so the same code runs from the canonical repo or a vendored platform copy.
+Backs the ``on_author`` (advisory) and ``pre_merge`` (blocking) trigger points —
+see framework/governance/REVIEW_REMEDIATION_FLOW.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from . import lint_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="sdd_doc_lint")
+    parser.add_argument("paths", nargs="+", help="file(s) or directory(ies) to lint")
+    parser.add_argument(
+        "--registry",
+        type=Path,
+        default=None,
+        help="path to LAYER_REGISTRY.yaml (else $SDD_REGISTRY or an upward search)",
+    )
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+
+    findings = []
+    try:
+        for arg in args.paths:
+            findings.extend(lint_path(Path(arg), registry=args.registry))
+    except OSError as exc:
+        # Registry not found/readable (e.g. run outside a framework/ project).
+        # Exit 2 (not 1) so callers can tell "could not run" from "found errors".
+        print(f"sdd-doc-lint: registry unavailable ({exc}); skipping.", file=sys.stderr)
+        return 2
+
+    errors = [f for f in findings if f.severity == "error"]
+    for f in sorted(findings, key=lambda x: (x.path, x.line, x.code)):
+        stream = sys.stderr if f.severity == "error" else sys.stdout
+        print(str(f), file=stream)
+
+    if errors:
+        print(
+            f"\nsdd-doc-lint: {len(errors)} error(s) across {len({f.path for f in errors})} file(s).",
+            file=sys.stderr,
+        )
+        return 1
+    print("sdd-doc-lint: no structural findings.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conformance/platforms/test_doc_lint_vendoring.py
+++ b/tests/conformance/platforms/test_doc_lint_vendoring.py
@@ -1,0 +1,43 @@
+"""Conformance: the vendored ``sdd_doc_lint`` copies stay byte-identical to the
+canonical ``tools/sdd_doc_lint/`` (PLATFORM-ALIGN Part A).
+
+The linter is deliberately vendored into each platform so the plugin's
+``on_author`` hook (and a Hermes-side entry) can run it at consumer runtime
+without depending on the other platform. To keep that vendoring from drifting
+into divergent copies (the D-0013 single-source ethos), this guard asserts the
+vendored ``__init__.py`` / ``__main__.py`` match the canonical source byte-for-byte.
+
+Re-sync after editing the canonical linter:
+    bash tools/sdd_doc_lint/sync-vendored.sh
+"""
+
+import unittest
+
+from _spec import REPO_ROOT
+
+CANONICAL = REPO_ROOT / "tools" / "sdd_doc_lint"
+VENDORED = [
+    REPO_ROOT / "platforms" / "claude-code-plugin" / "sdd_doc_lint",
+    REPO_ROOT / "platforms" / "hermes" / "sdd_doc_lint",
+]
+MODULES = ("__init__.py", "__main__.py")
+
+
+class DocLintVendoring(unittest.TestCase):
+    def test_vendored_copies_are_byte_identical(self):
+        canonical = {m: (CANONICAL / m).read_bytes() for m in MODULES}
+        for dest in VENDORED:
+            for m in MODULES:
+                with self.subTest(copy=dest.relative_to(REPO_ROOT).as_posix(), module=m):
+                    path = dest / m
+                    self.assertTrue(path.is_file(), f"missing vendored linter module: {path}")
+                    self.assertEqual(
+                        path.read_bytes(),
+                        canonical[m],
+                        f"{path.relative_to(REPO_ROOT).as_posix()} drifted from the canonical "
+                        "tools/sdd_doc_lint — re-run tools/sdd_doc_lint/sync-vendored.sh",
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/sdd_doc_lint/__init__.py
+++ b/tools/sdd_doc_lint/__init__.py
@@ -13,14 +13,34 @@ authored as Markdown or YAML.
 
 from __future__ import annotations
 
+import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
 
 import yaml
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
-REGISTRY = REPO_ROOT / "framework" / "registry" / "LAYER_REGISTRY.yaml"
+_REGISTRY_REL = Path("framework") / "registry" / "LAYER_REGISTRY.yaml"
+
+
+def find_registry(start: Path | None = None) -> Path:
+    """Locate ``framework/registry/LAYER_REGISTRY.yaml`` without assuming the
+    package's location, so a vendored copy works from any platform.
+
+    Order: ``$SDD_REGISTRY`` → search upward from the CWD → search upward from
+    this module → the canonical repo layout (``parents[2]``).
+    """
+    env = os.environ.get("SDD_REGISTRY")
+    if env:
+        return Path(env)
+    seeds = [start or Path.cwd(), Path(__file__).resolve().parent]
+    for seed in seeds:
+        for base in [seed, *seed.resolve().parents]:
+            candidate = base / _REGISTRY_REL
+            if candidate.is_file():
+                return candidate
+    return Path(__file__).resolve().parents[2] / _REGISTRY_REL
+
 
 LAYER_TAGS = ("brd", "prd", "ears", "bdd", "adr", "spec", "tdd", "iplan")
 
@@ -52,8 +72,9 @@ class Finding:
         return f"{self.path}:{self.line}: [{self.severity.upper()} {self.code}] {self.message}"
 
 
-def _load_registry():
-    data = yaml.safe_load(REGISTRY.read_text(encoding="utf-8"))
+def _load_registry(registry: Path | None = None):
+    registry = registry or find_registry()
+    data = yaml.safe_load(registry.read_text(encoding="utf-8"))
     layers = {layer["artifact"]: layer for layer in data["layers"]}
     pats = data["id_patterns"]
     return layers, re.compile(pats["document"]), re.compile(pats["element"])
@@ -153,15 +174,15 @@ def lint_file(path: Path, layers, doc_re, elem_re) -> list[Finding]:
     if artifact is None:
         return []
     try:
-        rel = path.relative_to(REPO_ROOT).as_posix()
+        rel = path.resolve().relative_to(Path.cwd().resolve()).as_posix()
     except ValueError:
         rel = path.as_posix()
     return lint_text(path.read_text(encoding="utf-8"), artifact, rel, layers, doc_re, elem_re)
 
 
-def lint_path(target: Path) -> list[Finding]:
+def lint_path(target: Path, registry: Path | None = None) -> list[Finding]:
     """Lint a file or recurse a directory; returns all findings."""
-    layers, doc_re, elem_re = _load_registry()
+    layers, doc_re, elem_re = _load_registry(registry)
     findings: list[Finding] = []
     if target.is_dir():
         for p in sorted(target.rglob("*")):

--- a/tools/sdd_doc_lint/__main__.py
+++ b/tools/sdd_doc_lint/__main__.py
@@ -1,13 +1,16 @@
-"""CLI: python -m sdd_doc_lint <path> [<path> ...]
+"""CLI: python -m sdd_doc_lint [--registry PATH] <path> [<path> ...]
 
 Exit 0 = no error-level findings; 1 = error findings; 2 = usage error.
-Run from the repository root (it resolves the framework registry relative to the
-package). Intended to back the `on_author` (advisory) and `pre_merge` (blocking)
-trigger points — see framework/governance/REVIEW_REMEDIATION_FLOW.md.
+The framework registry is located automatically (upward search for
+``framework/registry/LAYER_REGISTRY.yaml``, or ``$SDD_REGISTRY`` / ``--registry``),
+so the same code runs from the canonical repo or a vendored platform copy.
+Backs the ``on_author`` (advisory) and ``pre_merge`` (blocking) trigger points —
+see framework/governance/REVIEW_REMEDIATION_FLOW.md.
 """
 
 from __future__ import annotations
 
+import argparse
 import sys
 from pathlib import Path
 
@@ -15,14 +18,25 @@ from . import lint_path
 
 
 def main(argv: list[str] | None = None) -> int:
-    argv = sys.argv[1:] if argv is None else argv
-    if not argv:
-        print("usage: python -m sdd_doc_lint <path> [<path> ...]", file=sys.stderr)
-        return 2
+    parser = argparse.ArgumentParser(prog="sdd_doc_lint")
+    parser.add_argument("paths", nargs="+", help="file(s) or directory(ies) to lint")
+    parser.add_argument(
+        "--registry",
+        type=Path,
+        default=None,
+        help="path to LAYER_REGISTRY.yaml (else $SDD_REGISTRY or an upward search)",
+    )
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
 
     findings = []
-    for arg in argv:
-        findings.extend(lint_path(Path(arg)))
+    try:
+        for arg in args.paths:
+            findings.extend(lint_path(Path(arg), registry=args.registry))
+    except OSError as exc:
+        # Registry not found/readable (e.g. run outside a framework/ project).
+        # Exit 2 (not 1) so callers can tell "could not run" from "found errors".
+        print(f"sdd-doc-lint: registry unavailable ({exc}); skipping.", file=sys.stderr)
+        return 2
 
     errors = [f for f in findings if f.severity == "error"]
     for f in sorted(findings, key=lambda x: (x.path, x.line, x.code)):

--- a/tools/sdd_doc_lint/sync-vendored.sh
+++ b/tools/sdd_doc_lint/sync-vendored.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Re-sync the vendored sdd_doc_lint copies from the canonical tools/sdd_doc_lint.
+# The canonical copy is the single source of truth; each platform ships a
+# byte-identical copy so its runtime can import the linter independently
+# (PLATFORM-ALIGN Part A). Run from anywhere in the repo.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$here/../.." && pwd)"
+canonical="$repo_root/tools/sdd_doc_lint"
+
+for dest in \
+  "$repo_root/platforms/claude-code-plugin/sdd_doc_lint" \
+  "$repo_root/platforms/hermes/sdd_doc_lint"; do
+  mkdir -p "$dest"
+  cp "$canonical/__init__.py" "$dest/__init__.py"
+  cp "$canonical/__main__.py" "$dest/__main__.py"
+  echo "synced -> ${dest#"$repo_root"/}"
+done


### PR DESCRIPTION
## Summary

**PLATFORM-ALIGN Part A** — vendor the deterministic doc-linter into both
platforms so the plugin's `on_author` hook can run it reliably at consumer
runtime (not just best-effort). Plan: `plans/PLATFORM-ALIGN-PLAN.md`.

**Platform/tooling only — no `framework/` change, no spec bump.**

### Changes
- **Location-independent linter** — `tools/sdd_doc_lint` now resolves
  `framework/registry/LAYER_REGISTRY.yaml` by upward search (from the CWD and the
  module), with a `--registry` / `$SDD_REGISTRY` override, instead of a hardcoded
  `parents[2]`. The CLI exits **2** (not 1) when the registry is unavailable, so a
  caller can tell *"couldn't run"* from *"found errors"*.
- **Vendored into both platforms** — byte-identical copies at
  `platforms/claude-code-plugin/sdd_doc_lint/` and `platforms/hermes/sdd_doc_lint/`,
  re-synced by `tools/sdd_doc_lint/sync-vendored.sh`. A conformance **drift guard**
  (`tests/conformance/platforms/test_doc_lint_vendoring.py`) asserts the copies stay
  byte-identical to the canonical source (single-source-of-truth despite the
  vendoring). Suite **49 → 50**.
- **Hook wired to the vendored copy** — the plugin `on_author` hook derives its
  plugin root from its own path and runs the vendored linter on `PYTHONPATH`, so
  deterministic findings are now reliable rather than best-effort. Still
  **advisory** (exit 0, never blocks); skips silently when no `framework/` registry
  is reachable. Both platform READMEs document the vendoring + sync.

### Why vendor (vs pip-package / document-only)
Per the decision to vendor into both platforms: each platform ships the linter so
its runtime imports it independently (the plugin must not depend on the Hermes
Python server, and vice-versa). The drift guard + sync script keep the copies from
diverging.

## Test plan
- [x] linter unit tests (3) pass; valid fixtures exit 0, broken exit 1 — from canonical **and** vendored locations
- [x] `--registry /nonexistent` → exit 2 with a clean message (no traceback)
- [x] hook end-to-end: non-SDD silent; SDD doc → nudge + findings; always exit 0
- [x] conformance **50/50** (incl. the new vendoring drift guard); `sync-vendored.sh` idempotent
- [x] `pre-commit` clean (ruff/bandit on vendored copies, markdown, yaml)
- [ ] CI green on the PR

Part B (Hermes element-IDs → framework 4-segment hash + removing the legacy-layer
prompts) follows as a separate PR, cut after this merges.

https://claude.ai/code/session_013duDkfbMr9Xhe15movDVxf

---
_Generated by [Claude Code](https://claude.ai/code/session_013duDkfbMr9Xhe15movDVxf)_