### PR TITLE
docs(README): add framework description block under H1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,32 @@
 # AI Doc Flow Framework
 
-A specification-driven document-flow framework for AI-assisted software
-development, delivered as **one engine-agnostic specification with two
-independent platforms**.
+**AI Doc Flow Framework** is a structured workflow for
+**Specification-Driven Development (SDD)** with AI coding assistants. It
+guides a project through an 8-layer documentation chain — from business
+intent down to executable implementation plans — so AI tools read, audit,
+and act on a verifiable spec rather than ad-hoc prompts.
+
+```text
+BRD  →  PRD  →  EARS  →  BDD  →  ADR  →  SPEC  →  TDD  →  IPLAN  →  Code
+business  product  formal  executable  decision  component  test    impl
+intent    reqs     reqs    scenarios   record    contract   suite   plan
+```
+
+Each layer has its own template, contract, and quality gate. The framework
+owns the engine-agnostic specification; two independent platforms (Hermes
+MCP server, Claude Code plugin) each implement it. Both pass the same
+conformance suite.
+
+**What you get:**
+
+- Templates + schemas for every layer.
+- Cumulative `@upstream:` traceability tags from BRD all the way to code.
+- Deterministic lint (`sdd_doc_lint`) for structural correctness.
+- Conformance-tested outputs across both platforms.
+
+**Use it when** you want AI-assisted development backed by a verifiable
+specification trail, not ad-hoc prompts that produce inconsistent or
+hard-to-audit output.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

Fixes a first-impression bug: visitors landing on https://github.com/vladm3105/aidoc-flow-framework saw only a 2-sentence intro ("delivered as one engine-agnostic specification with two independent platforms") with no explanation of WHAT AI Doc Flow Framework is or WHY you'd use it.

## What this PR adds (right under the H1)

- **One-paragraph value statement.** Frames SDD with AI coding assistants vs ad-hoc prompts.
- **8-layer flow visualization** in a code block:
  ```
  BRD → PRD → EARS → BDD → ADR → SPEC → TDD → IPLAN → Code
  ```
  with one-word per-layer labels (business intent → product reqs → formal reqs → executable scenarios → decision record → component contract → test suite → impl plan).
- **"What you get"** bulleted list: templates + schemas per layer · cumulative `@upstream:` traceability tags · `sdd_doc_lint` deterministic structural lint · conformance-tested outputs.
- **"Use it when"** qualifier to set expectations.

## Scope

1 file (`README.md`), +30 / -5 lines. No code, no skills, no version bump, no tests affected.

## What this PR does NOT change

Existing `## Architecture`, `## Platforms`, `## Status`, `## Contributing`, `## Documentation`, `## Pre-migration history` sections — all untouched. The new block sits between the H1 and the existing `## Architecture` heading.

## Test plan

- [x] markdown renders correctly (verified locally)
- [x] No tests reference the README content the description block replaces
- [x] Pre-commit hooks pass via `env -u LD_LIBRARY_PATH`