### PR TITLE
chore: port claude-code-plugin skills + legacy project-mngt

### DIFF
--- a/legacy/claude-code-plugin/project-mngt/SKILL.md
+++ b/legacy/claude-code-plugin/project-mngt/SKILL.md
@@ -1,0 +1,984 @@
+---
+title: "project-mngt: Product Owner / Project Manager skill for MVP/MMP/MMR implementation planning"
+name: project-mngt
+description: Product Owner / Project Manager skill for MVP/MMP/MMR implementation planning
+tags:
+  - sdd-workflow
+  - shared-architecture
+custom_fields:
+  layer: null
+  artifact_type: null
+  architecture_approaches: [ai-agent-based, traditional-8layer]
+  priority: shared
+  development_status: legacy
+  skill_category: utility
+  upstream_artifacts: [BRD, PRD, EARS]
+  downstream_artifacts: [IPLAN, Code]
+---
+
+# project-mngt
+
+**Project Implementation Planning with MVP/MMP/MMR Methodology**
+
+## Purpose
+
+This skill teaches AI assistants how to analyze any project's requirements and create implementation plans using the MVP/MMP/MMR (Minimum Viable Product / Minimum Marketable Product / Minimum Marketable Release) methodology.
+
+**This is a METHODOLOGY skill that teaches HOW to plan, not WHAT to plan.**
+
+### Use Cases
+
+1. **Initial Project Planning**: Analyze requirements and create structured implementation plan
+2. **Plan Updates**: Modify existing plans when requirements change while preserving completed work
+3. **Progress Tracking**: Update plans with current status and adjust remaining work
+4. **Release Strategy**: Define logical stages and atomic groups for incremental delivery
+
+### Adaptability
+
+Works with:
+- Any number of requirement documents (5 or 500)
+- Different formats: BRD, PRD, User Stories, Epics, Features
+- Various domains: Trading systems, web apps, APIs, infrastructure, ML/AI
+- Changing requirements: Update plans without restarting completed work
+
+### ID Naming Standards
+
+**Reference**: `framework/governance/ID_NAMING_STANDARDS.md`
+
+**Common ID Formats**:
+- **Planning Documents**: `PLAN-NNN` (e.g., PLAN-01, PLAN-02)
+- **Requirements**: `REQ-NN` or `REQ-NN-YY` (e.g., REQ-01, REQ-01-01)
+- **Tasks**: `TASK-NNN` or `TASK-NNN-YY` (e.g., TASK-01, TASK-01-01)
+
+**Format Rules**:
+- Use TYPE-NN for primary documents (three digits with leading zeros)
+- Use TYPE-NN-YY for sub-items (two digits with leading zeros)
+- IDs are unique within their artifact type
+- Sequential numbering starts at 001
+
+---
+
+## MVP/MMP/MMR Framework
+
+### Definitions (2024-2025 Best Practices)
+
+#### MVP (Minimum Viable Product)
+**Purpose**: Learning vehicle to validate core hypothesis with early adopters
+**Focus**: Test riskiest assumptions, gather feedback, prove feasibility
+**Quality**: Can have bugs, imperfect UX, manual processes
+**Goal**: Answer "Can we build this?" and "Will users use it?"
+**Monetization**: Not required - learning, not earning
+**Timeline**: 4-12 weeks typical
+
+**MVP Success Criteria**:
+- Core functionality works end-to-end
+- Riskiest technical assumptions validated
+- User feedback collected
+- Product-market fit signals observed
+
+#### MMP (Minimum Marketable Product)
+**Purpose**: First release-ready product that delivers real customer value
+**Focus**: Market-ready quality, essential features, can be sold/deployed
+**Quality**: Polished UX, stable, production-ready, minimal bugs
+**Goal**: Answer "Will customers pay for this?" and "Can we support it at scale?"
+**Monetization**: Required - ready for paying customers
+**Timeline**: 8-20 weeks after MVP
+
+**MMP Success Criteria**:
+- All essential features complete
+- Production-quality code and UX
+- Security, performance, reliability validated
+- Support processes in place
+- Marketing/sales materials ready
+
+#### MMR (Minimum Marketable Release)
+**Purpose**: Incremental feature releases that enhance market appeal post-MMP
+**Focus**: Additional features, optimizations, integrations, scale improvements
+**Quality**: Same as MMP - production-ready, market-quality
+**Goal**: Answer "How do we grow adoption?" and "What drives retention?"
+**Monetization**: Drives expansion revenue, reduces churn, attracts new segments
+**Timeline**: 2-8 weeks per release (ongoing)
+
+**MMR Success Criteria**:
+- Adds measurable customer value
+- Maintains product quality standards
+- Fits within product roadmap vision
+- Data-driven prioritization
+
+### Progression Path
+
+```
+IDEA → MVP (validate) → MMP (launch) → MMR-1 → MMR-2 → MMR-n (grow)
+         ↓                ↓              ↓        ↓        ↓
+      Learn First     Earn First    Expand Value Stream
+```
+
+### Quality Gates
+
+| Stage | Testing | Documentation | UX | Performance | Security |
+|-------|---------|---------------|-----|-------------|----------|
+| MVP | Manual OK | Minimal | Basic | Good enough | Basic |
+| MMP | Automated | Complete | Polished | Production SLA | Full audit |
+| MMR | Automated | Updated | Polished | Production SLA | Continuous |
+
+
+---
+
+## Analysis Methodology
+
+Follow these 6 steps to create any implementation plan:
+
+### Step 1: Requirements Discovery
+
+**Objective**: Catalog all requirements and understand project scope
+
+**Process**:
+1. Read all requirement documents (BRD, PRD, user stories)
+2. Extract for each requirement:
+   - ID, Description, Complexity (1-5), Priority hints, Dependencies, Functional area
+3. Create requirement inventory table
+
+**Output**: Complete catalog of all requirements
+
+### Step 2: Dependency Mapping
+
+**Objective**: Identify relationships and sequencing constraints
+
+**Dependency Types**:
+- Technical: Requires infrastructure/library/component
+- Business: Prerequisite functionality for workflow
+- Data: Requires schema/migration/data source
+- Integration: Depends on external system/API
+
+**Process**:
+1. For each requirement, identify dependencies
+2. Classify as blocking or non-blocking
+3. Create dependency graph
+4. Identify critical path
+
+**Output**: Dependency map showing blocking relationships
+
+### Step 3: Atomic Grouping Principles
+
+**Objective**: Create independently deployable, testable groups
+
+**Atomic Group Characteristics**:
+- Cohesive: Related functionality together
+- Independent: Can be developed/tested/deployed separately
+- Testable: Clear acceptance criteria
+- Valuable: Delivers observable outcome
+- Sized Right: 1-4 weeks of work
+
+**Grouping Techniques**:
+1. Functional Cohesion: Group by feature area
+2. Technical Layer: Group by architectural component
+3. User Journey: Group by end-to-end workflow
+4. Dependency Cluster: Group tightly coupled requirements
+
+**Naming Convention**: "[Component] [Action]" (e.g., "Broker Integration", "Risk Validation Framework")
+
+**Output**: List of atomic groups with clear boundaries
+
+### Step 4: Stage Assignment (MVP/MMP/MMR)
+
+**Decision Framework**:
+
+MVP Assignment Criteria (must meet at least 2):
+- Validates core technical feasibility
+- Required for end-to-end workflow
+- Tests riskiest assumption
+- Generates critical user feedback
+- No viable workaround exists
+
+MMP Assignment Criteria:
+- Essential for first customer/user
+- Required for production deployment
+- Regulatory/compliance necessity
+- Security/reliability/data integrity critical
+- Competitive table stakes feature
+
+MMR Assignment Criteria:
+- Enhances existing functionality
+- Expands market reach or use cases
+- Optimization or performance improvement
+- Integration with optional systems
+- Nice-to-have that drives adoption/retention
+
+**Output**: Each atomic group assigned to MVP, MMP, MMR-1, MMR-2, etc.
+
+### Step 5: Priority Numbering
+
+**Priority Numbering System**:
+- Sequential priorities (1, 2, 3...): Must complete in order
+- Parallel priorities (same number): Can execute simultaneously
+
+**Prioritization Rules**:
+1. Dependency-Driven: Higher priority = fewer dependencies
+2. Risk-First: Address high-risk/uncertainty early
+3. Value-Weighed: Balance technical dependencies with business value
+4. Resource-Aware: Consider team size and skill distribution
+
+**Parallelization Check**:
+- No technical dependencies?
+- Different code areas?
+- Separate team members available?
+- No shared infrastructure bottleneck?
+- Integration points clearly defined?
+
+If all yes → Assign same priority number
+
+**Output**: Priority-numbered atomic groups
+
+### Step 6: Timeline Estimation
+
+**Complexity-Based Estimation**:
+- Complexity 1: 0.5-1 week
+- Complexity 2: 1-2 weeks
+- Complexity 3: 2-3 weeks
+- Complexity 4: 3-4 weeks
+- Complexity 5: 4-6 weeks
+
+**Buffer Management**:
+- Stage level: +15% buffer
+- Project level: +25% buffer
+
+**Timeline Formula**:
+```
+Total Time = Σ(Group Duration) / Parallel Tracks + Stage Buffers
+```
+
+**Output**: Gantt chart with start/end dates and milestones
+
+---
+
+## Progress Tracking & Status Management
+
+### Implementation Status Categories
+
+| Status | Symbol | Meaning | Mutability |
+|--------|--------|---------|------------|
+| COMPLETED | ✅ | Fully implemented, tested, deployed | IMMUTABLE |
+| IN_PROGRESS | 🚧 | Currently being worked on | Assess impact |
+| BLOCKED | ⏸️ | Cannot proceed due to dependency/issue | Requires resolution |
+| PLANNED | 📅 | Not yet started, future work | FREELY MODIFIABLE |
+| MODIFIED | 🔄 | Changed from original plan | Document changes |
+| CANCELLED | ❌ | Removed from scope | Justify removal |
+
+### Status Tracking Requirements
+
+1. Every atomic group MUST have a status
+2. **Completed work is IMMUTABLE** - never modify in plan updates
+3. In-progress work requires careful impact assessment
+4. Only planned work can be freely rearranged
+5. All status changes MUST be documented in change log
+
+
+---
+
+## Change Management Protocol
+
+### Scenario A: New Project (Initial Plan Creation)
+
+**When to Use**: Starting new project, no prior plan
+
+**Inputs**:
+- Complete set of requirement documents
+- Project context (domain, team size, constraints)
+- Timeline constraints (if any)
+
+**Process**:
+1. Execute Steps 1-6 (Requirements Discovery through Timeline Estimation)
+2. All atomic groups marked as PLANNED
+3. Timeline starts from project kickoff (Week 1)
+
+**Output**: `PLAN-XXX_[project_name].md` version 1.0
+
+---
+
+### Scenario B: BRD Changes with Existing Plan (MOST CRITICAL)
+
+**When to Use**: Requirements changed AND project underway
+
+**Inputs**:
+- Modified/new requirement documents
+- Existing implementation plan
+- **Current progress status** (which groups are complete/in-progress)
+- Current date (timeline restart point)
+
+**Process** (CRITICAL - Follow Exactly):
+
+**Phase 1: Preserve Completed Work (IMMUTABLE)**
+1. Identify all groups with status COMPLETED
+2. Mark as LOCKED - do NOT modify
+3. **Rule**: Never delete, rename, or change scope of completed work
+
+**Phase 2: Assess In-Progress Work**
+1. Identify groups with status IN_PROGRESS
+2. Assess: Does BRD change affect scope? Should work continue?
+3. Document assessment
+4. Decision: Continue as-is / Adjust scope / Cancel
+
+**Phase 3: Analyze BRD Changes**
+1. Identify added/modified/removed requirements
+2. Map changes to atomic groups
+3. Determine affected groups and new groups needed
+
+**Phase 4: Replan PLANNED Work Only**
+1. Only modify groups with status PLANNED
+2. Options: Regroup, Reprioritize, Add new, Cancel, Modify scope
+3. Re-run dependency analysis
+4. Re-run stage assignment
+
+**Phase 5: Update Timeline**
+1. **Start from current date**, NOT project start
+2. Calculate remaining work
+3. Re-estimate remaining groups
+4. Update end date projection
+5. Calculate timeline variance
+
+**Phase 6: Document Changes**
+1. Create detailed change log
+2. Document BRD changes and rationale
+3. List all affected groups
+4. Explain timeline impact
+5. Update progress summary
+
+**Output**: Updated `PLAN-XXX_[project_name].md` (version incremented)
+
+**CRITICAL RULES**:
+- ✅ PRESERVE all completed work
+- ✅ ASSESS impact on in-progress work
+- ✅ ONLY modify planned work
+- ✅ START timeline from TODAY
+- ✅ DOCUMENT all changes
+- ❌ NEVER modify completed groups
+- ❌ NEVER restart timeline from Week 1
+
+---
+
+### Scenario C: Progress Update (No BRD Changes)
+
+**When to Use**: Update plan with progress, requirements unchanged
+
+**Inputs**:
+- Existing plan
+- Progress update (status changes)
+- Current date
+
+**Process**:
+1. Update status of groups
+2. Mark completed groups with dates
+3. Update progress metrics
+4. Adjust timeline if pace differs
+5. Identify blocked items
+
+**Output**: Refreshed `PLAN-XXX_[project_name].md`
+
+
+---
+
+## Execution Templates
+
+### Template: Implementation Plan Document Structure
+
+```markdown
+# Implementation Plan: [Project Name]
+
+## Document Control
+
+| Item | Details |
+|------|---------|
+| **Project Name** | [Name] |
+| **Plan ID** | PLAN-01 |
+| **Version** | X.0 |
+| **Date** | YYYY-MM-DD |
+| **Status** | [Active / Completed / On Hold] |
+| **Owner** | [Name] |
+| **Preparer** | [Name] |
+
+### Document Revision History
+
+| Version | Date | Author | Changes Made | Approver |
+|---------|------|--------|--------------|----------|
+| 1.0 | YYYY-MM-DD | [Name] | Initial plan creation | |
+| | | | | |
+
+---
+
+## Executive Summary
+
+**Project Goal**: [One-sentence description]
+**Implementation Approach**: MVP → MMP → MMR staged releases
+**Current Status**: [X% complete, Y of Z groups done]
+**Timeline**: Start: YYYY-MM-DD, Projected End: YYYY-MM-DD, Duration: X weeks
+
+**Key Milestones**:
+- MVP: [Date] - [Status]
+- MMP: [Date] - [Status]
+- MMR-1: [Date] - [Status]
+
+---
+
+## Implementation Progress Summary
+*(Include in updated plans)*
+
+**Overall Status**: X% Complete (Y of Z groups completed)
+
+**Completed Stages**:
+- MVP (Completed: YYYY-MM-DD, Duration: X weeks)
+
+**Current Stage**: MMP Phase 2 (Week 3 of 4)
+
+**Completed Groups**: [List with dates]
+**In Progress**: [List with status]
+**Planned**: [List with start dates]
+**Blocked**: [List with issues]
+**Modified**: [List with reasons]
+**Cancelled**: [List with justification]
+
+**Timeline Adjustment**:
+- Original End: YYYY-MM-DD
+- Current Projected: YYYY-MM-DD
+- Variance: +/- X weeks
+- Reason: [Explain]
+
+---
+
+## Stage 1: MVP (Minimum Viable Product)
+
+**Goal**: [What this stage validates]
+**Status**: [NOT_STARTED / IN_PROGRESS / COMPLETED]
+**Duration**: [Original X weeks] | Actual: [If complete]
+
+**Success Criteria**:
+- [ ] [Criterion 1]
+- [ ] [Criterion 2]
+
+**Exit Criteria**:
+- [ ] Core functionality works end-to-end
+- [ ] Riskiest assumptions validated
+
+### Atomic Groups
+
+#### Priority 1: [Group Name]
+**Status**: [COMPLETED / IN_PROGRESS / BLOCKED / PLANNED / MODIFIED / CANCELLED]
+
+**Requirements**:
+- REQ-01: [Description]
+- REQ-02: [Description]
+
+**Dependencies**:
+- [Dependency 1] (Status: Satisfied / Pending)
+
+**Deliverable**: [Clear, testable output]
+
+**Success Criteria**:
+- [ ] [Criterion]
+
+**Duration**: X weeks
+**Completion Date**: [If COMPLETED]
+**Notes**: [If MODIFIED/BLOCKED/CANCELLED]
+
+---
+
+## Timeline Visualization
+
+```mermaid
+gantt
+    title Implementation Timeline
+    dateFormat YYYY-MM-DD
+    section MVP
+    Group 1 (✅)  :done, mvp1, 2024-01-01, 2w
+    Group 2 (🚧)  :active, mvp2, 2024-01-15, 2w
+    Group 3 (📅)  :mvp3, 2024-01-29, 1w
+```
+
+---
+
+## Change Log
+*(Required in updated plans)*
+
+### Version 2.0 - YYYY-MM-DD
+
+**Reason for Update**: [BRD changes / Progress update]
+
+**BRD Changes**:
+- BRD-004: Added 5 new requirements (REQ-041 to REQ-045)
+
+**Impact Analysis**:
+- Completed Work: Preserved as-is
+- In-Progress Work: [Assessment]
+- Planned Work: [Modifications]
+
+**Specific Changes**:
+1. Group X: MODIFIED - Added REQ-041, REQ-042
+2. Group Y: NEW - Created for REQ-043, REQ-044, REQ-045
+3. Group Z: CANCELLED - Requirement removed
+
+**Timeline Impact**: +2 weeks due to new Group Y
+
+---
+
+## Traceability Matrix
+
+| Atomic Group | Requirements | ADRs | BDD Scenarios | Status |
+|--------------|--------------|------|---------------|--------|
+| MVP Group 1 | REQ-01, REQ-02 | ADR-006 | broker.feature | ✅ |
+| MMP Group 5 | REQ-041, REQ-042 | ADR-008 | risk.feature | 🚧 |
+```
+
+
+---
+
+## AI Assistant Usage Instructions
+
+### How to Invoke This Skill
+
+#### Scenario 1: Create Initial Implementation Plan
+
+**Command Pattern**:
+```
+"Use the project-mgnt skill to create an implementation plan for [project name].
+
+Inputs:
+- Requirement documents: [list file paths]
+- Project context: [domain, team size, constraints]
+- Timeline constraint: [if any]
+
+Create PLAN-XXX_[project_name].md following MVP/MMP/MMR methodology."
+```
+
+**Example**:
+```
+"Use the project-mgnt skill to create an implementation plan for inventory system.
+
+Inputs:
+- Requirements: {project_root}/docs/BRD/BRD-*.md (11 files)
+- Context: E-commerce domain, 5 FTE team, staging deployment first
+- Constraint: MVP in <3 months
+
+Create PLAN-01_inventory_system.md in docs/08_IPLAN/"
+```
+
+---
+
+#### Scenario 2: Update Existing Plan (Requirements Changed)
+
+**Command Pattern**:
+```
+"Use the project-mgnt skill to update the implementation plan at [path].
+
+Inputs:
+- Modified BRDs: [list changed files]
+- Existing plan: [path]
+- Current progress: [which groups complete/in-progress]
+- Current date: [today]
+
+IMPORTANT: Preserve completed work, only modify planned work."
+```
+
+**Example**:
+```
+"Use the project-mgnt skill to update PLAN-01_inventory_system.md.
+
+Inputs:
+- Modified: BRD-004 added 5 new security requirements
+- Plan: docs/08_IPLAN/PLAN-01_inventory_system.md v1.0
+- Progress: MVP complete (Groups 1-4), Group 5 in progress (week 2/4)
+- Date: 2024-02-01
+
+Create v2.0 with change log."
+```
+
+---
+
+### Expected Outputs
+
+Every invocation MUST produce:
+
+1. **Implementation Plan Document**
+   - Filename: `PLAN-XXX_[project_name].md`
+   - Location: User-specified or docs/08_IPLAN/
+   - Format: Markdown following template
+   - Versioning: v1.0, v2.0, v3.0...
+
+2. **Required Sections**
+   - Document Control section with project metadata and revision history
+   - Executive Summary
+   - Progress Summary (if update)
+   - Stage breakdown (MVP, MMP, MMR)
+   - Atomic groups with priorities, status, dependencies
+   - Timeline visualization (Gantt chart)
+   - Success metrics and exit criteria
+   - Change log (if update)
+   - Traceability matrix
+
+3. **Change Log** (updates only)
+   - BRD changes documented
+   - Impact analysis
+   - Specific group changes
+   - Timeline impact
+
+---
+
+## Decision Frameworks
+
+### Framework 1: MVP Scope Decisions
+
+**Question**: Should this feature be in MVP?
+
+**Key Questions**:
+1. Does it test the core hypothesis?
+2. Can we validate without it?
+3. Is there a simpler alternative for MVP?
+4. Does it validate high-risk assumption?
+5. Is there a viable workaround?
+
+**MVP Inclusion Criteria** (meet at least 2):
+- [ ] Validates core technical feasibility
+- [ ] Required for end-to-end workflow
+- [ ] Tests riskiest assumption
+- [ ] Generates critical user feedback
+- [ ] No viable workaround exists
+
+---
+
+### Framework 2: Parallel vs Sequential
+
+**Decision Checklist**:
+
+```
+Group A + Group B can be parallel if:
+- [ ] No code dependencies
+- [ ] Different files/modules
+- [ ] No shared database schema changes
+- [ ] No shared infrastructure
+- [ ] Separate team members available
+- [ ] No specialized skill bottleneck
+- [ ] Integration points clearly defined
+- [ ] Low rework risk
+
+If 8-10 checks = ✅ PARALLEL (same priority)
+If 5-7 checks = ⚠️ PARALLEL with caution
+If <5 checks = ❌ SEQUENTIAL
+```
+
+---
+
+### Framework 3: Stage Gate Criteria
+
+**MVP → MMP Gate**:
+
+Exit Criteria (must meet ALL):
+- [ ] Core functionality works end-to-end
+- [ ] Riskiest assumptions validated
+- [ ] User feedback collected
+- [ ] Critical bugs logged
+- [ ] Team consensus: hypothesis validated
+- [ ] Product Owner sign-off
+
+Proceed if:
+- ✅ Hypothesis confirmed
+- ✅ Technical feasibility proven
+- ✅ Team confident
+
+STOP if:
+- ❌ Hypothesis rejected
+- ❌ Technical infeasibility
+- ❌ Cost exceeds value
+
+---
+
+### Framework 4: Update Impact Assessment
+
+**Process**:
+
+**Step 1: Categorize Change**
+- Type: New / Modified / Removed / External dependency
+- Size: Small (<5 req) / Medium (5-15) / Large (>15)
+- Timing: Early (planned) / Mid (in-progress) / Late (completed)
+
+**Step 2: Map to Groups**
+- Completed groups: [Impact: None / Re-validation needed]
+- In-progress groups: [Impact: Continue / Adjust / Stop]
+- Planned groups: [Impact: Modify / Cancel / Reprioritize]
+
+**Step 3: Impact Level**
+- NONE: No action
+- LOW: <1 week, adjust in place
+- MEDIUM: 1-2 weeks, consider new group
+- HIGH: >2 weeks, create new group
+- CRITICAL: Invalidates group, cancel/redistribute
+
+**Step 4: Decision Matrix**
+- COMPLETED: No change (immutable) unless re-validation needed
+- IN_PROGRESS: Continue / Adjust / Stop and replan
+- PLANNED: Adjust / Modify / Cancel / Create new
+
+
+---
+
+## Adaptation Guidelines
+
+### For Different Project Types
+
+#### Infrastructure Projects
+- **MVP**: Single environment (dev) with core infrastructure, automation scripts
+- **MMP**: Production with full DR/HA, all IaC automated
+- **Grouping**: By layer (network, compute, storage, security)
+- **Critical Path**: IAM/Security → Network → Compute
+
+#### API Development
+- **MVP**: Core endpoints, happy-path only, simplified auth
+- **MMP**: All endpoints, full error handling, OAuth, rate limiting
+- **Grouping**: By resource/domain (Users API, Orders API)
+- **Parallel**: Independent resources can develop simultaneously
+
+#### ML/AI Systems
+- **MVP**: Single model, manual training, sample data
+- **MMP**: Automated pipeline, versioning, A/B testing, production serving
+- **Grouping**: By ML pipeline stage (data prep, training, serving)
+- **Critical Path**: Data quality → Model training → Serving
+
+#### Web Applications
+- **MVP**: Single-page prototype, core flow, desktop-only
+- **MMP**: Responsive, cross-browser, all flows, production hosting
+- **Grouping**: By user journey (registration, onboarding, core workflow)
+- **Parallel**: Frontend + Backend (clear API contract)
+
+---
+
+### For Changing Requirements
+
+#### New Features Added Mid-Project
+1. Is it MVP validation? → Add to MVP (rare)
+2. Essential for launch? → Add to MMP
+3. Incremental value? → Add to MMR
+4. Can wait? → Backlog
+
+**Process**: Create requirement IDs, assess dependencies, fit in existing or create new group, assign stage/priority, update timeline, document in change log.
+
+#### Features Removed/Descoped
+1. In COMPLETED group? → Note descoping (already built)
+2. In IN_PROGRESS? → Assess if should continue or stop
+3. In PLANNED? → Cancel group or reduce scope
+
+**Process**: Identify affected groups, remove requirements, cancel empty groups or adjust deliverables, update timeline, document rationale.
+
+#### Priority Changes (Urgent Feature)
+1. Verify dependencies allow earlier execution
+2. Reprioritize to earlier priority number
+3. Shift other groups later
+4. Assess resource impact
+5. Update timeline
+6. Communicate trade-offs in change log
+
+---
+
+### For Different Team Sizes
+
+#### Small Team (2-3 FTE)
+- Limited parallelization (max 2 tracks)
+- Focus on sequence over parallel
+- Longer MVP/MMP stages
+- Add 30-50% buffer for context switching
+
+#### Medium Team (4-8 FTE)
+- Good balance (2-3 parallel tracks)
+- Specialization possible
+- Maximize stage parallelization
+- Clear ownership
+
+#### Large Team (9+ FTE)
+- High parallelization (4+ tracks)
+- Specialized roles
+- Risk: Communication overhead, integration complexity
+- Strategy: Strict API contracts, daily syncs, strong PM
+
+
+---
+
+## Best Practices Compendium
+
+### Common Pitfalls and Solutions
+
+**Pitfall 1: MVP Scope Creep**
+- Problem: MVP grows with "nice-to-have" features
+- Solution: Ruthlessly apply MVP criteria, time-box MVP, create "MMP Backlog"
+
+**Pitfall 2: Ignoring Dependencies**
+- Problem: Parallelizing groups with hidden dependencies causes rework
+- Solution: Thorough dependency mapping, define APIs before parallel work, daily syncs
+
+**Pitfall 3: Modifying Completed Work**
+- Problem: Updates change completed groups, causing confusion
+- Solution: Mark completed as IMMUTABLE, create NEW groups for modifications
+
+**Pitfall 4: Underestimating MMP Polish**
+- Problem: Thinking MMP is "MVP + features" vs "production quality"
+- Solution: Budget 50-100% more time for MMP, use strict "Definition of Done"
+
+**Pitfall 5: No Clear Stage Gates**
+- Problem: Moving MVP → MMP without validating success
+- Solution: Explicit gate meetings, written exit criteria, PO sign-off required
+
+---
+
+### When to Deviate
+
+**Acceptable Deviations**:
+- Regulatory deadline: Compress stages, parallelize aggressively
+- Market window: Skip some MMR features, focus on differentiators
+- Technical debt crisis: Insert "Stabilization Sprint" between stages
+
+**Never Deviate**:
+- ❌ Skip MVP validation
+- ❌ Launch MMP with known high-severity bugs
+- ❌ Ignore completed work in updates
+- ❌ Parallelize hard dependencies
+
+---
+
+### Lessons Learned
+
+1. **MVP Always Takes Longer**: Add 25% buffer (50% for first-time team)
+2. **MMP Needs More Testing**: Budget 30% of MMP for testing/QA
+3. **Documentation Never "Done"**: Start in MVP, update continuously
+4. **Velocity Improves**: First groups slower (learning), later groups faster (momentum)
+
+---
+
+## Validation Checklist
+
+### For New Plans
+
+**Completeness**:
+- [ ] All requirements accounted for
+- [ ] Dependencies identified and documented
+- [ ] No circular dependencies
+
+**Atomic Groups**:
+- [ ] Groups independently testable
+- [ ] Groups cohesive (related functionality)
+- [ ] Size reasonable (1-4 weeks each)
+- [ ] Descriptive names
+
+**Stage Assignment**:
+- [ ] MVP scope minimal (validation only)
+- [ ] MMP includes launch essentials
+- [ ] MMR is incremental (not launch-critical)
+
+**Timeline**:
+- [ ] Estimates based on complexity
+- [ ] Buffers included at stage level
+- [ ] Timeline realistic for team size
+
+---
+
+### For Updated Plans (CRITICAL)
+
+**Immutability**:
+- [ ] **All completed work preserved unchanged**
+- [ ] Completion dates/deliverables unchanged
+- [ ] No deletions/scope changes to completed groups
+
+**Impact Assessment**:
+- [ ] In-progress work assessed
+- [ ] Only planned work modified
+- [ ] New requirements mapped to groups
+
+**Change Log**:
+- [ ] BRD changes documented
+- [ ] Impact analysis complete
+- [ ] Specific changes listed with reasons
+- [ ] Timeline impact calculated
+
+**Timeline Continuity**:
+- [ ] Timeline starts from current date
+- [ ] Remaining work calculated accurately
+- [ ] Variance explained
+
+**Progress Tracking**:
+- [ ] Progress summary accurate
+- [ ] Status categories correct
+- [ ] Completion percentage calculated
+
+---
+
+## Appendix
+
+### Complexity Rating Scale
+
+| Rating | Definition | Duration |
+|--------|------------|----------|
+| 1 | Trivial: Config change, minimal code | 0.5-1 week |
+| 2 | Simple: Single component, clear requirements | 1-2 weeks |
+| 3 | Moderate: Multiple components, some integration | 2-3 weeks |
+| 4 | Complex: Cross-system integration, unknowns | 3-4 weeks |
+| 5 | Very Complex: Architectural change, high uncertainty | 4-6 weeks |
+
+### Glossary
+
+**MVP**: Learning-focused first version to validate hypothesis. Functional but imperfect.
+
+**MMP**: Market-ready first release with essential features and production quality. Can be sold.
+
+**MMR**: Incremental feature releases after MMP. Production-quality, adds value.
+
+**Atomic Group**: Independently deployable set of related requirements. 1-4 weeks, cohesive, testable.
+
+**Critical Path**: Longest dependency chain determining minimum timeline.
+
+**Dependency**: Prerequisite relationship between requirements or groups.
+
+**Stage Gate**: Decision point between stages to validate completion.
+
+**Priority Number**: Sequencing indicator. Same number = parallel execution.
+
+**Status**: Current state (COMPLETED, IN_PROGRESS, BLOCKED, PLANNED, MODIFIED, CANCELLED).
+
+**Change Log**: Document section tracking all modifications from previous version.
+
+**Immutable**: Cannot be changed. Completed work is immutable in updates.
+
+---
+
+## Worked Example Reference
+
+See examples directory for complete worked examples:
+
+**Trading System v1.0**: Initial plan from 11 BRDs
+- 13 atomic groups across MVP/MMP/MMR
+- All groups PLANNED
+- Timeline: 27 weeks from start
+
+**Trading System v2.0**: Updated after BRD-004 changes
+- MVP completed (Groups 1-4)
+- Group 5 in progress
+- New requirements added
+- Timeline adjusted, change log included
+
+*(Full examples in `../project-mngt/examples/`)*
+
+---
+
+## Skill Version History
+
+**Version 1.0** (2025-01-03):
+- Initial release
+- Complete MVP/MMP/MMR framework
+- Change management protocols
+- Templates and decision frameworks
+- Validation checklists
+- Adaptation guidelines
+
+---
+
+## Support and Feedback
+
+For issues or enhancements:
+1. Document issue or suggestion
+2. Provide scenario where skill didn't work
+3. Suggest improvement with rationale
+
+This skill evolves based on real-world usage and feedback.

--- a/legacy/claude-code-plugin/project-mngt/examples/README.md
+++ b/legacy/claude-code-plugin/project-mngt/examples/README.md
@@ -1,0 +1,143 @@
+# Project Management Skill Examples
+
+This directory contains reference examples showing how to apply the project-mgnt skill to real projects.
+
+## Software Platform Example
+
+The software platform example demonstrates the complete MVP/MMP/MMR planning methodology applied to a multi-service software platform.
+
+### Context
+
+**Project**: Multi-service data processing platform
+**Requirements**: 11 BRD documents with 317 total requirements
+- BRD-000: Implementation Plan (metadata)
+- BRD-001: Foundation & Overview (15 FR, 8 QA)
+- BRD-002: Core Processing Logic (18 FR, 12 QA)
+- BRD-003: Data Analysis & Ingestion (20 FR, 10 QA)
+- BRD-004: Validation & Controls (26 FR, 15 QA)
+- BRD-005: Resource Management (23 FR, 12 QA)
+- BRD-007: Technical Infrastructure (26 FR, 10 QA)
+- BRD-008: Processing Pipelines (27 FR, 9 QA)
+- BRD-009: External Service Integration (26 FR, 25 QA) - **CRITICAL PREREQUISITE**
+- BRD-010: Foundational Monitoring (8 FR, 4 QA)
+- BRD-011: Comprehensive Observability (18 FR, 9 QA)
+
+**Team**: 5-6 FTE (2 backend, 1 frontend, 1 QA, 1 DevOps, 1 PM)
+**Constraints**: Must validate in staging before production deployment
+**Timeline**: Target 27 weeks total
+
+### Analysis Results
+
+**Atomic Groups Identified**: 13 groups across 3 stages
+
+**Stage Assignment**:
+- **MVP** (4 groups, 8 weeks): Staging environment validation
+  - Priority 1: External Service Integration (BRD-009) - 4 weeks
+  - Priority 2: Basic Monitoring (BRD-010 partial) - 1 week (parallel with P1)
+  - Priority 3: Core Processor (BRD-007 subset) - 2 weeks
+  - Priority 4: Simple State Machine (BRD-002 simplified) - 1 week
+
+- **MMP** (4 groups, 10 weeks): Single pipeline production
+  - Priority 5: Validation Framework (BRD-004) - 3 weeks
+  - Priority 6: ML Classification (BRD-003 partial) - 3 weeks (parallel with P5)
+  - Priority 7: Data Selection + Enforcement (BRD-003 + BRD-004) - 2 weeks
+  - Priority 8: Primary Pipeline (BRD-008 primary only) - 2 weeks
+
+- **MMR** (5 groups, 9 weeks): Multi-pipeline + advanced features
+  - MMR-1 (4 weeks): Additional Pipelines
+    - Priority 9: Secondary Pipelines (BRD-008) - 2 weeks
+    - Priority 10: Resource Management & Recovery (BRD-005) - 2 weeks
+  - MMR-2 (3 weeks): Advanced Observability
+    - Priority 11: Load Balancing (BRD-004 balancing) - 1 week
+    - Priority 12: Comprehensive Dashboards (BRD-011) - 2 weeks
+  - MMR-3 (2 weeks): Advanced Features
+    - Priority 13: Performance Optimization (BRD-005 optimization) - 2 weeks
+
+### Key Decisions
+
+**MVP Scope Rationale**:
+- Minimal: Only service connection, basic monitoring, core processing, simple workflow
+- Goal: Validate staging environment works end-to-end
+- Deferred: Validation enforcement, ML models, multiple pipelines (all MMP+)
+- Critical Path: BRD-009 (External Integration) blocks everything
+
+**MMP Scope Rationale**:
+- Validation-complete: Full validation and enforcement before production
+- Single pipeline: Primary pipeline only (most common, well-understood)
+- Production-ready: All quality gates, automated testing, monitoring
+
+**MMR Progression**:
+- MMR-1: Expand pipeline types for diversification
+- MMR-2: Enhanced observability for scale management
+- MMR-3: Optimization features for performance improvement
+
+**Parallelization Strategy**:
+- MVP: Groups 1-2 parallel (integration + monitoring, different subsystems)
+- MMP: Groups 5-6 parallel (validation + ML models, different teams)
+- MMR-1: Groups 9-10 parallel (independent pipelines)
+- MMR-2: Groups 11-12 parallel (balancing + dashboards, different focus)
+
+### Version History
+
+**Version 1.0** (Initial Plan):
+- Created from 11 BRD documents
+- 13 atomic groups defined
+- All groups marked PLANNED
+- Timeline: 27 weeks from project start
+- File: `platform_v1.md` (example placeholder)
+
+**Version 2.0** (Updated after BRD-004 changes):
+- Context: MVP completed (4 weeks), MMP Group 5 in progress
+- BRD Change: BRD-004 added 5 new validation requirements (REQ-041 to REQ-045)
+- Impact:
+  - Groups 1-4 (MVP): COMPLETED, preserved unchanged
+  - Group 5 (Validation): IN_PROGRESS, absorbed REQ-041, REQ-042
+  - Groups 6-8: PLANNED, unchanged
+  - NEW Group 14: Created in MMR-3 for REQ-043, REQ-044, REQ-045
+- Timeline Impact: +2 weeks for new Group 14
+- File: `platform_v2.md` (example placeholder)
+
+### Lessons from This Example
+
+1. **Critical Path Identification**: BRD-009 was correctly identified as blocking prerequisite
+2. **MVP Minimalism**: Resisted temptation to include validation enforcement in MVP
+3. **Stage-Appropriate Quality**: MVP focused on validation, MMP on production-readiness
+4. **Preserving Progress**: Version 2.0 kept MVP work immutable despite BRD changes
+5. **Flexible MMR**: New requirements fit into MMR-3 without disrupting MMP timeline
+
+### How to Use This Example
+
+1. **Study the analysis**: See how 11 BRDs were grouped into 13 atomic units
+2. **Understand the rationale**: Note why certain features went to MVP vs MMP vs MMR
+3. **Learn from parallelization**: Observe which groups could run simultaneously
+4. **Review the update process**: See how v2.0 preserved completed work
+5. **Adapt to your project**: Apply same methodology to your requirements
+
+### Creating Your Own Plan
+
+To create a plan for your project:
+
+```
+"Use the project-mgnt skill to create an implementation plan for [your project].
+
+Inputs:
+- Requirement documents: [your BRD/PRD files]
+- Project context: [your domain, team size, constraints]
+- Timeline constraint: [if any]
+
+Create PLAN-XXX_[your_project_name].md"
+```
+
+The skill will analyze your requirements and create a customized plan following the same methodology demonstrated in this software platform example.
+
+---
+
+## Other Examples (Future)
+
+This directory can be expanded with examples from other domains:
+- Web application (e-commerce site)
+- API service (REST API development)
+- Infrastructure project (cloud migration)
+- ML/AI system (recommendation engine)
+
+Each example would demonstrate domain-specific adaptations of the core methodology.

--- a/platforms/claude-code-plugin/skills/context-analyzer/SKILL.md
+++ b/platforms/claude-code-plugin/skills/context-analyzer/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: context-analyzer
+description: Scan a project's SDD artifacts and build a context model (inventory, traceability graph, workflow position, upstream candidates) to inform new document creation. Use before authoring an artifact in an existing project.
+metadata:
+  tags:
+    - sdd-workflow
+    - utility
+  custom_fields:
+    skill_category: utility
+    version: "0.2.0"
+    framework_spec_version: "0.7.0"
+    last_updated: "2026-05-23"
+---
+
+# context-analyzer
+
+## Purpose
+
+Scan a project's documentation and assemble a context model so a new artifact is
+authored with full awareness of what already exists. It surfaces the artifact
+inventory, parsed metadata, the traceability graph, current workflow position,
+and the most relevant upstream documents — preventing missing references and
+duplicate content.
+
+## When to Use
+
+Use `context-analyzer` when:
+
+- Starting documentation work in an existing project.
+- About to create an artifact that needs upstream references.
+- You need to understand what documentation exists or where the gaps are.
+- Preparing context for a `doc-*` skill invocation.
+
+Do **not** use it on a project with no existing documentation, for a single
+isolated document, or for deep traceability validation (use
+`../trace-check/SKILL.md`).
+
+## Behavior
+
+Given a `project_root` (and optionally a `target_artifact_type` and a scan
+`depth` of quick / standard / deep), the skill:
+
+1. **Scans structure** — enumerates artifacts under `docs/<NN>_<X>/` (01_BRD …
+   08_IPLAN) by type, ID, path, title, and status.
+2. **Parses metadata** — extracts frontmatter and Document Control (status,
+   version, last-updated, tags) per artifact.
+3. **Extracts traceability** — reads each artifact's Traceability section into a
+   bidirectional upstream/downstream graph.
+4. **Determines workflow position** — maps artifacts to layers 1–8, identifies
+   completed / current / next-required layers, and reports coverage gaps using
+   the cumulative upstream rules (BRD→…→IPLAN).
+5. **Identifies upstream candidates** — for a target type, ranks relevant
+   upstream documents by directness, topic match, recency, and status.
+6. **Extracts key terms** — builds project vocabulary from titles, headers, and
+   glossaries.
+7. **Returns the context model** — inventory counts, workflow position with
+   gaps, ranked upstream candidates, key terms, and coverage gaps.
+
+The model is consumed by `../skill-recommender/SKILL.md`,
+`../workflow-optimizer/SKILL.md`, `../quality-advisor/SKILL.md`, and the
+`doc-*` authoring skills. For deep traceability validation it defers to
+`../trace-check/SKILL.md`.
+
+## Related Resources
+
+- Layer registry (layers, `can_reference`):
+  `framework/registry/LAYER_REGISTRY.yaml`
+- Traceability: `framework/governance/TRACEABILITY.md`
+- ID & tag standards: `framework/governance/ID_NAMING_STANDARDS.md`
+- Layer READMEs: `framework/layers/02_PRD/README.md` ·
+  `framework/layers/05_ADR/README.md`
+- Related skills: `../skill-recommender/SKILL.md` ·
+  `../workflow-optimizer/SKILL.md` · `../quality-advisor/SKILL.md` ·
+  `../trace-check/SKILL.md`

--- a/platforms/claude-code-plugin/skills/doc-review/SKILL.md
+++ b/platforms/claude-code-plugin/skills/doc-review/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: doc-review
+description: Cross-cutting quality review of a single file or a whole folder - finds data inconsistencies, broken references, typos, and unclear terminology. Use before publishing or committing documentation.
+metadata:
+  tags:
+    - sdd-workflow
+    - utility
+    - quality-assurance
+  custom_fields:
+    skill_category: utility
+    upstream_artifacts: []
+    downstream_artifacts: []
+    version: "0.2.0"
+    framework_spec_version: "0.7.0"
+    last_updated: "2026-05-23"
+---
+
+# doc-review
+
+## Purpose
+
+A cross-cutting documentation quality reviewer. `doc-review` analyzes one file
+or an entire folder for four classes of issue — **data inconsistencies**,
+**reference errors**, **typos/formatting**, and **terminology** — and reports
+findings by severity. It is content/quality focused; it does not enforce SDD
+structure or traceability.
+
+**Layer**: cross-cutting utility (produces no artifacts).
+
+## When to Use
+
+**Use** to review documentation before publication or commit, after a batch of
+generation, or to audit a folder for cross-file consistency.
+
+**Do NOT use** for:
+
+- bidirectional traceability — use `../trace-check/SKILL.md`;
+- cross-document SDD validation (links, tags, IDs) — use
+  `../doc-validator/SKILL.md`;
+- single-document structural quality gates — use that layer's
+  `../doc-<layer>-audit/SKILL.md`.
+
+## Behavior
+
+### Modes
+
+| Mode | Input | Behavior |
+|------|-------|----------|
+| Single file | a file path | Deep analysis of one file |
+| Folder | a directory path | Analyzes all files together, adding cross-file checks (terminology consistency, cross-document references, duplicate content) |
+
+Optional inputs: `scope` (`quick` / `full` / `deep`), `focus`
+(`data,references,typos,terms`), `report_format` (`markdown` / `json` /
+`summary`).
+
+### Review dimensions (four parallel sub-agents)
+
+The skill discovers the target files, then runs four reviewers in parallel and
+merges their findings:
+
+1. **Data consistency** — count mismatches (stated vs actual), status/maturity
+   mismatches, date logic (`last_updated >= created`), version format,
+   duplicate content. Codes `DATA-*`.
+2. **References** — markdown link and anchor resolution, relative-path
+   correctness, traceability-tag format (`@brd:`/`@prd:`/`@ears:`/`@bdd:`/
+   `@adr:`/`@spec:`/`@tdd:`/`@iplan:`), circular references. Codes `REF-*`.
+3. **Typos / formatting** — misspellings, doubled words, markdown syntax
+   (unclosed blocks, broken tables), punctuation and whitespace. Codes `TYPO-*`.
+4. **Terminology** — undefined acronyms, inconsistent naming, ambiguous
+   pronouns, subjective qualifiers ("fast", "simple"), conflicting
+   definitions. Codes `TERM-*`.
+
+### Severity and gates
+
+Findings are `ERROR` (must fix), `WARNING` (should fix), or `INFO`. Default
+gate: **0 errors**; warnings allowed by scope (`quick` ≤10, `full` ≤5,
+`deep` 0). Auto-fix (opt-in) is limited to simple, safe patterns — date/count
+normalization, relative-path fixes, tag-format fixes, doubled words,
+punctuation/whitespace. Everything else is reported for manual review.
+
+A project may add a custom dictionary and severity overrides (e.g. a
+`.doc-review.yaml`) to suppress domain-term false positives.
+
+## Related Resources
+
+- Cross-document validation: `../doc-validator/SKILL.md`
+- Traceability: `../trace-check/SKILL.md`
+- Naming authority (tag/ID formats): `../doc-naming/SKILL.md`
+- Quality advice: `../quality-advisor/SKILL.md`
+- Workflow routing: `../doc-flow/SKILL.md`
+- Governance: `framework/governance/DOC_GOVERNANCE_CORE.md`
+- Diagrams: `../charts-flow/SKILL.md`

--- a/platforms/claude-code-plugin/skills/skill-recommender/SKILL.md
+++ b/platforms/claude-code-plugin/skills/skill-recommender/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: skill-recommender
+description: Suggest the right aidoc-flow skill for a request by parsing user intent and matching it against the skill catalog with ranked, rationale-backed recommendations.
+metadata:
+  tags:
+    - sdd-workflow
+    - utility
+  custom_fields:
+    skill_category: utility
+    upstream_artifacts: []
+    downstream_artifacts: []
+    version: "0.2.0"
+    framework_spec_version: "0.7.0"
+    last_updated: "2026-05-23"
+---
+
+# skill-recommender
+
+## Purpose
+
+Recommend the appropriate aidoc-flow skill(s) for a request so users don't have
+to know the full catalog. Parses intent, matches against the skill set, and
+returns ranked recommendations with confidence and rationale.
+
+**Layer**: cross-cutting utility (no artifacts produced or consumed).
+
+## When to Use
+
+**Use when**:
+
+- The user is unsure which skill fits their documentation task.
+- Starting a workflow and needing guidance on the next step.
+- Discovering which skills cover a given intent.
+
+**Do NOT use when**:
+
+- The user names a specific skill (run it directly).
+- The task is non-documentation work.
+
+For full workflow routing, defer to `../doc-flow/SKILL.md`.
+
+## Behavior
+
+### Step 1 — Parse intent
+
+Extract an action and a target from the request.
+
+| Action | Signal keywords |
+|--------|-----------------|
+| create | create, write, draft, new, add |
+| update | update, modify, edit, revise |
+| validate | validate, check, verify, audit, review |
+| analyze | analyze, examine, inspect |
+| plan | plan, roadmap, schedule, organize |
+
+| Target | Keywords | Maps to |
+|--------|----------|---------|
+| business requirements | business, brd, objectives | `doc-brd` |
+| product requirements | product, prd, features, user stories | `doc-prd` |
+| formal requirements | ears, when-the-shall | `doc-ears` |
+| test scenarios | bdd, gherkin, scenarios | `doc-bdd` |
+| architecture decisions | adr, decision | `doc-adr` |
+| technical specification | spec, interfaces, data models | `doc-spec` |
+| test definitions | tdd, test cases, thresholds | `doc-tdd` |
+| implementation plan | iplan, file manifest, execution | `doc-iplan` |
+| traceability | trace, links | `trace-check` |
+| cross-document validation | validate, consistency | `doc-validator` |
+| diagrams | diagram, chart, flow | `charts-flow` |
+| roadmap | roadmap, adr implementation | `adr-roadmap` |
+| naming / IDs | id, naming, format | `doc-naming` |
+| new project | initialize, scaffold, greenfield | `project-init` |
+| existing codebase | adopt, brownfield, existing code, reverse-engineer | `project-adopt` |
+| tailor the flow to a project | adapt, profile, house style, skip layer, stricter gate, glossary | `project-profile` |
+| promote a local adaptation | promote, extract, generalize, upstream, contribute back | `knowledge-extractor` |
+| change to a published artifact | change, chg, modify existing, change request | `doc-chg` |
+| approval gate | gate, approval, sign-off | `gate-check` |
+
+### Step 2 — Match against the catalog (54 skills)
+
+**Layer families** — each ships four variants: base, `-autopilot` (generate
+end-to-end), `-audit` (quality gate), `-fixer` (apply audit fixes):
+
+`doc-brd` · `doc-prd` · `doc-ears` · `doc-bdd` · `doc-adr` · `doc-spec` ·
+`doc-tdd` · `doc-iplan` (× {base, -autopilot, -audit, -fixer} = 32 skills).
+
+**Change-management family** — the CHG overlay for editing existing artifacts
+(a governance overlay, not a layer), with the same four variants:
+
+`doc-chg` (× {base, -autopilot, -audit, -fixer} = 4 skills).
+
+**Utilities (18)**:
+
+| Skill | Category | Role |
+|-------|----------|------|
+| `doc-flow` | core-workflow | Workflow orchestrator / routing |
+| `project-init` | core-workflow | Scaffold a new project (greenfield) |
+| `project-adopt` | utility | Adopt SDD into an existing codebase (brownfield) |
+| `project-profile` | utility | Create/maintain the project adaptation profile (`.aidoc/profile.yaml`) |
+| `knowledge-extractor` | utility | Draft a promotion proposal from profile + learnings |
+| `gate-check` | utility | Run CHG approval gates; prepare sign-off |
+| `doc-naming` | utility | ID & naming authority |
+| `doc-ref` | utility | Reference (REF) documents |
+| `doc-review` | utility | Cross-cutting quality review |
+| `doc-validator` | utility | Cross-document validation |
+| `trace-check` | utility | Bidirectional traceability |
+| `charts-flow` | utility | Mermaid diagrams |
+| `adr-roadmap` | utility | Roadmaps from ADRs |
+| `context-analyzer` | utility | Project context analysis |
+| `quality-advisor` | utility | Quality advice |
+| `skill-recommender` | utility | This skill |
+| `workflow-optimizer` | utility | Workflow optimization |
+| `security-audit` | utility | Security analysis |
+
+### Step 3 — Score and rank
+
+Weight intent match (40%), target match (30%), context fit (20%), and common
+sequences (10%). Classify confidence: **High** ≥80%, **Medium** 50–79%,
+**Low** <50% (suggest clarification).
+
+### Step 4 — Recommend
+
+Return up to 3 ranked entries, each with `skill`, `confidence`, `rationale`,
+and a `next_steps` or `condition`. When the intent is ambiguous, ask one
+clarifying question instead of guessing.
+
+```yaml
+recommendations:
+  - skill: doc-prd
+    confidence: 92%
+    rationale: "Request mentions 'product requirements' — direct PRD match."
+    next_steps: "Run doc-prd to create the PRD."
+  - skill: doc-brd
+    confidence: 55%
+    rationale: "A BRD may be needed upstream if none exists."
+    condition: "Use if no BRD covers this feature."
+clarification_needed: false
+```
+
+## Related Resources
+
+- Workflow routing: `../doc-flow/SKILL.md`
+- Project context input: `../context-analyzer/SKILL.md`
+- Workflow position awareness: `../workflow-optimizer/SKILL.md`
+- Layer registry: `framework/registry/LAYER_REGISTRY.yaml`

--- a/platforms/claude-code-plugin/skills/trace-check/SKILL.md
+++ b/platforms/claude-code-plugin/skills/trace-check/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: trace-check
+description: Validate bidirectional traceability across the 8-layer SDD flow - link resolution, ID format, cumulative tagging, coverage, and orphan detection - and optionally repair broken links. Use before committing or auditing SDD documentation.
+metadata:
+  tags:
+    - sdd-workflow
+    - utility
+    - quality-assurance
+  custom_fields:
+    skill_category: utility
+    upstream_artifacts: []
+    downstream_artifacts: []
+    version: "0.2.0"
+    framework_spec_version: "0.7.0"
+    last_updated: "2026-05-23"
+    adapts: [active_layers]
+---
+
+# trace-check
+
+## Purpose
+
+Validate traceability across all SDD artifacts (BRD → PRD → EARS → BDD → ADR →
+SPEC → TDD → IPLAN → Code) and report — or optionally repair — gaps. It checks
+bidirectional link symmetry, ID-format compliance, cumulative tagging, link and
+anchor resolution, coverage, and orphans. The framework ships no runtime code:
+**this skill IS the checker**, applying the declarative checks below against the
+governance spec.
+
+## When to Use
+
+Use `trace-check` when:
+
+- Before committing documentation changes, or after creating/updating artifacts.
+- Running a periodic audit (sprint/release) of traceability completeness.
+- Verifying ID-format or cumulative-tag compliance, or detecting orphans.
+
+Do **not** use it for code-implementation review, non-SDD documentation, or
+in-creation single-document feedback (use `../quality-advisor/SKILL.md`).
+
+## Behavior
+
+Given a `project_root` (default `{project_root}/docs/`) and optional
+`artifact_types`, `strictness_level` (permissive / strict (default) / pedantic),
+`auto_fix`, and `report_format` (markdown / json / text):
+
+1. **Discover artifacts** — scan `docs/<NN>_<X>/` (01_BRD … 08_IPLAN), parse
+   document IDs from filenames, build an ID → path inventory, flag duplicate IDs
+   and non-conformant `docs/<NN>_<X>/` structure.
+2. **Parse traceability** — read each artifact's Traceability section and the
+   `@brd:`…`@iplan:`/`@impl-status:` tags in docs and code into a bidirectional
+   upstream/downstream graph.
+3. **Validate ID format** — document refs `TYPE-NN`; element refs 4-segment
+   `TYPE.NN.SS.xxxx`; two-digit zero-padding; valid TYPE; no collisions. Reject
+   legacy 3-segment IDs and placeholders (TBD/XXX/NNN).
+4. **Validate cumulative tagging** — confirm each artifact carries exactly the
+   upstream tag families its layer requires (BRD 0 → … → IPLAN 7) per the
+   `can_reference` set in `framework/registry/LAYER_REGISTRY.yaml`; report gaps
+   and any downstream-tag leakage.
+5. **Resolve links** — confirm every markdown link path and `#anchor` resolves
+   (markdown H1, YAML `id:`, feature `Scenario:`).
+6. **Check bidirectional consistency** — for each A→B link verify B→A exists;
+   score `(matched pairs / total) × 100` (target ≥ 95%).
+7. **Compute coverage and orphans** — upstream is required for every artifact
+   except BRD; downstream is optional; flag mid-chain artifacts with no
+   downstream and unexpected orphans.
+8. **Report** — summary (pass/fail, coverage %, consistency %), broken links
+   with file:line, missing-traceability and bidirectional gaps, orphans,
+   coverage-by-type table, and prioritized fixes.
+
+**Auto-fix (`auto_fix: true`)**: create a timestamped backup first, then repair
+relative paths, add missing downstream references, and log changes to revision
+history; provide a rollback command. Never invent placeholder IDs.
+
+**Quality gates**: 100% link resolution and ID compliance, ≥ 95% bidirectional
+consistency, no orphaned mid-chain artifacts, Traceability section present on
+every artifact.
+
+## Adaptation
+
+Before checking references, read the project adaptation profile
+(`.aidoc/profile.yaml`). Honor `active_layers`: treat a disabled skippable
+layer as absent by design — do not report a missing reference to it (apply
+the cascade rule). Ignore any unknown or out-of-surface key.
+Authority: `framework/governance/ADAPTATION.md`.
+
+## Related Resources
+
+- Traceability & cumulative tagging: `framework/governance/TRACEABILITY.md`
+- ID & tag standards: `framework/governance/ID_NAMING_STANDARDS.md`
+- Layer registry (`can_reference`/`downstream`):
+  `framework/registry/LAYER_REGISTRY.yaml`
+- Governance core: `framework/governance/DOC_GOVERNANCE_CORE.md`
+- Related skills: `../doc-flow/SKILL.md` · `../adr-roadmap/SKILL.md` ·
+  `../quality-advisor/SKILL.md` · `../context-analyzer/SKILL.md`

--- a/platforms/claude-code-plugin/skills/trace-check/examples/example_validation_report.md
+++ b/platforms/claude-code-plugin/skills/trace-check/examples/example_validation_report.md
@@ -1,0 +1,177 @@
+# Traceability Validation Report - Example
+
+**Project**: [PROJECT_NAME]
+**Validation Date**: 2025-11-11 17:40:01 EST
+**Scope**: All artifacts (8 SPEC files)
+**Execution Time**: 4.2 seconds
+
+## Summary
+
+- ✅ **Overall Status**: PASS (with warnings)
+- 📊 **Coverage**: 88% (7/8 complete)
+- 🔗 **Consistency**: 75% (6/8 links bidirectional)
+- ⚠️ **Warnings**: 1 missing reverse link
+- ❌ **Errors**: 0 blocking issues
+
+## Broken Links (0 found)
+
+No broken links detected.
+
+## Missing Traceability (1 artifact)
+
+| Artifact | Issue | Severity | Recommendation |
+|----------|-------|----------|----------------|
+| SPEC-03 | No TDD reference in Section 7.2 | Info | Add TDD-NN when tests created |
+
+**Details**:
+
+- **File**: `{project_root}/docs/06_SPEC/SPEC-03_data_service.yaml`
+- **Line**: 45-52 (Section 7: Traceability)
+- **Issue**: Downstream section lists "To Be Created" but no specific TDD reference
+- **Impact**: Low (common for new specifications before test creation)
+
+## Bidirectional Inconsistencies (1 found)
+
+| Forward Link | Reverse Link | Status | Fix Command |
+|--------------|--------------|--------|-------------|
+| SPEC-01 → ADR-02 | ADR-02 → SPEC-01 | ❌ Missing | Add to ADR-02:463 |
+
+### Fix Details
+
+**Issue**: SPEC-01 references ADR-02 (line 56), but ADR-02 does not reference SPEC-01 back.
+
+**Current State** (ADR-02:462-467):
+
+```markdown
+## 7.2 Downstream Artifacts
+
+**To Be Created:**
+- SPEC-NN: Technical implementation specifications
+```
+
+**Recommended Fix** (ADR-02:462-470):
+
+```markdown
+## 7.2 Downstream Artifacts
+
+**In Progress:**
+- [SPEC-01](../06_SPEC/SPEC-01_connection_service.yaml#connection_service) - Connection Service (Status: Draft, Created: 2025-11-11)
+
+**To Be Created:**
+- SPEC-02+: Additional technical specifications (TBD)
+```
+
+**Auto-fix Command**:
+
+```bash
+/skill trace-check --auto-fix true --artifact-types SPEC
+```
+
+## ID Format Compliance (8/8 PASS)
+
+All SPEC artifacts follow correct ID naming conventions (document refs are
+`SPEC-NN`, two-digit, per `framework/governance/ID_NAMING_STANDARDS.md`):
+
+| Artifact | ID Format | H1 Header | Zero-Padding | Status |
+|----------|-----------|-----------|--------------|--------|
+| SPEC-01 | ✅ Valid | ✅ Present | ✅ 01 | PASS |
+| SPEC-02 | ✅ Valid | ✅ Present | ✅ 02 | PASS |
+| SPEC-03 | ✅ Valid | ✅ Present | ✅ 03 | PASS |
+| SPEC-04 | ✅ Valid | ✅ Present | ✅ 04 | PASS |
+| SPEC-05 | ✅ Valid | ✅ Present | ✅ 05 | PASS |
+| SPEC-06 | ✅ Valid | ✅ Present | ✅ 06 | PASS |
+| SPEC-07 | ✅ Valid | ✅ Present | ✅ 07 | PASS |
+| SPEC-08 | ✅ Valid | ✅ Present | ✅ 08 | PASS |
+
+## Link Resolution (24/24 PASS)
+
+All markdown links resolve to valid files with correct anchors. SPEC (Layer 6)
+upstream sources are BRD, PRD, EARS, BDD, and ADR — there is no SYS or REQ
+layer in the 8-layer model:
+
+| Source | Target | Type | Anchor | Status |
+|--------|--------|------|--------|--------|
+| SPEC-01 | BRD-01 | .md | #BRD-01 | ✅ |
+| SPEC-01 | EARS-02 | .md | #service_connection | ✅ |
+| SPEC-01 | EARS-01 | .md | #EARS-01 | ✅ |
+| SPEC-01 | ADR-02 | .md | #ADR-02 | ✅ |
+| SPEC-02 | BRD-01 | .md | #BRD-01 | ✅ |
+| SPEC-02 | EARS-03 | .md | #EARS-03 | ✅ |
+| ... | ... | ... | ... | ... |
+
+## Coverage Metrics
+
+| Type | Total | Complete | Coverage | Target | Status |
+|------|-------|----------|----------|--------|--------|
+| SPEC | 8     | 7        | 88%      | 100%   | ⚠️     |
+
+**Complete**: Artifacts with Section 7 containing upstream sources and downstream artifacts (or "To Be Created" note)
+
+**Incomplete**:
+
+- SPEC-03: Missing specific TDD reference (has generic "To Be Created")
+
+## Orphaned Artifacts (0 found)
+
+No orphaned artifacts detected. All SPEC files have:
+
+- ✅ At least one upstream source (BRD, PRD, EARS, BDD, or ADR)
+- ✅ At least one downstream artifact or "To Be Created" note
+
+## Recommendations
+
+### High Priority
+
+**1. Fix SPEC-01 → ADR-02 reverse link**
+
+- **Issue**: Impacts traceability integrity (bidirectional consistency at 75%)
+- **Action**: Add SPEC-01 reference to ADR-02 Section 7.2
+- **Estimated Time**: 2 minutes (manual edit)
+- **Auto-fix**: Available via `--auto-fix true` flag
+
+### Medium Priority
+
+**2. Add TDD reference to SPEC-03**
+
+- **Issue**: Missing downstream test reference
+- **Action**: Create TDD-NN test specification and update SPEC-03
+- **Estimated Time**: 30 minutes (TDD creation + link update)
+- **Note**: Normal for new specifications; address during test planning
+
+### Maintenance
+
+**3. Run trace-check weekly**
+
+- **Purpose**: Catch new traceability issues early
+- **Schedule**: Before weekly team review or sprint planning
+- **Command**: `/skill trace-check --strictness-level strict`
+- **Expected Time**: <30 seconds for current 8 SPEC files
+
+## Validation Details
+
+**Artifacts Scanned**: 8
+**Links Validated**: 24
+**ID Format Checks**: 8
+**Bidirectional Pairs Checked**: 8
+**Execution Time**: 4.2 seconds
+
+**Validation Parameters**:
+
+- `project_root_path`: `{project_root}/docs/`
+- `artifact_types`: `["SPEC"]`
+- `strictness_level`: `"strict"`
+- `auto_fix`: `false`
+- `report_format`: `"markdown"`
+
+## Next Steps
+
+1. **Immediate**: Review and approve ADR-02 fix (see Fix Details above)
+2. **Short-term**: Add TDD reference to SPEC-03 when tests are created
+3. **Ongoing**: Run trace-check before all documentation commits
+4. **Future**: Consider CI/CD integration for automated traceability validation
+
+---
+
+**Report Generated By**: trace-check skill v3.0.0
+**Report Format**: Markdown
+**Total Report Generation Time**: 4.2 seconds

--- a/platforms/claude-code-plugin/skills/workflow-optimizer/SKILL.md
+++ b/platforms/claude-code-plugin/skills/workflow-optimizer/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: workflow-optimizer
+description: Determine current position in the 8-layer SDD workflow and recommend prioritized next steps, parallel-work opportunities, and progress metrics. Use after completing an artifact or when unsure what to create next.
+metadata:
+  tags:
+    - sdd-workflow
+    - utility
+  custom_fields:
+    skill_category: utility
+    version: "0.2.0"
+    framework_spec_version: "0.7.0"
+    last_updated: "2026-05-23"
+---
+
+# workflow-optimizer
+
+## Purpose
+
+Guide a user through the 8-layer SDD workflow (BRD → PRD → EARS → BDD → ADR →
+SPEC → TDD → IPLAN → Code). It locates the current position from completed
+artifacts, recommends prioritized next steps with rationale, surfaces work that
+can proceed in parallel, and reports progress — removing the friction of
+manually deciding what to build next.
+
+## When to Use
+
+Use `workflow-optimizer` when:
+
+- You just completed an artifact and need next-step guidance.
+- You are starting documentation and want a workflow overview.
+- You want to find parallel-work opportunities or a progress report.
+
+Do **not** use it to pick a skill for a specific task (use
+`../skill-recommender/SKILL.md`), to gather project context (use
+`../context-analyzer/SKILL.md`), or to validate artifacts (use
+`../trace-check/SKILL.md` or `../quality-advisor/SKILL.md`).
+
+## Behavior
+
+Given a `project_root` (and optionally a just-completed artifact and a focus
+filter), the skill:
+
+1. **Analyzes project state** — discovers artifacts and extracts status (Draft,
+   In Review, Approved, Superseded, Deprecated) from Document Control, producing
+   counts by type.
+2. **Determines workflow position** — maps artifacts to layers 1–8 (each with a
+   single-layer prerequisite per the cumulative chain), marking layers as
+   completed, in-progress, ready, or blocked, and computes a progress
+   percentage.
+3. **Identifies required next steps** — uses the dependency chain to list
+   mandatory next artifacts, prioritized P0/P1/P2 with rationale and what each
+   unblocks.
+4. **Finds parallel opportunities** — independent BRD/PRD tracks, ADRs that can
+   be drafted concurrently, and BDD scenarios that can start once EARS
+   requirements exist; notes items blocked by missing upstream layers.
+5. **Calculates progress metrics** — per-layer status and the critical path
+   (EARS → BDD → ADR → SPEC → TDD → IPLAN).
+6. **Generates recommendations** — concrete next actions naming the layer skill
+   to run (e.g. `../doc-ears/SKILL.md`), parallel suggestions, blocked items
+   with unblock paths, and a progress summary.
+
+## Related Resources
+
+- Layer registry (layers & prerequisites):
+  `framework/registry/LAYER_REGISTRY.yaml`
+- Traceability: `framework/governance/TRACEABILITY.md`
+- Layer skills: `../doc-brd/SKILL.md` … `../doc-iplan/SKILL.md`
+- Related skills: `../context-analyzer/SKILL.md` ·
+  `../skill-recommender/SKILL.md` · `../doc-flow/SKILL.md`


### PR DESCRIPTION
## Summary

Ports 8 files that existed only on the abandoned working branch `chore/pre-commit-and-working-changes`, which had diverged ~52 commits behind `main` (notably before PR #21 `claude/hermes-legacy-layer-removal` reorganised the repo). The rest of that branch duplicated CI/pre-commit work already merged via separate PRs, so it could not be rebased cleanly. Carrying only the genuinely unique content forward.

## Linked Issue

(none — recovery of stranded content from an abandoned branch)

## Changes

- `platforms/claude-code-plugin/skills/context-analyzer/SKILL.md` — new skill
- `platforms/claude-code-plugin/skills/doc-review/SKILL.md` — new skill
- `platforms/claude-code-plugin/skills/skill-recommender/SKILL.md` — new skill
- `platforms/claude-code-plugin/skills/trace-check/SKILL.md` (+ `examples/example_validation_report.md`) — new skill
- `platforms/claude-code-plugin/skills/workflow-optimizer/SKILL.md` — new skill
- `legacy/claude-code-plugin/project-mngt/SKILL.md` + `examples/README.md` — archive snapshot ("park project-mngt as legacy; pull from shipped plugin")

`pyproject.toml` from the source branch was intentionally dropped — its bandit `exclude_dirs` referenced sibling submodule names (`business`, `iplanic`, `iops-framework`, `operations`) that exist only in the parent `aidoc-flow` repo, where an equivalent `pyproject.toml` already lives.

8 files changed, 1778 insertions, 0 deletions.

## Testing

- [x] Pre-commit hooks pass locally (`yamllint`, `markdownlint`, `detect-secrets`, framework conformance suite)
- [ ] Unit tests pass — N/A (no Python code added)
- [ ] Integration tests pass — N/A
- [x] Branch cut from current `origin/main`; no conflicts

## Checklist

- [x] Code follows project conventions
- [ ] Tests added/updated — N/A (documentation-only additions)
- [x] Documentation updated — these *are* the docs (SKILL.md files)
- [ ] Traceability tags present — N/A (not `source:sdd`)
- [ ] Acceptance criteria verified — no linked issue

## Notes for reviewers

- Original branch tip is preserved as the local tag `backup/pre-rebase-2026-05-28` (and the remote branch `chore/pre-commit-and-working-changes` still exists).
- After this PR lands, the original `chore/pre-commit-and-working-changes` branch can be deleted upstream as fully superseded.