### PR TITLE
chore: wire gitleaks secret-scanning + add a yamllint config

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,11 @@
+# gitleaks configuration. Extends the default rule set; the allowlist below
+# keeps gitleaks from flagging the detect-secrets baseline (which intentionally
+# records secret *hashes*, not secrets).
+[extend]
+  useDefault = true
+
+[allowlist]
+  description = "Files allowed to contain secret-like tokens"
+  paths = [
+    '''\.secrets\.baseline$''',
+  ]

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,1 @@
+.secrets.baseline

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,7 +64,7 @@ repos:
     rev: v1.35.1
     hooks:
       - id: yamllint
-        args: [--strict]
+        args: [-c, .yamllint.yaml]
 
   # ---- secrets ---------------------------------------------------------------
   - repo: https://github.com/Yelp/detect-secrets
@@ -72,6 +72,11 @@ repos:
     hooks:
       - id: detect-secrets
         args: [--baseline, .secrets.baseline]
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks  # git-aware secret scan; config in .gitleaks.toml
 
   # ---- dependency vulnerability audit ----------------------------------------
   # Heavy / network-bound — runs in the `manual` stage (CI) + pre-push, not on

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,19 @@
+# yamllint configuration. Extends the default rules with project-appropriate
+# relaxations (wider line length as a warning; tolerate missing document-start
+# and non-bool truthy keys common in our YAML templates).
+extends: default
+
+rules:
+  line-length:
+    max: 120
+    level: warning
+  document-start:
+    present: false
+  truthy:
+    check-keys: false
+  comments:
+    min-spaces-from-content: 1
+  braces:
+    max-spaces-inside: 1
+  brackets:
+    max-spaces-inside: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- **gitleaks** secret-scanning wired into `.pre-commit-config.yaml` (with
+  `.gitleaks.toml` allowlisting the `.secrets.baseline`) — a git-aware scan
+  alongside the existing `detect-secrets` baseline check. Added a project
+  `.yamllint.yaml` config (line-length 120 as a *warning*; tolerate
+  missing document-start and non-bool truthy keys common in our templates) and
+  pointed the yamllint hook at it (dropping `--strict` so the configured
+  warnings stay non-blocking). Tooling-only; no framework spec change.
+
 ### Changed
 
 - Framework spec **0.7.0 → 0.7.1** (patch) — documentation consistency pass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,6 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-### Added
-
-- **gitleaks** secret-scanning wired into `.pre-commit-config.yaml` (with
-  `.gitleaks.toml` allowlisting the `.secrets.baseline`) — a git-aware scan
-  alongside the existing `detect-secrets` baseline check. Added a project
-  `.yamllint.yaml` config (line-length 120 as a *warning*; tolerate
-  missing document-start and non-bool truthy keys common in our templates) and
-  pointed the yamllint hook at it (dropping `--strict` so the configured
-  warnings stay non-blocking). Tooling-only; no framework spec change.
-
 ### Changed
 
 - Framework spec **0.7.0 → 0.7.1** (patch) — documentation consistency pass
@@ -118,6 +108,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **gitleaks** secret-scanning wired into `.pre-commit-config.yaml` (with
+  `.gitleaks.toml` allowlisting the `.secrets.baseline`) — a git-aware scan
+  alongside the existing `detect-secrets` baseline check. Added a project
+  `.yamllint.yaml` config (line-length 120 as a *warning*; tolerate missing
+  document-start and non-bool truthy keys common in our templates) and pointed
+  the yamllint hook at it (dropping `--strict` so the configured warnings stay
+  non-blocking). Tooling-only; no framework spec change.
 - **Pre-commit hooks** (`.pre-commit-config.yaml` + a `pre-commit` CI workflow,
   D-0021): hygiene (whitespace/EOF/check-yaml·json·toml/merge/large-files/
   private-key), **ruff** + ruff-format, **bandit** (gated medium+), **markdownlint**,


### PR DESCRIPTION
## Summary

The two genuinely-new infra bits salvaged from PR #23, applied **cleanly on
current `main`** — without #23's stale reverts or its cross-project
`pyproject.toml`.

### Added
- **gitleaks** secret-scan wired into `.pre-commit-config.yaml` (pinned
  `v8.21.2`), with `.gitleaks.toml` allowlisting `.secrets.baseline`. A
  git-aware scan that complements the existing `detect-secrets` baseline hook.
- **`.yamllint.yaml`** config (extends default; line-length **120 as a
  warning**; tolerate missing `document-start` and non-bool truthy keys, which
  are common in our YAML templates) and pointed the existing `yamllint` hook at
  it. Dropped `--strict` from that hook so the config's intentional *warnings*
  (e.g. long lines in vendored YAML) stay **non-blocking** rather than failing.

### Deliberately not included (from #23)
- The contaminated `pyproject.toml` — its `[tool.bandit] exclude_dirs`
  referenced dirs from another project (`business`, `iplanic`, `iops-framework`,
  `operations`) and its `[tool.ruff]` block would have changed repo-wide lint
  behavior.
- #23's `.pre-commit-config.yaml` rewrite (it dropped `markdownlint` + the local
  `conformance` hook) and its other stale reverts of merged work.

**Tooling-only — no `framework/` change.**

## Test plan
- [x] `pre-commit run gitleaks --all-files` — installs `v8.21.2`, **Passed** (no secrets flagged)
- [x] `pre-commit run yamllint --all-files` — **Passed** (warnings non-blocking; no new errors)
- [x] `pre-commit run --files <changed>` — all hooks green (check-yaml/toml, detect-secrets, gitleaks, yamllint)
- [x] conformance **50/50** (unaffected — no framework change)
- [ ] CI green on the PR

https://claude.ai/code/session_013duDkfbMr9Xhe15movDVxf

---
_Generated by [Claude Code](https://claude.ai/code/session_013duDkfbMr9Xhe15movDVxf)_