### PR TITLE
fix(plugin): align doc skills with template source of truth, ban confabulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,28 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Closed a confabulation hole in the Claude Code plugin's read-time/audit
+  skills: `doc-flow` and every `doc-<layer>-audit` skill now explicitly require
+  the auditor to load the corresponding `*-TEMPLATE.yaml` and enumerate the
+  required sections from it before running the structural check, with a
+  written ban on rationalising drift as a "compact" / "walkthrough" / "lint-
+  pinned" variant. The audit Structure cells now defer to that enumeration
+  instead of hard-coding "all N template sections", which was a brittle parallel
+  source of truth. Also realigned three creation skills with their templates:
+  `doc-brd` (replaced an 18-section list containing phantom sections — User
+  Stories, Implementation Approach, Support & Maintenance, Cost-Benefit, Quality
+  Assurance — with the template's actual 15 numbered sections plus the diagrams
+  registry and appendix backmatter; remapped `§7.2 ADR Requirements` → `§8
+  adr_topics` everywhere it was cross-referenced; dropped stale `§3.6/§3.7`
+  Platform-vs-Feature cross-refs that never existed in the template), `doc-ears`
+  and `doc-adr` (renumbered to count `document_control` as Section 1, matching
+  the template's own `# Section N:` numbering and the PRD-style convention).
+  New conformance test `tests/conformance/platforms/test_skill_template_alignment.py`
+  prevents the drift class from recurring: audit skills must carry the explicit
+  enumeration block and no hard-coded count; creation skills' `Required structure
+  (N sections)` heading must match the template's numbered count; and creation
+  skill section lists must use only template-derived vocabulary (no phantoms).
+  Template is the single source of truth (D-0013).
 - Purged the pre-migration legacy taxonomy from the Hermes prompt templates so
   the creation/review/remediation agents follow the v3.2 source-of-truth naming
   convention (`ucx_flow_v3`). Removed the 10/12-layer `SYS / REQ / CTR / TSPEC /

--- a/platforms/claude-code-plugin/skills/doc-adr-audit/SKILL.md
+++ b/platforms/claude-code-plugin/skills/doc-adr-audit/SKILL.md
@@ -59,13 +59,22 @@ Authority: `${CLAUDE_PLUGIN_ROOT}/framework/layers/05_ADR/README.md`,
 `${CLAUDE_PLUGIN_ROOT}/framework/layers/05_ADR/ADR-TEMPLATE.yaml` (embedded rules + `_antipatterns`),
 and `${CLAUDE_PLUGIN_ROOT}/framework/governance/ID_NAMING_STANDARDS.md`.
 
+**Template-conformance enumeration (mandatory first step).** Load
+`ADR-TEMPLATE.yaml` and enumerate every required section (each top-level YAML
+key that is not explicitly `required: false`). The Structure check below is
+satisfied **only** when every enumerated required section appears as a `##`
+heading in the artifact. Any missing required section is a **blocking finding**
+— never rationalise it as a "compact" variant, "documented walkthrough",
+"lint-pinned", or any other exception. There is one template per layer and one
+canonical required-section set.
+
 **Tier 1 — blocking (error):**
 
 | Check | Verifies |
 |-------|----------|
 | Element ID format | every internal ID matches `ADR.NN.SS.xxxx` (4-hex hash); document refs use dash `ADR-NN` |
 | Single decision | the ADR records exactly one decision |
-| Structure | all 10 required sections present and non-empty |
+| Structure | every section enumerated above is present and non-empty |
 | Cumulative tags | `@brd @prd @ears @bdd` all present and well-formed |
 | Quality gate | SPEC-Ready score ≥ threshold (default 90) for Accepted status |
 

--- a/platforms/claude-code-plugin/skills/doc-adr-autopilot/SKILL.md
+++ b/platforms/claude-code-plugin/skills/doc-adr-autopilot/SKILL.md
@@ -23,7 +23,7 @@ metadata:
 ## Purpose
 
 Automated **ADR generation pipeline**. From an upstream artifact
-(BRD §7.2 / PRD §14 / EARS / BDD), a user prompt, or an implementation plan
+(BRD §8 / PRD §14 / EARS / BDD), a user prompt, or an implementation plan
 (`IPLAN-*`), it analyzes the source, scopes the decision, generates a complete
 Context-Decision-Consequences record, validates readiness, maintains
 `ADR-00_index.md`, and drives the audit↔fix cycle to a passing score — for one
@@ -59,17 +59,17 @@ For each target, check whether the ADR already exists (nested folder
 
 Determine `deliverable_type` (`code`/`document`/`ux`/`risk`/`process`,
 inherited from upstream) and the originating topic (PRD §14, tracing back to
-BRD §7.2) from the source content. One ADR records **one** decision.
+BRD §8) from the source content. One ADR records **one** decision.
 
 ## Workflow
 
 1. **Input analysis** — classify the input (upstream id / prompt / IPLAN),
-   locate the originating topic (PRD §14 → BRD §7.2), and decide generate vs
+   locate the originating topic (PRD §14 → BRD §8), and decide generate vs
    review-and-fix.
 2. **Decision scope** — confirm exactly one decision; reserve the next
    `ADR-NN`; verify the cited upstream artifacts exist.
 3. **Generation** — produce the ADR per `../doc-adr/SKILL.md`: Document Control
-   first (status `Proposed`/`Accepted`), all 10 sections, 2–3 alternatives with
+   first (status `Proposed`/`Accepted`), §2–§10 + glossary + appendix, 2–3 alternatives with
    cost/fit, internal element IDs `ADR.NN.SS.xxxx`, cumulative tags
    `@brd @prd @ears @bdd`, the `@adr: ADR-NN` self-tag, architecture-flow
    diagram via `../charts-flow/SKILL.md`.

--- a/platforms/claude-code-plugin/skills/doc-adr/SKILL.md
+++ b/platforms/claude-code-plugin/skills/doc-adr/SKILL.md
@@ -39,7 +39,7 @@ them with `@depends: ADR-NN`.
 
 Use `doc-adr` when:
 
-- An architectural topic from BRD §7.2 / PRD §14 needs a recorded decision.
+- An architectural topic from BRD §8 / PRD §14 needs a recorded decision.
 - Choosing a technology, pattern, or integration approach with alternatives.
 - Capturing rationale and consequences for a long-lived architectural choice.
 
@@ -75,20 +75,25 @@ Draft/In Review/Approved. The status tracks the SPEC-Ready score:
 | Deprecated | — | No longer relevant (kept for history) |
 | Superseded | — | Replaced by a newer ADR (link it) |
 
-### Required structure (10 sections)
+### Required structure (10 numbered sections + glossary + appendix backmatter)
 
-`## Document Control` comes **first** (status, date, decision-makers, author,
+`document_control` is **Section 1** (status, date, decision-makers, author,
 `originating_topic` → PRD §14, `brd_reference`, SPEC-Ready score, revision
 history). Then:
 
-1. Context (problem statement, business driver, constraints, technical
-context) · 2. Decision (chosen solution, key components, MVP/next-cycle scope) ·
-3. Alternatives Considered (2–3 options, each with pros/cons, cost, fit;
-rejected options carry a rejection reason) · 4. Consequences (positive
-outcomes, trade-offs/risks with severity, cost estimate) · 5. Architecture
-Flow (diagrams + integration points) · 6. Implementation Assessment (phases,
-rollback, monitoring baseline) · 7. Verification (success criteria, BDD
-cross-refs) · 8. Traceability · 9. Related Decisions · 10. Glossary.
+2. Context (problem statement, business driver, constraints, technical
+context) · 3. Decision (chosen solution, key components, MVP/next-cycle scope) ·
+4. Alternatives Considered (2–3 options, each with pros/cons, cost, fit;
+rejected options carry a rejection reason) · 5. Consequences (positive
+outcomes, trade-offs/risks with severity, cost estimate) · 6. Architecture
+Flow (diagrams + integration points) · 7. Implementation Assessment (phases,
+rollback, monitoring baseline) · 8. Verification (success criteria, BDD
+cross-refs) · 9. Traceability · 10. Related Decisions.
+
+Plus a **Glossary** (`glossary:` key) and **Appendix** (`appendix:` key) as
+required backmatter (unnumbered). Section numbers and identifiers come from
+`ADR-TEMPLATE.yaml`'s own `# Section N:` numbering — **the template is the
+source of truth**.
 
 See `ADR-TEMPLATE.yaml` for per-section content and authoring `_antipatterns`.
 
@@ -111,14 +116,15 @@ See `ADR-TEMPLATE.yaml` for per-section content and authoring `_antipatterns`.
 ## Creation Process
 
 1. **Confirm the topic** — one decision, traced to its PRD §14 originating
-   topic and BRD §7.2 driver.
+   topic and BRD §8 driver.
 2. **Reserve ID** — next free `ADR-NN` (two digits, expand only as needed:
    `ADR-01`, `ADR-99`, `ADR-102`).
 3. **Create the nested folder** — every ADR lives in
    `docs/05_ADR/ADR-NN_{slug}/`. Monolithic: `ADR-NN_{slug}.md` inside it;
    section-based (>25 KB): `ADR-NN.S_{section}.md` + index from
    `${CLAUDE_PLUGIN_ROOT}/framework/layers/05_ADR/ADR-00_index.TEMPLATE.md`.
-4. **Document Control first**, then complete all 10 sections from the template.
+4. **Document Control (Section 1) first**, then complete §2–§10 plus the
+   glossary and appendix backmatter from the template.
 5. **Evaluate 2–3 alternatives** with cost and fit; give every rejected option
    a rejection reason. State the decision decisively with rationale.
 6. **Add cumulative tags** `@brd @prd @ears @bdd`; add the `@adr: ADR-NN`

--- a/platforms/claude-code-plugin/skills/doc-bdd-audit/SKILL.md
+++ b/platforms/claude-code-plugin/skills/doc-bdd-audit/SKILL.md
@@ -59,12 +59,21 @@ Authority: `${CLAUDE_PLUGIN_ROOT}/framework/layers/04_BDD/README.md`,
 `${CLAUDE_PLUGIN_ROOT}/framework/layers/04_BDD/BDD-TEMPLATE.yaml` (embedded rules + scenario
 conventions), and `${CLAUDE_PLUGIN_ROOT}/framework/governance/ID_NAMING_STANDARDS.md`.
 
+**Template-conformance enumeration (mandatory first step).** Load
+`BDD-TEMPLATE.yaml` and enumerate every required section (each top-level YAML
+key that is not explicitly `required: false`). The Structure check below is
+satisfied **only** when every enumerated required section appears as a `##`
+heading in the artifact. Any missing required section is a **blocking finding**
+— never rationalise it as a "compact" variant, "documented walkthrough",
+"lint-pinned", or any other exception. There is one template per layer and one
+canonical required-section set.
+
 **Tier 1 — blocking (error):**
 
 | Check | Verifies |
 |-------|----------|
 | Element ID format | every ID matches `BDD.NN.SS.xxxx` (4-hex hash) |
-| Structure | all 5 template sections present and non-empty |
+| Structure | every section enumerated above is present and non-empty |
 | Gherkin quality | scenarios are atomic, executable, valid Given-When-Then |
 | Cumulative tags | `@brd @prd @ears` present, Gherkin-native, no space after colon |
 | Scenario tags | each scenario has `@scenario-type`, priority, `@scenario-id`, `spec_trace` |

--- a/platforms/claude-code-plugin/skills/doc-brd-audit/SKILL.md
+++ b/platforms/claude-code-plugin/skills/doc-brd-audit/SKILL.md
@@ -59,12 +59,21 @@ Authority: `${CLAUDE_PLUGIN_ROOT}/framework/layers/01_BRD/README.md`,
 `${CLAUDE_PLUGIN_ROOT}/framework/layers/01_BRD/BRD-TEMPLATE.yaml` (embedded rules +
 `cross_section_rules`), and `${CLAUDE_PLUGIN_ROOT}/framework/governance/ID_NAMING_STANDARDS.md`.
 
+**Template-conformance enumeration (mandatory first step).** Load
+`BRD-TEMPLATE.yaml` and enumerate every required section (each top-level YAML
+key that is not explicitly `required: false`). The Structure check below is
+satisfied **only** when every enumerated required section appears as a `##`
+heading in the artifact. Any missing required section is a **blocking finding**
+— never rationalise it as a "compact" variant, "documented walkthrough",
+"lint-pinned", or any other exception. There is one template per layer and one
+canonical required-section set.
+
 **Tier 1 — blocking (error):**
 
 | Check | Verifies |
 |-------|----------|
 | Element ID format | every ID matches `BRD.NN.SS.xxxx` (4-hex hash) |
-| Structure | all required template sections present and non-empty |
+| Structure | every section enumerated above is present and non-empty |
 | Cross-section rules | `cross_section_rules` from the template hold |
 | Quality gate | PRD-Ready score ≥ threshold (default 90) |
 

--- a/platforms/claude-code-plugin/skills/doc-brd-autopilot/SKILL.md
+++ b/platforms/claude-code-plugin/skills/doc-brd-autopilot/SKILL.md
@@ -64,8 +64,9 @@ type (Platform vs Feature) from the source content.
 2. **Type & scope** — Platform vs Feature; for a Feature BRD, verify the
    referenced Platform BRD exists; reserve the next `BRD-NN`.
 3. **Generation** — produce the BRD per `../doc-brd/SKILL.md`: Document Control
-   first, all 18 sections, §7.2 across the 7 categories, element IDs
-   `BRD.NN.SS.xxxx`, diagram tags via `../charts-flow/SKILL.md`.
+   (Section 1) first, §3–§15 required sections (toggle §2 Executive Summary per
+   `section_toggles`), diagrams registry, appendix, §8 across the 7 categories,
+   element IDs `BRD.NN.SS.xxxx`, diagram tags via `../charts-flow/SKILL.md`.
 4. **Validation** — run `../doc-brd-audit/SKILL.md` from scratch.
 5. **Audit ↔ fix cycle** — while score < threshold and iterations < max: run
    `../doc-brd-fixer/SKILL.md`, then re-audit. On pass, update

--- a/platforms/claude-code-plugin/skills/doc-brd/SKILL.md
+++ b/platforms/claude-code-plugin/skills/doc-brd/SKILL.md
@@ -67,28 +67,35 @@ placeholders like `BRD-XXX` or reference documents that do not yet exist.
 | Describes one user-facing workflow / feature | **Feature** |
 | Builds on capabilities an existing Platform BRD established | **Feature** |
 
-- **Platform BRD** populates Section 3.6 (Technology Stack Prerequisites) and
-  3.7 (Mandatory Technology Conditions).
-- **Feature BRD** marks 3.6/3.7 as `N/A — See Platform BRD-NN §3.6/§3.7` and
-  references the specific items.
+- **Platform BRD** — file `BRD-NN_platform_{slug}`; ADRs are created **before**
+  the PRD to validate architectural choices; §8 (Architecture Decision Topics)
+  is populated with the Selected categories that downstream BRDs will depend on.
+- **Feature BRD** — file `BRD-NN_{feature_slug}`; standard layer flow
+  (BRD → PRD → EARS → BDD → ADR); §8 references the Platform BRD's adopted
+  topics rather than introducing new architectural decisions.
 
-### Required structure (18 sections)
+### Required structure (15 sections)
 
-`## Document Control` comes **first**, before all numbered sections (project
-name, version, date `YYYY-MM-DD`, owner, prepared-by, status, revision-history
-table). Then:
+`document_control` is **Section 1** (project name, version, date `YYYY-MM-DD`,
+owner, prepared-by, status, revision-history table). Then:
 
-1. Introduction · 2. Business Objectives · 3. Project Scope · 4. Stakeholders ·
-5. User Stories · 6. Functional Requirements · 7. Quality Attributes
-(incl. **7.2 Architecture Decision Requirements**) · 8. Constraints &
-Assumptions · 9. Acceptance Criteria · 10. Business Risk Management ·
-11. Implementation Approach · 12. Support & Maintenance · 13. Cost-Benefit ·
-14. Project Governance (incl. 14.5 Approval) · 15. Quality Assurance ·
-16. Traceability · 17. Glossary (17.1–17.6) · 18. Appendices.
+2. Executive Summary (OPTIONAL — derived; toggled by `section_toggles`) ·
+3. Introduction · 4. Business Objectives · 5. Project Scope · 6. Stakeholders ·
+7. Functional Requirements · 8. Architecture Decision Topics (`adr_topics`) ·
+9. Quality Expectations · 10. Constraints and Assumptions ·
+11. Acceptance Criteria and Success Validation · 12. Business Risk Management ·
+13. Approval · 14. Traceability · 15. Glossary.
+
+The template additionally defines two structural blocks alongside the numbered
+sections: a **Diagrams Registry** (`diagrams:`) and a **Lifecycle Reference**
+appendix (`appendix:`) — see those template keys for the required shape. Section
+numbers and section identifiers come from the template's own numbering and
+top-level YAML keys; **the template is the source of truth**, and this skill's
+list is a navigation aid, not a parallel definition.
 
 See `BRD-TEMPLATE.yaml` for per-section content and `cross_section_rules`.
 
-### Section 7.2 — Architecture Decision Requirements (mandatory)
+### Section 8 — Architecture Decision Topics (mandatory)
 
 Identify architectural topics needing decisions, with cost-focused,
 alternatives-based analysis, across the 7 categories. **Do not reference ADR
@@ -104,11 +111,11 @@ numbers** — ADRs do not exist yet.
 | 6 | AI/ML | No AI/ML components |
 | 7 | Technology Selection | Using an existing stack |
 
-Each `Selected` topic carries a `BRD.NN.07.xxxx` element ID and includes a
+Each `Selected` topic carries a `BRD.NN.08.xxxx` element ID and includes a
 status, business driver, business constraints, an **Alternatives Overview**
 table (with cost estimates), a **Cloud Provider Comparison** (GCP/Azure/AWS), a
 recommended selection, and the PRD requirements it implies. Layer separation:
-BRD §7.2 = *what & why & how much*; PRD = *how to evaluate*; ADR = *the decision*.
+BRD §8 = *what & why & how much*; PRD = *how to evaluate*; ADR = *the decision*.
 
 ### Element IDs and tags
 
@@ -135,8 +142,10 @@ Most BRDs are authored from stakeholder input — keep the default
    regardless of size. Monolithic: `BRD-NN_{slug}.md` inside it; section-based
    (>25 KB): `BRD-NN.S_{section}.md` + index from
    `${CLAUDE_PLUGIN_ROOT}/framework/layers/01_BRD/BRD-00_index.TEMPLATE.md`.
-4. **Document Control first**, then complete all 18 sections from the template.
-5. **Handle 3.6/3.7** per type; **fill §7.2** across the 7 categories.
+4. **Document Control (Section 1) first**, then complete the 14 remaining
+   required sections + the diagrams registry + appendix per template; toggle §2
+   (Executive Summary) per `section_toggles`.
+5. **Fill §8** (Architecture Decision Topics) across the 7 categories.
 6. **Configure upstream mode** (`none` default; `ref` if from `docs/00_REF/`).
 7. **Update the BRD index** `docs/01_BRD/BRD-00_index.md` in the same change.
 8. **Validate** (below) and commit the BRD and index together.
@@ -147,9 +156,11 @@ The framework ships no runtime code — **this skill is the validator**. Apply t
 checklist against `${CLAUDE_PLUGIN_ROOT}/framework/layers/01_BRD/README.md` and
 `${CLAUDE_PLUGIN_ROOT}/framework/governance/ID_NAMING_STANDARDS.md`.
 
-- [ ] Document Control is the first section.
-- [ ] All 18 sections present and non-empty; 3.6/3.7 correct for the BRD type.
-- [ ] §7.2 covers all 7 categories; no ADR numbers referenced.
+- [ ] Document Control (Section 1) is the first section.
+- [ ] All required template sections present and non-empty: §1, §3–§15, plus
+      the diagrams registry and appendix; §2 Executive Summary only when
+      `section_toggles` includes it. Enumerate by reading `BRD-TEMPLATE.yaml`.
+- [ ] §8 covers all 7 ADR-topic categories; no ADR numbers referenced.
 - [ ] Element IDs match `BRD.NN.SS.xxxx`; no removed patterns.
 - [ ] Traceability matrix / index created or updated; no broken links.
 - [ ] Diagram contract: `@diagram: c4-l1` and `@diagram: dfd-l1` present (use
@@ -172,7 +183,7 @@ issues are found, fix and re-check; if unfixable, log for manual review.
 ## Next Skill
 
 `../doc-prd/SKILL.md` — the PRD references this BRD (`@brd: BRD.NN.SS.xxxx`),
-defines product features and KPIs, and inherits the §7.2 architecture topics.
+defines product features and KPIs, and inherits the §8 architecture topics.
 
 ## Adaptation
 
@@ -200,5 +211,5 @@ Authority: `${CLAUDE_PLUGIN_ROOT}/framework/governance/ADAPTATION.md`.
 | **Layer** | 1 (entry point) |
 | **Upstream tags** | None |
 | **Key decision** | Platform vs Feature |
-| **Must include** | Document Control (first), §7.2 (7 categories), 18 sections |
+| **Must include** | §1 Document Control, §3–§15 required sections, §8 (7 categories), diagrams registry, appendix |
 | **Next** | `doc-prd` |

--- a/platforms/claude-code-plugin/skills/doc-ears-audit/SKILL.md
+++ b/platforms/claude-code-plugin/skills/doc-ears-audit/SKILL.md
@@ -59,12 +59,21 @@ Authority: `${CLAUDE_PLUGIN_ROOT}/framework/layers/03_EARS/README.md`,
 `${CLAUDE_PLUGIN_ROOT}/framework/layers/03_EARS/EARS-TEMPLATE.yaml` (embedded rules), and
 `${CLAUDE_PLUGIN_ROOT}/framework/governance/ID_NAMING_STANDARDS.md`.
 
+**Template-conformance enumeration (mandatory first step).** Load
+`EARS-TEMPLATE.yaml` and enumerate every required section (each top-level YAML
+key that is not explicitly `required: false`). The Structure check below is
+satisfied **only** when every enumerated required section appears as a `##`
+heading in the artifact. Any missing required section is a **blocking finding**
+— never rationalise it as a "compact" variant, "documented walkthrough",
+"lint-pinned", or any other exception. There is one template per layer and one
+canonical required-section set.
+
 **Tier 1 — blocking (error):**
 
 | Check | Verifies |
 |-------|----------|
 | Element ID format | every ID matches `EARS.NN.SS.xxxx` (4-hex hash) |
-| Structure | all 5 template sections present and non-empty |
+| Structure | every section enumerated above is present and non-empty |
 | EARS syntax | every requirement has a trigger (WHEN/IF/WHILE) + `THE … SHALL`; statements atomic |
 | Quantifiable constraints | timing uses p50/p95/p99; no vague terms ("fast", "real-time") |
 | Quality gate | BDD-Ready score ≥ threshold (default 90) |

--- a/platforms/claude-code-plugin/skills/doc-ears/SKILL.md
+++ b/platforms/claude-code-plugin/skills/doc-ears/SKILL.md
@@ -59,14 +59,18 @@ documents that exist; never invent placeholders like `PRD-XXX` or `TBD`.
 
 ## Layer Guidance
 
-### Required structure (5 sections)
+### Required structure (5 numbered sections + glossary backmatter)
 
-`## Document Control` comes **first** (status, version, dates `YYYY-MM-DD`,
+`document_control` is **Section 1** (status, version, dates `YYYY-MM-DD`,
 priority, single `@prd:` source, `@brd:` reference, BDD-Ready score,
 revision-history table). Then:
 
-1. Purpose & Context · 2. Requirements (the five patterns) · 3. Quality
-Attributes (tabular) · 4. Traceability · 5. Glossary.
+2. Purpose & Context · 3. Requirements (the five patterns) · 4. Quality
+Attributes (tabular) · 5. Traceability.
+
+Plus a **Glossary** backmatter section (`glossary:` template key — required,
+unnumbered). Section numbers and identifiers come from `EARS-TEMPLATE.yaml`'s
+own `# Section N:` numbering — **the template is the source of truth**.
 
 See `EARS-TEMPLATE.yaml` for per-section content and embedded authoring guidance.
 
@@ -120,7 +124,8 @@ timing uses p50/p95/p99 notation. Carry changeable values as
    `docs/03_EARS/EARS-NN_{slug}/` regardless of size. Monolithic:
    `EARS-NN_{slug}.md` inside it; section-based (>25 KB): `EARS-NN.S_{section}.md`
    - index from `${CLAUDE_PLUGIN_ROOT}/framework/layers/03_EARS/EARS-00_index.TEMPLATE.md`.
-4. **Document Control first**, then complete all 5 sections from the template.
+4. **Document Control (Section 1) first**, then complete §2–§5 plus the
+   glossary backmatter from the template.
 5. **Categorize requirements** into the five patterns; write atomic
    `THE … SHALL …` statements (WITHIN timing where applicable) with
    `@threshold:` constraints.

--- a/platforms/claude-code-plugin/skills/doc-flow/SKILL.md
+++ b/platforms/claude-code-plugin/skills/doc-flow/SKILL.md
@@ -116,6 +116,20 @@ layers (see *Adaptation*), mark each completed / in-progress / ready / blocked,
 and report position plus a progress percentage — layers at their terminal status
 (`Approved`, or `Completed` for IPLAN) ÷ **active** layers.
 
+**Template-conformance check (mandatory).** For every artifact found, compare it
+to its layer's canonical `${CLAUDE_PLUGIN_ROOT}/framework/layers/<NN>_<X>/<TYPE>-TEMPLATE.yaml`:
+load the template's top-level section keys, then check the artifact's `##` headings
+contain every required section. Report any missing required sections as a
+**drift finding** (artifact `Status` notwithstanding), e.g. *"BRD-01 missing 6 of
+18 required sections: Implementation Approach, Support & Maintenance, …"*.
+
+Drift findings are first-class — **do not** rationalise them as a "compact"
+variant, "documented walkthrough format", or "pinned to lint" exception. There
+is **one** template per layer and one canonical section list. Lint passing
+(structural subset) does not imply template conformance (full section set). When
+drift is found, recommend `doc-<layer>-fixer` (or `doc-<layer>-autopilot` for a
+full re-author) to close the gap.
+
 **What's next.** Recommend the next artifact per the cumulative chain (each layer
 needs its single-layer prerequisite), over the project's **active** layers only —
 never recommend a layer the profile disabled. Prioritize:

--- a/platforms/claude-code-plugin/skills/doc-iplan-audit/SKILL.md
+++ b/platforms/claude-code-plugin/skills/doc-iplan-audit/SKILL.md
@@ -60,12 +60,21 @@ Authority: `${CLAUDE_PLUGIN_ROOT}/framework/layers/08_IPLAN/README.md`,
 `${CLAUDE_PLUGIN_ROOT}/framework/layers/08_IPLAN/IPLAN-TEMPLATE.yaml`, and
 `${CLAUDE_PLUGIN_ROOT}/framework/governance/ID_NAMING_STANDARDS.md`.
 
+**Template-conformance enumeration (mandatory first step).** Load
+`IPLAN-TEMPLATE.yaml` and enumerate every required section (each top-level YAML
+key that is not explicitly `required: false`). The Structure check below is
+satisfied **only** when every enumerated required section appears as a `##`
+heading in the artifact. Any missing required section is a **blocking finding**
+— never rationalise it as a "compact" variant, "documented walkthrough",
+"lint-pinned", or any other exception. There is one template per layer and one
+canonical required-section set.
+
 **Tier 1 — blocking (error):**
 
 | Check | Verifies |
 |-------|----------|
 | Document ID format | IPLAN referenced as `IPLAN-NN` (dash form); no dotted `IPLAN.NN.SS.xxxx`; `@tdd` uses `TDD.NN.SS.xxxx`, `@spec` uses `SPEC-NN` |
-| Structure | all 6 template sections present and non-empty |
+| Structure | every section enumerated above is present and non-empty |
 | Test-first order | `file_manifest` lists tests before implementation files |
 | Session handoff | `session_handoff.sessions` present with a `next_session_directive` |
 | Upstream references | parent SPEC/TDD references resolve to existing docs |

--- a/platforms/claude-code-plugin/skills/doc-prd-audit/SKILL.md
+++ b/platforms/claude-code-plugin/skills/doc-prd-audit/SKILL.md
@@ -59,12 +59,21 @@ Authority: `${CLAUDE_PLUGIN_ROOT}/framework/layers/02_PRD/README.md`,
 `${CLAUDE_PLUGIN_ROOT}/framework/layers/02_PRD/PRD-TEMPLATE.yaml` (embedded rules), and
 `${CLAUDE_PLUGIN_ROOT}/framework/governance/ID_NAMING_STANDARDS.md`.
 
+**Template-conformance enumeration (mandatory first step).** Load
+`PRD-TEMPLATE.yaml` and enumerate every required section (each top-level YAML
+key that is not explicitly `required: false`). The Structure check below is
+satisfied **only** when every enumerated required section appears as a `##`
+heading in the artifact. Any missing required section is a **blocking finding**
+— never rationalise it as a "compact" variant, "documented walkthrough",
+"lint-pinned", or any other exception. There is one template per layer and one
+canonical required-section set.
+
 **Tier 1 — blocking (error):**
 
 | Check | Verifies |
 |-------|----------|
 | Element ID format | every ID matches `PRD.NN.SS.xxxx` (4-hex hash); `SS` = host section |
-| Structure | all 15 template sections present and non-empty |
+| Structure | every section enumerated above is present and non-empty |
 | Cumulative tags | `@brd:` tags present and resolving to existing BRD elements |
 | Customer-facing content | §10 substantive in ≥3 categories (not placeholders) |
 | Quality gate | EARS-Ready score ≥ threshold (default 90) |

--- a/platforms/claude-code-plugin/skills/doc-prd/SKILL.md
+++ b/platforms/claude-code-plugin/skills/doc-prd/SKILL.md
@@ -40,7 +40,7 @@ Use `doc-prd` when:
 
 - A BRD exists and you need to define product features and user requirements.
 - Translating business needs into product capabilities, personas, and KPIs.
-- Elaborating BRD §7.2 architecture topics into technical options for ADR.
+- Elaborating BRD §8 architecture topics into technical options for ADR.
 
 For end-to-end generation from a BRD, a prompt, or an IPLAN, use
 `../doc-prd-autopilot/SKILL.md`.
@@ -107,7 +107,7 @@ Placeholder-only content is a blocking error.
 
 ### Section 14 — ADR topic elaboration
 
-Elaborate BRD §7.2 topics with **technical options and evaluation criteria**.
+Elaborate BRD §8 topics with **technical options and evaluation criteria**.
 Layer separation: BRD = *what & why* · PRD = *how to evaluate* · ADR = *the
 decision*. **Do not reference ADR numbers** — ADRs do not exist yet.
 
@@ -128,7 +128,7 @@ decision*. **Do not reference ADR numbers** — ADRs do not exist yet.
 ## Creation Process
 
 1. **Read the parent BRD** — all section files as one document; extract
-   objectives, stakeholders, success criteria, and §7.2 topics.
+   objectives, stakeholders, success criteria, and §8 topics.
 2. **Reserve ID** — next free `PRD-NN` (two digits: `PRD-01`, `PRD-99`,
    `PRD-102`).
 3. **Create the nested folder** — every PRD lives in

--- a/platforms/claude-code-plugin/skills/doc-spec-audit/SKILL.md
+++ b/platforms/claude-code-plugin/skills/doc-spec-audit/SKILL.md
@@ -59,13 +59,22 @@ Authority: `${CLAUDE_PLUGIN_ROOT}/framework/layers/06_SPEC/README.md`,
 `${CLAUDE_PLUGIN_ROOT}/framework/layers/06_SPEC/SPEC-TEMPLATE.yaml` (embedded rules), and
 `${CLAUDE_PLUGIN_ROOT}/framework/governance/ID_NAMING_STANDARDS.md`.
 
+**Template-conformance enumeration (mandatory first step).** Load
+`SPEC-TEMPLATE.yaml` and enumerate every required section (each top-level YAML
+key that is not explicitly `required: false`). The Structure check below is
+satisfied **only** when every enumerated required section appears as a `##`
+heading in the artifact. Any missing required section is a **blocking finding**
+— never rationalise it as a "compact" variant, "documented walkthrough",
+"lint-pinned", or any other exception. There is one template per layer and one
+canonical required-section set.
+
 **Tier 1 — blocking (error):**
 
 | Check | Verifies |
 |-------|----------|
 | YAML syntax | the SPEC parses as valid YAML |
 | Document ID | dash form `SPEC-NN`; no dotted SPEC element IDs; no removed patterns |
-| Structure | all 8 required template sections present and non-empty |
+| Structure | every section enumerated above is present and non-empty |
 | Cumulative tags | upstream chain complete (`@brd @prd @ears @bdd @adr`); no gaps |
 | Quality gate | TDD-Ready score ≥ threshold (default 90) |
 

--- a/platforms/claude-code-plugin/skills/doc-tdd-audit/SKILL.md
+++ b/platforms/claude-code-plugin/skills/doc-tdd-audit/SKILL.md
@@ -59,12 +59,21 @@ Authority: `${CLAUDE_PLUGIN_ROOT}/framework/layers/07_TDD/README.md`,
 `${CLAUDE_PLUGIN_ROOT}/framework/layers/07_TDD/TDD-TEMPLATE.yaml` (embedded rules), and
 `${CLAUDE_PLUGIN_ROOT}/framework/governance/ID_NAMING_STANDARDS.md`.
 
+**Template-conformance enumeration (mandatory first step).** Load
+`TDD-TEMPLATE.yaml` and enumerate every required section (each top-level YAML
+key that is not explicitly `required: false`). The Structure check below is
+satisfied **only** when every enumerated required section appears as a `##`
+heading in the artifact. Any missing required section is a **blocking finding**
+— never rationalise it as a "compact" variant, "documented walkthrough",
+"lint-pinned", or any other exception. There is one template per layer and one
+canonical required-section set.
+
 **Tier 1 — blocking (error):**
 
 | Check | Verifies |
 |-------|----------|
 | Element ID format | every test-case ID matches `TDD.NN.04.xxxx` (4-hex hash); no removed patterns |
-| Structure | all 7 template sections present and non-empty |
+| Structure | every section enumerated above is present and non-empty |
 | Test types | each case carries a valid `type` (unit/integration/e2e/security) |
 | BDD mapping | each BDD scenario maps to tests (Section 3) |
 | Cumulative tags | upstream @brd @prd @ears @bdd @adr @spec all present |

--- a/tests/conformance/platforms/test_skill_template_alignment.py
+++ b/tests/conformance/platforms/test_skill_template_alignment.py
@@ -1,0 +1,231 @@
+"""Conformance: Claude Code plugin skills align with the canonical layer
+templates.
+
+Catches the drift class that produced the `doc-flow` confabulation incident
+(skills describing sections that do not exist in the template, audit checklists
+declaring hard-coded counts that drift away from the template). The template
+is the single source of truth (D-0013); skills that reference structure must
+align with it.
+
+Checks per layer (BRD/PRD/EARS/BDD/ADR/SPEC/TDD/IPLAN):
+
+1. The audit skill (``doc-<layer>-audit/SKILL.md``) defers to the template:
+   it must contain the explicit "Load <TYPE>-TEMPLATE.yaml and enumerate" block
+   and **must not** declare a hard-coded section count of the form
+   ``all N template sections`` or ``all N required sections``.
+
+2. The creation skill (``doc-<layer>/SKILL.md``) declares a section count in
+   its ``### Required structure (N …)`` heading that matches the template's
+   own ``# Section N:`` numbering.
+
+3. The creation skill's numbered section list references only template keys —
+   no phantom sections (e.g. ``User Stories`` in BRD before this fix).
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+import yaml
+from _spec import FRAMEWORK, PLATFORMS_ROOT, registry_layers
+
+PLUGIN_SKILLS = PLATFORMS_ROOT / "claude-code-plugin" / "skills"
+
+# The convention is: template top-level YAML keys that are not header
+# metadata are sections.
+_HEADER_KEYS = {"id", "title", "metadata", "version", "schema_version", "description", "layer"}
+
+# Words that commonly appear in a section title and a creation skill's list
+# but are also generic English — stop-words for the "references only template
+# keys" check.
+_STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "the",
+    "of",
+    "to",
+    "in",
+    "for",
+    "with",
+    "or",
+    "on",
+    "at",
+    "incl",
+    "incl.",
+    "from",
+    "by",
+    "as",
+    "this",
+    "that",
+    "see",
+    "per",
+}
+
+
+def _normalise(token: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", token.lower())
+
+
+def _template_sections(template_path: Path) -> dict[str, dict]:
+    """Return {key: section_body} for every top-level mapping that is not a
+    metadata header key."""
+    with template_path.open(encoding="utf-8") as fh:
+        doc = yaml.safe_load(fh)
+    return {k: v for k, v in doc.items() if k not in _HEADER_KEYS and isinstance(v, dict)}
+
+
+def _template_numbered_count(template_path: Path) -> int:
+    """Count the template's own ``# Section N: …`` comment headers."""
+    text = template_path.read_text(encoding="utf-8")
+    return len(re.findall(r"^# Section \d+:", text, flags=re.MULTILINE))
+
+
+def _required_structure_count(skill_path: Path) -> int | None:
+    text = skill_path.read_text(encoding="utf-8")
+    m = re.search(r"### Required structure \((\d+)\b", text)
+    return int(m.group(1)) if m else None
+
+
+def _required_structure_block(skill_path: Path) -> str:
+    """The text from `### Required structure` up to the next `###` heading."""
+    text = skill_path.read_text(encoding="utf-8")
+    m = re.search(
+        r"### Required structure[^\n]*\n(.*?)(?=^###\s|\Z)",
+        text,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    return m.group(1) if m else ""
+
+
+def _skill_section_titles(block: str) -> list[str]:
+    """Extract bolded or numbered section titles from a Required-structure
+    block. Returns the raw title strings (e.g. ``Functional Requirements``).
+    """
+    titles: list[str] = []
+    # Bold list items: `1. **Title** — …`
+    titles += re.findall(r"\d+\.\s+\*\*([^*]+)\*\*", block)
+    # Inline-dotted list items: `2. Title (incl. …) · 3. Title …`
+    for piece in re.split(r"·", block):
+        m = re.match(r"\s*\d+\.\s+([^(·\n]+)", piece)
+        if m:
+            titles.append(m.group(1).strip().rstrip("."))
+    # De-dup, preserve order.
+    seen, out = set(), []
+    for t in titles:
+        n = _normalise(t)
+        if n and n not in seen:
+            seen.add(n)
+            out.append(t.strip())
+    return out
+
+
+class AuditSkillsDeferToTemplate(unittest.TestCase):
+    """Each ``doc-<layer>-audit`` SKILL.md loads the template at runtime and
+    does not hard-code a brittle section count."""
+
+    def test_template_enumeration_block_present(self):
+        for layer in registry_layers():
+            artifact = layer["artifact"]
+            skill = PLUGIN_SKILLS / f"doc-{artifact.lower()}-audit" / "SKILL.md"
+            with self.subTest(layer=artifact):
+                self.assertTrue(skill.is_file(), f"missing {skill}")
+                body = skill.read_text(encoding="utf-8")
+                self.assertIn(
+                    "Template-conformance enumeration",
+                    body,
+                    f"{skill.name} is missing the explicit template-enumeration"
+                    " block — the auditor will not know to load the template",
+                )
+                self.assertIn(
+                    f"{artifact}-TEMPLATE.yaml",
+                    body,
+                    f"{skill.name} must reference {artifact}-TEMPLATE.yaml in"
+                    " the enumeration block",
+                )
+
+    def test_no_hardcoded_section_count(self):
+        pattern = re.compile(
+            r"all\s+\d+\s+(?:required\s+)?(?:template\s+)?sections",
+            re.IGNORECASE,
+        )
+        for layer in registry_layers():
+            artifact = layer["artifact"]
+            skill = PLUGIN_SKILLS / f"doc-{artifact.lower()}-audit" / "SKILL.md"
+            with self.subTest(layer=artifact):
+                body = skill.read_text(encoding="utf-8")
+                hits = pattern.findall(body)
+                self.assertFalse(
+                    hits,
+                    f"{skill.name} still hard-codes a section count "
+                    f"({hits!r}); audit skills must defer to the template "
+                    "enumeration",
+                )
+
+
+class CreationSkillsMatchTemplate(unittest.TestCase):
+    """Each ``doc-<layer>`` SKILL.md's ``Required structure`` count matches
+    the template's own ``# Section N:`` numbered count, and its section list
+    contains only real template keys (no phantoms)."""
+
+    def test_required_structure_count_matches_template(self):
+        for layer in registry_layers():
+            artifact = layer["artifact"]
+            skill = PLUGIN_SKILLS / f"doc-{artifact.lower()}" / "SKILL.md"
+            template = FRAMEWORK / layer["folder"] / layer["template"]
+            with self.subTest(layer=artifact):
+                self.assertTrue(skill.is_file(), f"missing {skill}")
+                self.assertTrue(template.is_file(), f"missing {template}")
+                skill_count = _required_structure_count(skill)
+                self.assertIsNotNone(
+                    skill_count,
+                    f"{skill.name} is missing a `### Required structure (N …)` heading",
+                )
+                template_count = _template_numbered_count(template)
+                self.assertEqual(
+                    skill_count,
+                    template_count,
+                    f"{skill.name} declares {skill_count} sections but "
+                    f"{template.name} numbers {template_count} via "
+                    "`# Section N:` comments — the template is the source of "
+                    "truth (D-0013)",
+                )
+
+    def test_required_structure_section_list_uses_only_template_keys(self):
+        for layer in registry_layers():
+            artifact = layer["artifact"]
+            skill = PLUGIN_SKILLS / f"doc-{artifact.lower()}" / "SKILL.md"
+            template = FRAMEWORK / layer["folder"] / layer["template"]
+            with self.subTest(layer=artifact):
+                block = _required_structure_block(skill)
+                titles = _skill_section_titles(block)
+                template_keys = {_normalise(k) for k in _template_sections(template).keys()}
+                # Heuristic: a non-phantom title must share at least one
+                # significant token with **some** template key (treating each
+                # template key as a single normalised string for substring
+                # comparison). Genuine phantoms (e.g. "User Stories" in a BRD
+                # whose template has no `user_stories` key) share no token
+                # with any key.
+                phantoms = []
+                for title in titles:
+                    tokens = [
+                        _normalise(t) for t in title.split() if t and t.lower() not in _STOPWORDS
+                    ]
+                    if not tokens:
+                        continue
+                    if any(any(tok and tok in key for tok in tokens) for key in template_keys):
+                        continue
+                    phantoms.append(title)
+                self.assertFalse(
+                    phantoms,
+                    f"{skill.name} section list contains titles with no "
+                    f"matching template key: {phantoms}. The template is the "
+                    "source of truth — remove phantom sections from the skill"
+                    " or add them to the template.",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Close the confabulation hole that produced the *"compact 10-section vs 15-section enterprise template"* rationalisation when `/aidoc-flow:doc-flow` met the url-shortener example: `doc-flow` and every `doc-<layer>-audit` skill now load the layer's `*-TEMPLATE.yaml` and enumerate required sections from it, with an explicit ban on rationalising drift as a "compact" / "walkthrough" / "lint-pinned" variant.
- Realign three creation skills with their templates (D-0013 — template is canonical): `doc-brd` had 5 phantom sections (User Stories, Implementation Approach, Support & Maintenance, Cost-Benefit, Quality Assurance) that did not exist in `BRD-TEMPLATE.yaml`; `doc-ears` and `doc-adr` renumbered with `document_control` as Section 1 per the PRD-style convention.
- New conformance test (`tests/conformance/platforms/test_skill_template_alignment.py`) prevents the whole drift class from recurring.

## What changed

| Bug | Where | Fix |
|---|---|---|
| **B2** doc-flow rationalises drift as a "compact format" | `doc-flow/SKILL.md` | Added a mandatory **Template-conformance check** step under "Where am I" + a written ban on the confabulation patterns |
| **B2+** doc-`<layer>`-audit skills had no instruction to load the template | 8× `doc-*-audit/SKILL.md` | Added a **Template-conformance enumeration (mandatory first step)** block to every audit skill, naming its template file by name |
| **B4** audit skills declared hard-coded counts that drift from the template | 8× `doc-*-audit/SKILL.md` | Replaced "all N template sections" with "every section enumerated above" — single source of truth |
| **B5** doc-brd lists 18 sections, template defines 15 (+ 5 phantoms) | `doc-brd/SKILL.md`, plus stale `§7.2`/`§3.6`/`§3.7` cross-refs in `doc-brd-autopilot`, `doc-prd`, `doc-adr`, `doc-adr-autopilot` | Replaced section list with the template's actual 15 numbered sections + diagrams registry + appendix backmatter. Remapped "§7.2 ADR Requirements" → "§8 adr_topics" everywhere. Dropped non-existent §3.6/§3.7 cross-refs |
| **B6** doc-ears renumbers from `1. Purpose`, dropping doc_control | `doc-ears/SKILL.md` | Renumbered so `document_control` is Section 1 (PRD convention); glossary is required backmatter |
| **B7** doc-adr renumbers from `1. Context`, dropping doc_control | `doc-adr/SKILL.md` | Renumbered so `document_control` is Section 1; glossary + appendix are required backmatter |
| **B3** no test caught the drift | `tests/conformance/platforms/test_skill_template_alignment.py` | 4 new checks per layer: enumeration block present, no hard-coded count, `Required structure (N)` matches `# Section N:` count, section list uses template-derived vocabulary |

## Out of scope (intentionally)

- The url-shortener demo example (`examples/url-shortener/docs/`) is **not** touched — the user will re-author it with the fixed plugin.
- The "all N sections" prose in creation-skill *Creation Process* steps (e.g. `doc-bdd:129`, `doc-prd:138`) currently matches the template counts; left as-is to keep the PR scoped.

## Test plan

- [x] `python3 -m unittest discover tests/conformance` — 70/70 pass (4 new checks included)
- [x] `PYTHONPATH=platforms/claude-code-plugin python3 -m sdd_doc_lint examples/url-shortener/docs` — clean
- [x] Pre-commit hooks (ruff, bandit, markdownlint, detect-secrets, conformance suite) pass on the commit
- [ ] After merge: re-run `/aidoc-flow:doc-flow` against the url-shortener example — drift should be reported as a finding, not rationalised