### PR TITLE
doc-flow: bundled-path resolution guidance (P2 / R2 de-risk)

### DIFF
--- a/plans/PLUGIN-MARKETPLACE-PLAN.md
+++ b/plans/PLUGIN-MARKETPLACE-PLAN.md
@@ -296,11 +296,16 @@ P1 Steps 1–8 done on `claude/multi-platform-migration-AamWB`:
 
 **Two findings worth carrying forward:**
 
-- **`${CLAUDE_PLUGIN_ROOT}` in prose (R2, sharpened).** claude-code-guide
-  confirmed the variable auto-expands only in config `command` fields, **not**
-  skill/agent body prose. P1's deliverable (self-containment — the files now
-  ship at that anchor) stands; whether the model resolves the variable in prose
-  is the **P2 live-test** question, with documented fallbacks (R2).
+- **`${CLAUDE_PLUGIN_ROOT}` in prose (R2, sharpened — guidance added).**
+  claude-code-guide confirmed the variable auto-expands only in config `command`
+  fields, **not** skill/agent body prose. P1's deliverable (self-containment — the
+  files now ship at that anchor) stands. **Proactive mitigation (2026-05-27):**
+  added a "Reading bundled files" note to `doc-flow` (the orchestrator/entry point)
+  telling the model to resolve `CLAUDE_PLUGIN_ROOT` via the shell (it expands in
+  Bash) or relative to the plugin root, and never to open the literal-text path.
+  The **P2 live run** confirms whether that orchestrator-level note suffices or
+  whether it must be broadcast to the directly-invokable per-layer skills (or moved
+  to a hook). Deferred the broadcast to avoid ~50 speculative edits before the run.
 - **Linter exclusions for the bundle.** Canonical `framework/` markdown is *not*
   style-clean — it is deliberately excluded from markdownlint/pre-commit because
   it is GATE-SPEC-governed. The byte-identical bundle inherits that: added
@@ -331,9 +336,10 @@ CLI, GitHub scope is the monorepo only, tag pushes 403):**
 3. **Live skill run (the R2 check)** — run a layer skill (e.g.
    `/aidoc-flow:doc-brd-autopilot`) against `examples/url-shortener/seed/` and
    confirm the model **reads the bundled framework files** referenced as
-   `${CLAUDE_PLUGIN_ROOT}/framework/…`. If it cannot resolve the variable in prose,
-   apply the R2 fallback (a resolution note in the orchestrator skill, or a
-   hook-injected root) and re-run.
+   `${CLAUDE_PLUGIN_ROOT}/framework/…`. `doc-flow` now carries a "Reading bundled
+   files" resolution note; if a *directly-invoked* layer skill still can't resolve
+   the path, broadcast that note to the per-layer skills (or move it to a hook) and
+   re-run.
 4. **Install smoke test** — `/plugin marketplace add vladm3105/aidoc-flow-framework`
    then `/plugin install aidoc-flow@aidoc-flow-framework`; run a skill end-to-end
    from the installed copy. **Only after 2–4 pass is "tested/ready" true.**

--- a/platforms/claude-code-plugin/CHANGELOG.md
+++ b/platforms/claude-code-plugin/CHANGELOG.md
@@ -14,6 +14,15 @@ this platform adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Changed
+
+- **`doc-flow` — bundled-path resolution guidance.** Added a "Reading bundled
+  files" note clarifying that `${CLAUDE_PLUGIN_ROOT}` is an environment variable
+  (it does not auto-expand in skill prose) and how to resolve a
+  `${CLAUDE_PLUGIN_ROOT}/framework/…` reference — read it via the shell (where the
+  variable expands) or relative to the plugin root. Proactively de-risks the P2
+  live-run / install smoke test (plan risk R2).
+
 ## [0.4.0] — 2026-05-27
 
 ### Changed

--- a/platforms/claude-code-plugin/skills/doc-flow/SKILL.md
+++ b/platforms/claude-code-plugin/skills/doc-flow/SKILL.md
@@ -196,6 +196,23 @@ next-step recommendations (never suggest authoring it, and don't count it
 against completion). Ignore unknown / out-of-surface keys; absent a profile, use
 the full 8-layer flow. Authority: `${CLAUDE_PLUGIN_ROOT}/framework/governance/ADAPTATION.md`.
 
+## Reading bundled files
+
+Skills reference the plugin's vendored spec as `${CLAUDE_PLUGIN_ROOT}/framework/…`.
+`CLAUDE_PLUGIN_ROOT` is an **environment variable** Claude Code sets to the
+plugin's install directory — it is **not** a literal folder named
+`${CLAUDE_PLUGIN_ROOT}`, and it does not auto-expand inside this prose. To open a
+bundled file, resolve it first:
+
+- In a shell the variable expands, so read it directly, e.g.
+  `cat "$CLAUDE_PLUGIN_ROOT/framework/registry/LAYER_REGISTRY.yaml"`; or run
+  `echo "$CLAUDE_PLUGIN_ROOT"` to get the path and then read it.
+- If the variable is unset in the current context, the `framework/` bundle ships
+  at the plugin root **beside `skills/`** — locate the plugin install directory
+  and read `framework/…` relative to it.
+
+Never try to open the path with the literal `${CLAUDE_PLUGIN_ROOT}` text in it.
+
 ## Related Resources
 
 - Spec guide: `${CLAUDE_PLUGIN_ROOT}/framework/SPEC_DRIVEN_DEVELOPMENT_GUIDE.md`


### PR DESCRIPTION
## Summary

Proactively de-risks the P2 live-run / install smoke test (plan risk **R2**) by adding bundled-path resolution guidance to the plugin.

`claude-code-guide` confirmed that `${CLAUDE_PLUGIN_ROOT}` auto-expands only in hook / MCP / LSP / monitor **config `command` fields**, **not** in skill or agent body prose. So when a skill says "read `${CLAUDE_PLUGIN_ROOT}/framework/layers/01_BRD/BRD-TEMPLATE.yaml`", a running model sees the literal string and must resolve it itself. P1 already made the plugin self-contained (the bundle ships at that anchor); this closes the remaining "will the model actually open it?" risk.

### Changes
- **`doc-flow`** (orchestrator / documented entry point) gains a **"Reading bundled files"** note: `CLAUDE_PLUGIN_ROOT` is an environment variable (not a literal folder, doesn't expand in prose); resolve it via the shell (`cat "$CLAUDE_PLUGIN_ROOT/framework/…"` — it expands in Bash) or `echo` it; fallback — the `framework/` bundle ships at the plugin root beside `skills/`, so resolve relative to the install; never open the literal-text path.
- Plan **R2** + the **P2 runbook** updated; recorded under plugin CHANGELOG `[Unreleased]`.

### Scoping (deliberate)
The note lives in `doc-flow` only — **not** broadcast across all ~50 skills. If the P2 live run shows a *directly-invoked* layer skill still can't resolve the path, the follow-up is to broadcast the note to the per-layer skills or move it to a hook. Deferred to avoid ~50 speculative edits before the run confirms it's needed.

No version bump (batches with the next release).

## Test plan

- [x] Conformance suite green — 66 tests
- [x] markdownlint clean on the edited skill + docs (`pre-commit`)
- [ ] **(User, CLI — the actual R2 confirmation):** live skill run against `examples/url-shortener/seed/` + `/plugin install` smoke test — verify the model reads the bundled `framework/` files

https://claude.ai/code/session_013duDkfbMr9Xhe15movDVxf

---
_Generated by [Claude Code](https://claude.ai/code/session_013duDkfbMr9Xhe15movDVxf)_