### PR TITLE
chore(plugin): polish marketplace + plugin manifests for pre-1.0 preview

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,6 @@
 {
   "name": "aidoc-flow-framework",
+  "description": "BYO marketplace hosting the aidoc-flow Claude Code plugin (pre-1.0 preview). Spec-driven development for the 8-layer doc flow (BRD → IPLAN).",
   "owner": {
     "name": "vladm3105",
     "email": "vla.myakota@gmail.com"
@@ -8,7 +9,7 @@
     {
       "name": "aidoc-flow",
       "source": "./platforms/claude-code-plugin",
-      "description": "AI-Driven Specification-Driven Development (SDD) workflow — 50 active skills + 2 deprecated stubs (52 total), 11 agents, and 1 command for the 8-layer doc flow (BRD → IPLAN). Consumes the engine-agnostic aidoc-flow framework spec.",
+      "description": "Pre-1.0 preview. AI-Driven Specification-Driven Development (SDD) workflow — 50 active skills + 2 deprecated stubs (52 total), 11 agents, and 1 command for the 8-layer doc flow (BRD → IPLAN). Consumes the engine-agnostic aidoc-flow framework spec. APIs and surfaces may change before 1.0.",
       "version": "0.4.0"
     }
   ]

--- a/platforms/claude-code-plugin/.claude-plugin/plugin.json
+++ b/platforms/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "aidoc-flow",
-  "description": "AI-Driven Specification-Driven Development (SDD) workflow — skills, agents, and commands for the 8-layer doc flow (BRD → IPLAN). Consumes the aidoc-flow framework spec.",
+  "description": "Pre-1.0 preview. AI-Driven Specification-Driven Development (SDD) workflow — skills, agents, and commands for the 8-layer doc flow (BRD → IPLAN). Consumes the aidoc-flow framework spec. APIs and surfaces may change before 1.0.",
   "version": "0.4.0",
   "author": {
     "name": "AI Doc Flow",
@@ -10,6 +10,6 @@
   },
   "license": "MIT",
   "repository": "https://github.com/vladm3105/aidoc-flow-framework",
-  "homepage": "https://aidoc-flow.com/claude-code",
+  "homepage": "https://github.com/vladm3105/aidoc-flow-framework#install-the-claude-code-plugin",
   "keywords": ["sdd", "spec-driven-development", "documentation", "brd", "prd", "ears", "bdd", "adr", "iplan"]
 }


### PR DESCRIPTION
## Summary

Three small manifest polish items so the BYO marketplace presents cleanly to first-install users.

## Changes

1. **`marketplace.json` gains a top-level `description`** — discoverability in `/plugin marketplace list` and any aggregator UIs.
2. **Both descriptions prefixed with \"Pre-1.0 preview.\"** + explicit \"APIs and surfaces may change before 1.0\" note — sets correct expectations for early installers.
3. **`plugin.json:homepage` fixed** — was placeholder `https://aidoc-flow.com/claude-code` (not yet live); now points at `https://github.com/vladm3105/aidoc-flow-framework#install-the-claude-code-plugin` (working anchor in README, verified).

## Scope

2 files, 4 insertions / 3 deletions. No code, no skills, no tests, no version bump. Plugin functional surface unchanged.

## Test plan

- [x] `claude plugin validate platforms/claude-code-plugin --strict` — passes
- [x] `tests/conformance` — 91/91 OK (unchanged)
- [x] `tests/packaging` — 5/5 OK (unchanged)
- [x] `tests/release` — 8/8 OK (unchanged)
- [x] `tests/conformance/platforms/test_plugin_release_metadata.py` — 13/13 OK (marketplace plugins[0].name and version unchanged; description not asserted)
- [x] JSON syntactically valid (both files parse cleanly)
- [x] README anchor `#install-the-claude-code-plugin` matches actual heading at line 34

## What this does NOT change

- Plugin VERSION (still 0.4.0)
- Framework spec VERSION (still 0.11.0)
- Any skill, agent, or command
- Bundle layout / install command (still `vladm3105/aidoc-flow-framework` + `aidoc-flow@aidoc-flow-framework`)