### PR TITLE
docs: comprehensive cleanup — 23 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 > Scope: this is the **project-level** changelog tracking the multi-platform
 > migration. Once scaffolded, each platform keeps its own changelog at
 > `platforms/<name>/CHANGELOG.md`, and `framework/` versions independently.
+>
+> This file logs both project releases (`v1.x.y`) and framework-spec releases (`Framework Spec 0.x.y`). Per-stream details for the Claude Code plugin live in [`platforms/claude-code-plugin/CHANGELOG.md`](platforms/claude-code-plugin/CHANGELOG.md).
 
 ## [Unreleased]
 
@@ -236,7 +238,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   hand-fixed genuine findings) so `pre-commit run --all-files` is green; the stale
   `ucx_hermes` placeholder config was replaced.
 
-## [0.11.0] — 2026-05-31
+## [0.11.0] — Framework Spec — 2026-05-31
 
 ### Added
 
@@ -253,6 +255,9 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - 5 stale skills bumped to align with framework spec.
+- Plugin (`claude-code-plugin/v0.4.0`) ships a consolidated canonical skill set: **52 skills = 50 active + 2 deprecated stubs**. Hard-deleted 3 redundant skills (`context-analyzer`, `skill-recommender`, `workflow-optimizer`) — folded into `doc-flow`. Deprecated 2 skills (`doc-review`, `trace-check`) — retained as redirect stubs until v0.5.0, folded into `doc-validator`.
+- Plugin marketplace + manifest metadata updated for pre-1.0 preview posture (see `platforms/claude-code-plugin/CHANGELOG.md`).
+- IPLAN ↔ iplanic integration explicitly deferred — see [`plans/IPLAN-IPLANIC-DEFERRED.md`](plans/IPLAN-IPLANIC-DEFERRED.md).
 
 ## [1.1.0] — 2026-05-24
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,8 @@ The platforms share the `framework/` spec and nothing else. Both pass the same
 shared conformance suite (`tests/conformance/`). The `framework/` spec defines
 the 8-layer SDD flow (BRD → PRD → EARS → BDD → ADR → SPEC → TDD → IPLAN → Code).
 
+**Current state (as of 2026-06-01):** framework spec `0.11.0`, Claude Code plugin `0.4.0` (pre-1.0 preview, 52 skills = 50 active + 2 deprecated stubs). IPLAN ↔ iplanic integration deferred — see `plans/IPLAN-IPLANIC-DEFERRED.md`.
+
 ## Durable conventions
 
 - **The framework spec is the contract.** Engine-agnostic; carries no platform

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing to AI Doc Flow Framework
+
+Thanks for considering a contribution. This project follows a conformance-gated workflow: every PR must pass the conformance test suite and the relevant platform tests.
+
+## Quick start
+
+```bash
+git clone https://github.com/vladm3105/aidoc-flow-framework
+cd aidoc-flow-framework
+pip install pre-commit && pre-commit install
+```
+
+## Project layout
+
+See [`docs/REPO_STRUCTURE.md`](docs/REPO_STRUCTURE.md) for the full layout. The two surfaces:
+
+- `framework/` — engine-agnostic SDD specification (the contract).
+- `platforms/` — platform implementations (Hermes MCP server, Claude Code plugin).
+
+## Before you push
+
+```bash
+# Conformance (framework spec invariants)
+cd tests/conformance && python3 -m unittest discover -q
+
+# Unit + per-layer + packaging + release (all tiers)
+cd .. && python3 -m unittest discover -s unit -q
+python3 -m unittest discover -s acceptance/deterministic -q
+python3 -m unittest discover -s packaging -q
+python3 -m unittest discover -s release -q
+```
+
+## How to add a test, a skill, a lint check
+
+See [`tests/CONTRIBUTING.md`](tests/CONTRIBUTING.md) (test-suite contribution guidance).
+
+## How to add a governance file or change a framework spec section
+
+The framework spec is GATE-SPEC governed. Any change under `framework/` (the spec subtree) requires bumping `framework/VERSION` and going through the conformance suite. See [`docs/PROJECT.md`](docs/PROJECT.md) §6 (Change Management).
+
+## Reporting bugs and security issues
+
+- Functional bugs: <https://github.com/vladm3105/aidoc-flow-framework/issues>
+- Security vulnerabilities: see [`SECURITY.md`](SECURITY.md) for the disclosure protocol.
+
+## License
+
+MIT (see [`LICENSE`](LICENSE)).

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ From Claude Code:
 
 The migration is complete (cutover shipped as `v1.0.0`); the project is now in
 **post-cutover development** — latest project release `v1.1.0`, framework spec
-`0.11.0`. Post-v1.0 work to date: the project adaptation overlay, the
+`0.11.0`. The Claude Code plugin (`platforms/claude-code-plugin/`) is currently a **pre-1.0 preview** (v0.4.0); APIs and surfaces may change before 1.0. The framework spec is stable at `0.11.0`. Post-v1.0 work to date: the project adaptation overlay, the
 GATE-SPEC change-management gate (`framework/governance/chg/`), the
 authoring-style/spec quality updates through framework `0.11.0`, and the
 pre-commit + CI security tooling (CodeQL, bandit, detect-secrets, pip-audit,
@@ -72,6 +72,7 @@ for the vulnerability-reporting policy.
 - `docs/TAGGING.md` — git-tag policy (release + bookmark tags).
 - `docs/PARITY.md` — Hermes ↔ plugin capability comparison.
 - `framework/README.md` — the engine-agnostic SDD specification.
+- [`docs/STARTUP_HANDOFF.md`](docs/STARTUP_HANDOFF.md) — historical session brief from the Phase-3/4 migration period.
 
 ## Pre-migration history
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -104,8 +104,7 @@ Delivered after the cutover (project release `v1.1.0`; framework spec `0.1.0 →
 0.3.1`):
 
 - **Canonical plugin skill set** — the corpus was pruned/recreated to one
-  standard (P3-T6/T7) and grew to **54 skills** with the CHG family,
-  `gate-check`, `project-adopt`, `project-profile`, and `knowledge-extractor`.
+  standard (P3-T6/T7) and settled at **52 skills (50 active + 2 deprecated stubs)** in plugin v0.4.0, after `skill-recommender`/`workflow-optimizer`/`context-analyzer` folded into `doc-flow` and `doc-review`/`trace-check` were folded into `doc-validator` (the latter two retained as deprecation redirects through v0.5.0).
 - **Project adaptation overlay** (ADAPT, D-0019) — `framework/governance/
   ADAPTATION.md` + `ADAPTATION_SURFACE.yaml` (a closed knob set) and the
   `project-profile` / `knowledge-extractor` skills.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ plus two platforms). Security fixes are applied to the latest release line.
 | Component | Supported |
 |-----------|-----------|
 | Latest project release (`v1.x`) | ✅ |
-| `framework/` spec — latest (`0.3.x`) | ✅ |
+| `framework/` spec — latest (`0.11.x`) | ✅ |
 | Platforms — latest tagged release | ✅ |
 | Older / pre-cutover (`< v1.0`, archive branch) | ❌ |
 

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -7,10 +7,7 @@ shape on each side.
 
 > Status: as of project `v1.1.0` / `hermes/v0.1.1` /
 > `claude-code-plugin/v0.4.0` (framework spec `0.11.0`; both platforms on the
-> 8-layer model; plugin skill set is the canonical 52 (50 active + 2 deprecated)
-> — 32 layer-family skills, 4 CHG skills, 14 utilities, and 2 deprecated
-> redirect stubs (`doc-review`, `trace-check`) scheduled for removal in
-> `v0.5.0`). Updates land when a platform ships a structurally different
+> 8-layer model; plugin skill set is the canonical 52 = 32 layer-family + 4 CHG + 14 utilities + 2 deprecated redirect stubs (`doc-review`, `trace-check`, scheduled for removal in `v0.5.0`)). Updates land when a platform ships a structurally different
 > capability, not per-PR.
 
 Both platforms pass the shared conformance suite at
@@ -174,7 +171,7 @@ structurally identical report.
   registration block in the manifest.
 - **Slash-prefix invocation** — `/aidoc-flow:doc-brd-autopilot`,
   `/aidoc-flow:doc-flow`, etc.
-- **AI Team subagent roster** (9 agents in `agents/`) — a specialist
+- **AI Team subagent roster** (11 agents in `agents/` — 9 lifecycle + 2 review lenses) — a specialist
   team mirroring the SDD lifecycle: `pm-orchestrator` (delegates via
   the `Task` tool) plus the spec lane (`requirements-analyst`,
   `solutions-architect`, `test-architect`), execution lane

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -102,9 +102,7 @@ Post-migration, the gated CHG process returns in two roles:
 2. **Feature** — the CHG overlay ships inside `framework/governance/` as a
    capability both platforms expose to their end users.
 
-Per-platform internal development continues under ordinary SemVer + changelog
-
-- PR review — the gated process is not applied to a platform's own commits.
+Per-platform internal development continues under ordinary SemVer + changelog; PR review applies, the gated process is not.
 
 ### CHG implementation model (implemented — CHG-D1, D-0020)
 

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -59,6 +59,8 @@ aidoc-flow-framework/
 │   ├── conformance/                 Shared suite both platforms must pass
 │   └── chg/                         GATE-SPEC diff-aware guard (spec_gate.py)
 │
+├── tools/                 # sync-plugin-framework.sh, build-plugin-mirror.sh, sdd_doc_lint/
+├── examples/              # url-shortener/ end-to-end demo chain (BRD → IPLAN)
 └── plans/                           Migration record: per-task plans, DECISIONS.md, HANDOFF.md, …
 ```
 

--- a/docs/STARTUP_HANDOFF.md
+++ b/docs/STARTUP_HANDOFF.md
@@ -1,5 +1,7 @@
 # Startup Handoff — AI Doc Flow Framework (extracted from migration session)
 
+> **Historical artifact:** written 2026-05-20 during Phase 3/4. Captures the business/product hypothesis at that point. Current project state lives in [`../ROADMAP.md`](../ROADMAP.md) and [`../CHANGELOG.md`](../CHANGELOG.md). Plugin state lives in [`../platforms/claude-code-plugin/CHANGELOG.md`](../platforms/claude-code-plugin/CHANGELOG.md).
+>
 > **Purpose:** Distill the business / startup ideas that surfaced during a
 > multi-phase technical-migration session into a self-contained brief a
 > fresh session can pick up. The migration itself is *evidence and proof-

--- a/platforms/claude-code-plugin/.claude-plugin/plugin.json
+++ b/platforms/claude-code-plugin/.claude-plugin/plugin.json
@@ -5,8 +5,7 @@
   "version": "0.4.0",
   "author": {
     "name": "AI Doc Flow",
-    "email": "plugins@aidoc-flow.com",
-    "url": "https://aidoc-flow.com"
+    "url": "https://github.com/vladm3105/aidoc-flow-framework"
   },
   "license": "MIT",
   "repository": "https://github.com/vladm3105/aidoc-flow-framework",

--- a/platforms/claude-code-plugin/CHANGELOG.md
+++ b/platforms/claude-code-plugin/CHANGELOG.md
@@ -22,12 +22,20 @@ this platform adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `${CLAUDE_PLUGIN_ROOT}/framework/…` reference — read it via the shell (where the
   variable expands) or relative to the plugin root. Proactively de-risks the P2
   live-run / install smoke test (plan risk R2).
+- Manifest metadata polished for pre-1.0 preview (PR #44). Plugin description and marketplace description prefixed "Pre-1.0 preview." with explicit "APIs and surfaces may change before 1.0" note.
+- Plugin manifest `homepage` repointed from placeholder `https://aidoc-flow.com/claude-code` to the working install-section anchor at `https://github.com/vladm3105/aidoc-flow-framework#install-the-claude-code-plugin`.
+- Plugin manifest `author` cleaned up: dropped non-resolving `aidoc-flow.com` email + url; left `name` and added GitHub repo URL.
+- Framework spec dependency bumped to `0.11.0` (was `0.10.0`).
+
+### Documentation
+
+- IPLAN ↔ iplanic integration explicitly deferred — see framework `plans/IPLAN-IPLANIC-DEFERRED.md`.
 
 ## [0.4.0] — 2026-05-27
 
 ### Changed
 
-- **Skill set consolidated 55 → 50 (redundancy audit).** Folded five
+- **Skill set consolidated 55 → 50 active (+ 2 deprecated stubs = 52 total, redundancy audit).** Folded five
   overlapping utilities into two homes, carrying their procedural detail:
   - `skill-recommender` + `workflow-optimizer` + `context-analyzer` → **`doc-flow`**,
     which now carries the intent-keyword → skill map, the `where am I` position
@@ -74,6 +82,8 @@ this platform adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `aidoc-flow.com` identity and `homepage` to `https://aidoc-flow.com/claude-code`
   (**D-0023** — one brand, path-based per-integration pages). Publish-time URL +
   mailbox verification is the P2 gate.
+
+  > Note: in `v0.4.0` the homepage was repointed to <https://github.com/vladm3105/aidoc-flow-framework#install-the-claude-code-plugin> until the aidoc-flow.com identity is live.
 - **Review-team mode (AGENT-TEAM Phase 2)** — a shared `review-team` skill plus
   two review-lens agents (`adversary`, `synthesizer`): the plugin's binding of the
   engine-agnostic `framework/governance/REVIEW_TEAM.md` model. The crew fans out as

--- a/platforms/claude-code-plugin/README.md
+++ b/platforms/claude-code-plugin/README.md
@@ -1,5 +1,7 @@
 # aidoc-flow — Claude Code plugin
 
+> **Status: Pre-1.0 preview.** APIs and surfaces may change before 1.0.
+
 The native **Claude Code** delivery of the AI Doc Flow framework: a
 Specification-Driven Development (SDD) engine that drives a project from a
 Business Requirements Document down to an implementation plan through eight
@@ -31,9 +33,7 @@ Published through the repo-root marketplace manifest
 ```
 
 Work down the layers (`doc-prd`, `doc-ears`, … `doc-iplan`), running each
-layer's `-audit` before promoting to the next. A complete, gate-clean example
-chain — initial requirements through to an IPLAN — lives in
-[`../../examples/url-shortener/`](../../examples/url-shortener/).
+layer's `-audit` before promoting to the next. A worked example chain — initial requirements through to an IPLAN — lives in [`../../examples/url-shortener/`](../../examples/url-shortener/). (Note: this corpus predates the STRUCT01 lint check and currently emits structural findings; a regeneration is planned for v0.5.0.)
 
 `doc-flow` is the orchestrator: describe your goal and it routes you to the
 right skill. The deeper authoring guidance is in
@@ -49,7 +49,7 @@ right skill. The deeper authoring guidance is in
 | Agents | 11 | AI Team specialist roster — `requirements-analyst`, `pm-orchestrator`, `solutions-architect`, `test-architect`, `software-engineer`, `devops-release-engineer`, `code-reviewer`, `security-engineer`, `traceability-auditor`, plus the two review-team lenses `adversary` and `synthesizer`. See `docs/AGENTS.md`. |
 | Commands | 1 | `/aidoc-flow:save-plan` — capture the current conversation plan to a timestamped file. |
 | Hooks | 1 | `hooks/sdd-doc-review.sh` — a `PostToolUse` advisory nudge (see below). |
-| **Total skills** | **50** | |
+| **Total skills** | **52** (50 active + 2 deprecated stubs scheduled for removal in v0.5.0) | |
 
 The plugin auto-registers everything via Claude Code's directory
 conventions (`skills/`, `agents/`, `commands/`); no per-skill enumeration in
@@ -126,3 +126,18 @@ engine; pick Hermes if you want an MCP server.
 
 Both platforms pass the same shared conformance suite at
 `../../tests/conformance/`.
+
+## Contributing
+
+Hooks and workflow live in the framework repo. From the repo root:
+
+```bash
+pip install pre-commit && pre-commit install
+```
+
+Open issues and pull requests at <https://github.com/vladm3105/aidoc-flow-framework/issues>.
+
+## Reporting bugs and security issues
+
+- Functional bugs: file an issue at <https://github.com/vladm3105/aidoc-flow-framework/issues>.
+- Security vulnerabilities: see [`../../SECURITY.md`](../../SECURITY.md) for the disclosure protocol.

--- a/platforms/claude-code-plugin/docs/AGENTS.md
+++ b/platforms/claude-code-plugin/docs/AGENTS.md
@@ -2,7 +2,7 @@
 
 **Specialist Claude Code subagents for the AI Doc Flow Framework's Specification-Driven Development (SDD) flow.**
 
-This directory defines a team of nine specialist Claude Code subagents that mirror the SDD lifecycle. They are the **Claude Code plugin's** native team: each agent owns a function and orchestrates the relevant plugin `doc-*` skills. Agents auto-register via Claude Code's `agents/` directory convention.
+This directory defines a team of nine lifecycle subagents plus two review-team lenses (eleven agent files total) that mirror the SDD lifecycle. They are the **Claude Code plugin's** native team: each agent owns a function and orchestrates the relevant plugin `doc-*` skills. Agents auto-register via Claude Code's `agents/` directory convention.
 
 > This framework is "one specification, two platforms." This roster is the Claude Code plugin's native team, driving the lifecycle through the plugin's `doc-*` skills. The framework's separate MCP-server platform implements the same spec independently; both satisfy the same conformance suite.
 

--- a/platforms/claude-code-plugin/docs/SKILL_AUTHORING.md
+++ b/platforms/claude-code-plugin/docs/SKILL_AUTHORING.md
@@ -5,7 +5,7 @@ plugin. It is the single pattern the skill set is recreated against (P3-T6).
 The framework spec is the source of truth for *content*; this file governs
 *form*.
 
-## 1. Scope — the canonical skill set (50)
+## 1. Scope — the canonical skill set (52 = 50 active + 2 deprecated stubs)
 
 - **Layer families (8 × 4 = 32):** `doc-{brd,prd,ears,bdd,adr,spec,tdd,iplan}`
   in four variants — base (`doc-X`), `-autopilot`, `-audit`, `-fixer`.
@@ -18,9 +18,11 @@ The framework spec is the source of truth for *content*; this file governs
 Removed and **never reintroduced**: `-reviewer`/`-validator` variants (merged
 into `-audit`); test-type families (utest/itest/ftest/ptest/stest/sectest);
 SPEC-subtype families (cspec/dspec/uxspec/riskspec/procspec); contract-tester,
-test-automation, mermaid-gen; loose `*.md` files at `skills/` root. The
-navigation helpers `skill-recommender`/`workflow-optimizer`/`context-analyzer`
-folded into `doc-flow`; `trace-check` + `doc-review` folded into `doc-validator`.
+test-automation, mermaid-gen; loose `*.md` files at `skills/` root.
+
+Hard-deleted in v0.4.0 (will not exist under `skills/`): the navigation helpers `skill-recommender`, `workflow-optimizer`, `context-analyzer` — folded into `doc-flow`.
+
+Deprecated in v0.4.0 but still ship as redirect stubs under `skills/` (marked `deprecated: true`, scheduled for hard removal in v0.5.0): `doc-review`, `trace-check` — folded into `doc-validator` (scope=prose and traceability pass respectively).
 
 ## 2. Frontmatter (mandatory)
 


### PR DESCRIPTION
## Summary

Resolves 23 documentation drift findings from a comprehensive review. Doc-only PR (no version bumps, no code/skill changes).

## Fixes by file

- [x] **`platforms/claude-code-plugin/README.md`** (4 fixes): pre-1.0 preview banner under H1; "Total skills" row corrected 50 → 52 (50 active + 2 deprecated stubs); Quickstart `gate-clean` claim refined; new "Contributing" + "Reporting bugs" sections at end.
- [x] **`README.md`** (framework root, 2 fixes): pre-1.0 preview note in Status section; `STARTUP_HANDOFF.md` added to Documentation list.
- [x] **`SECURITY.md`** (1 fix): supported framework spec `0.3.x` → `0.11.x` (was 8 minor versions stale).
- [x] **`ROADMAP.md`** (1 fix): "54 skills" → "52 skills (50 active + 2 deprecated stubs)" with deletion vs deprecation explanation.
- [x] **`platforms/claude-code-plugin/docs/SKILL_AUTHORING.md`** (2 fixes): canonical set "(50)" → "(52 = 50 active + 2 deprecated stubs)"; distinguished hard-deleted from deprecated stubs.
- [x] **`CHANGELOG.md`** (2 fixes): `[0.11.0]` entry relabeled with "Framework Spec" stream marker; added preamble blockquote explaining mixed project/spec streams and pointing at plugin CHANGELOG; appended v0.4.0 plugin work bullets (52-skill consolidation, manifest polish, IPLAN/iplanic deferral).
- [x] **`platforms/claude-code-plugin/.claude-plugin/plugin.json`** (1 fix): dropped non-resolving `aidoc-flow.com` email + url placeholders from author; kept `name` and added GitHub repo URL.
- [x] **`docs/PARITY.md`** (2 fixes): agent count "(9 agents)" → "(11 agents — 9 lifecycle + 2 review lenses)"; tightened 52-skill breakdown wording.
- [x] **`platforms/claude-code-plugin/CHANGELOG.md`** (3 fixes): [Unreleased] now reflects PR #42/#44 work (manifest polish, homepage repoint, author cleanup, framework spec bump); [0.4.0] header notes "52 total"; [0.3.0] notes homepage repoint in v0.4.0.
- [x] **`platforms/claude-code-plugin/docs/AGENTS.md`** (1 fix): "nine specialist subagents" → "nine lifecycle subagents plus two review-team lenses (eleven agent files total)".
- [x] **`docs/STARTUP_HANDOFF.md`** (1 fix): added historical artifact banner pointing at current ROADMAP/CHANGELOG.
- [x] **`docs/PROJECT.md`** (1 fix): merged stray "PR review" bullet fragment back into the prior sentence.
- [x] **`docs/REPO_STRUCTURE.md`** (1 fix): repo tree now lists `tools/` and `examples/`.
- [x] **`CLAUDE.md`** (1 fix): added "Current state (as of 2026-06-01)" block in "What this project is".
- [x] **`CONTRIBUTING.md`** (new): minimal but functional Contributing guide referenced by README/CHANGELOG.

## Notes

- The CHANGELOG `[0.11.0]` entry header retains the matchable `[0.11.0]` prefix to keep `tests/release/test_changelog_entry.py` green, while adding the "Framework Spec" stream marker.

## Verification

- [x] `python3 -c "import json; json.load(open(...plugin.json)); json.load(open(...marketplace.json))"` — both validate
- [x] `claude plugin validate platforms/claude-code-plugin --strict` — passes
- [x] `tests/conformance/`: 91 tests OK
- [x] `tests/packaging/`: 5 tests OK
- [x] `tests/release/`: 8 tests OK
- [x] `tests/unit/`: 15 tests OK
- [x] `tests/acceptance/deterministic/`: 53 tests OK
- [x] Pre-commit hooks pass (via `env -u LD_LIBRARY_PATH`)

## Test plan

- [ ] CI green on all platforms (conformance + plugin + Hermes + CodeQL + pre-commit).
- [ ] markdownlint clean.