### PR TITLE
feat(tests): --promote algorithm + README + CHANGELOG (Impl-5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,6 +218,52 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **Pre-deployment acceptance test suite** — new
+  `tests/scripts/test-acceptance.sh` (~1500 lines) drives every active
+  plugin surface element (50 skills + 11 agents + 1 command + 1 hook =
+  63 total) against a named example's seed; the produced chain is the
+  release-gate evidence that the plugin works end-to-end.
+
+  Driver structure (per
+  [`examples/url-shortener/ACCEPTANCE_TEST_PLAN.md`](examples/url-shortener/ACCEPTANCE_TEST_PLAN.md)):
+  Phase 0 (bootstrap + preflight: manifest validate, lint smoke, state
+  detection, API auth) → Phase 1.1 (happy-path BRD→IPLAN cascade with
+  autopilot + audit + optional fixer + lint per layer) → Phase 1.2
+  (6-fixture negative validation at
+  `tests/acceptance/fixtures/negative/`) → Phase 2 (CHG cycle driven by
+  per-example `chg/test-change.md`) → Phase 3 (14 utility probes with
+  minimum-coverage thresholds preventing empty-output false-PASS) →
+  Phase 4 (11 agents + `/aidoc-flow:save-plan` command + deterministic
+  `hooks/sdd-doc-review.sh` test).
+
+  Per-run log layout under `examples/<NAME>/logs/<TS>/` with
+  human-readable `summary.txt`, machine-readable `summary.json`
+  validating against
+  `tests/scripts/test-acceptance.schema.json` (v1.0), and per-element
+  `.log` + `.meta.json` under `bootstrap/`, `skills/`, `agents/`,
+  `command/`, `hook/`, `cascade/`, `negative/`, `sandbox/`.
+
+  `--mock=<run-dir>` replays a prior recorded run without LLM cost for
+  script-development iteration. `--promote` archives the previous
+  `examples/<NAME>/docs/` to `docs-archive/v<X.Y.Z>/` and replaces it
+  with the freshly-produced cascade output; `--push` pushes the promote
+  commit. 45-minute hard wall-clock cap. Token cost per `--live` run:
+  ~$11–20.
+
+  First example: `examples/url-shortener/` with seed at
+  `seed/initial-requirements.md` and CHG change-set at
+  `chg/test-change.md` (visit-rate analytics dashboard).
+
+  Six shared negative fixtures at `tests/acceptance/fixtures/negative/`
+  exercise structural-defect detection: missing required sections
+  (STRUCT01), malformed trace-tags (ID01), non-existent upstream refs,
+  low audit-score content, missing required diagrams, broken chain
+  traces. 4 of 6 verifiable deterministically; 2 require live LLM.
+
+  Companion parent-repo PR wires `release.yml` to invoke the acceptance
+  suite on tag push with `actions/upload-artifact@v4` and raises the
+  `T4L` token-ledger ceiling from 500K to 1M.
+
 - **Token-efficient authoring governance** — new
   `framework/governance/AUTHORING_STYLE.md` canonicalises the writing voice
   the SDD corpus expects: elimination list (benefit statements, efficiency

--- a/examples/url-shortener/README.md
+++ b/examples/url-shortener/README.md
@@ -1,57 +1,121 @@
-# Plugin flow walkthrough — URL shortener (seed only)
+# url-shortener — pre-deployment acceptance example
 
-This example currently carries **only the seed prompt**
-([`seed/initial-requirements.md`](seed/initial-requirements.md)) — the input
-to the 8-layer SDD flow.
+This directory is the **release-gate acceptance test** for the
+aidoc-flow Claude Code plugin. The seed at
+[`seed/initial-requirements.md`](seed/initial-requirements.md) is driven
+through every plugin surface element — 63 total: 50 skills, 11 agents,
+one command, one hook — and the chain produced under `docs/` is the
+evidence that the plugin works end-to-end.
 
-The previous worked output chain (`docs/01_BRD/` through `docs/08_IPLAN/`)
-was authored before the current `STRUCT01` lint and the v0.4.0 skill
-consolidation; it has been cleared. The new demo chain will be authored
-from a Claude Code session by driving the seed through every
-`doc-{layer}-autopilot` skill against the current templates, then
-committed under `docs/` once it passes both `sdd_doc_lint` and each
-layer's `-audit` quality gate.
+The acceptance suite is described in detail in
+[`ACCEPTANCE_TEST_PLAN.md`](ACCEPTANCE_TEST_PLAN.md). This README is
+the user-facing summary.
 
-The test-suite live tier (`LIVE=1 bash tests/scripts/test-plugin.sh
---suite=fullpath --live`) exercises the same end-to-end path for
-**regression validation** — it asserts the autopilot skills can produce a
-structurally-conformant chain — but its outputs are test-instrumented
-(staged fixtures, per-layer assertions) and are **not** suitable as
-production demo content. The demo lives under `examples/`; the live tier
-runs in ephemeral test workspaces.
-
-## How to drive the seed through the 8-layer flow yourself
-
-From a Claude Code session with the plugin installed:
+## Directory layout
 
 ```text
-/aidoc-flow:doc-brd-autopilot from examples/url-shortener/seed/initial-requirements.md
+url-shortener/
+├── ACCEPTANCE_TEST_PLAN.md       # design reference (do not edit casually)
+├── README.md                     # this file
+├── seed/
+│   └── initial-requirements.md   # the acceptance-test input
+├── chg/
+│   └── test-change.md            # change-set exercised by Phase 2
+├── docs/                         # latest release-gate cascade output
+│                                 # (populated by --promote; see below)
+├── docs-archive/                 # historical cascades, one dir per release
+│   └── v<X.Y.Z>/                 # archived by --promote before overwriting docs/
+└── logs/<TS>/                    # ephemeral per-run logs (gitignored)
+    ├── plugin-test.log
+    ├── summary.{txt,json}
+    ├── skills/, agents/, command/, hook/, cascade/, negative/, sandbox/
+    └── …
 ```
 
-Then continue layer-by-layer with `doc-prd-autopilot`, `doc-ears-autopilot`,
-…, `doc-iplan-autopilot`. Each layer gates with its `-audit` skill and the
-deterministic structural validator (`sdd_doc_lint`).
+## Running the suite
 
-## Re-run the deterministic gate (after you've authored a chain)
+From the framework root:
 
 ```bash
-PYTHONPATH=platforms/claude-code-plugin python3 -m sdd_doc_lint examples/url-shortener/docs
-# exit 0 = no error-level findings
+# Full deterministic + live run (release gate). ~$11–20 in token cost.
+LIVE=1 bash tests/scripts/test-acceptance.sh url-shortener --live
+
+# Live run that also promotes the cascade output to docs/ on success.
+LIVE=1 bash tests/scripts/test-acceptance.sh url-shortener --live --promote
+
+# Promote AND push to origin in one step (CI / release-tag automation).
+LIVE=1 bash tests/scripts/test-acceptance.sh url-shortener --live --promote --push
+
+# Cheap deterministic-only smoke (no LLM cost; ~5 seconds).
+bash tests/scripts/test-acceptance.sh url-shortener --no-live
+
+# Replay a recorded run for free script-development iteration.
+bash tests/scripts/test-acceptance.sh url-shortener --mock=logs/<TS>
 ```
 
-## What this demonstrates (once regenerated)
+Outcomes:
 
-- The full **8-layer chain** for one feature set (shorten a URL, redirect,
-  count clicks — see scope in the seed file).
-- **Cumulative traceability**: each downstream layer carries `@brd … @tdd`
-  tags referencing real upstream element IDs (4-segment `TYPE.NN.SS.xxxx`).
-- The **C4 + DFD + sequence diagram** model per layer
++ **PASS** — all 63 surface elements produced gate-meeting output.
++ **FAIL** — at least one element produced sub-threshold output or
+  errored. Inspect `logs/<TS>/summary.txt` for the per-element table
+  and `logs/<TS>/<subdir>/<name>.log` for the failing element's raw
+  output.
+
+## What `docs/` contains
+
+After a `--promote`-flagged run, `docs/` holds the 8-layer chain
+(`01_BRD/` through `08_IPLAN/`, plus `09_CHG/` if Phase 2 ran)
+produced by driving the seed through every `doc-<layer>-autopilot`
+skill. A `.version` marker records which plugin release the chain
+came from.
+
+Before the first cascade lands, `docs/` is empty — the suite operates
+in bootstrap mode (Phase 0 detects this and skips chain-dependent
+checks until the first cascade produces content).
+
+## What `docs-archive/` contains
+
+`--promote` archives the previous `docs/` content to
+`docs-archive/v<previous-version>/` before overwriting. Archived
+chains are never deleted — they're the regression baseline for
+skill-drift tracking (per plan §3.2 retention policy: pre-1.0 keep
+every archive uncompressed; post-1.0 compress beyond the 5 most recent
+if `docs-archive/` exceeds 5 MB).
+
+## What gets exercised — quick reference
+
+| Phase | Surface elements | Count |
+|------:|---|---:|
+| 0 — Bootstrap | manifest validate + lint smoke + state detection | (infra) |
+| 1.1 — Cascade | `doc-{brd…iplan}-{base,autopilot,audit,fixer}` | 32 |
+| 1.2 — Negative validation | 6 shared fixtures at `tests/acceptance/fixtures/negative/` | (assertions, not skills) |
+| 2 — CHG | `doc-chg`, `doc-chg-{autopilot,audit,fixer}` | 4 |
+| 3 — Utilities | `doc-flow`, `doc-validator`, …, `project-profile` | 14 |
+| 4 — Agents + command + hook | 11 agents + `/aidoc-flow:save-plan` + `hooks/sdd-doc-review.sh` | 13 |
+| **Total surface elements** | | **63** |
+
+See [`ACCEPTANCE_TEST_PLAN.md`](ACCEPTANCE_TEST_PLAN.md) §7 + §8 for the
+per-skill minimum-coverage thresholds that prevent empty-output
+false-PASS.
+
+## What this proves
+
+A passing `--live` run demonstrates:
+
++ The full **8-layer chain** authoring works end-to-end from a seed.
++ **Cumulative traceability**: each downstream layer carries
+  `@brd … @tdd` tags referencing real upstream element IDs (4-segment
+  `TYPE.NN.SS.xxxx`).
++ The **C4 + DFD + sequence diagram** contract per layer
   (`framework/governance/DIAGRAM_STANDARDS.md`): BRD `c4-l1`/`dfd-l1`,
-  PRD `c4-l2`/`dfd-l2`/`sequence`, ADR decision `sequence`,
-  SPEC `c4-l3`/`dfd-l3`.
+  PRD `c4-l2`/`dfd-l2`/`sequence`, ADR decision `sequence`, SPEC
+  `c4-l3`/`dfd-l3`.
++ Every utility, agent, command, and hook produces gate-meeting output
+  against the produced chain.
 
-> The plugin has no runtime — its skills are LLM instructions — so the
-> output chain is authored by following the skills, and the
-> **deterministic gate** is `sdd_doc_lint`. The semantic readiness score
-> (≥90) is the LLM `-audit` skill's judgment, noted per document and not
-> machine-checked.
+## Adding a second example
+
+`payment-gateway`, `multi-tenant`, etc. follow the same shape — copy
+this directory's structure (just `seed/` and `chg/`), run
+`bash tests/scripts/test-acceptance.sh <NEW-NAME> --live`. No script
+changes required. See `ACCEPTANCE_TEST_PLAN.md` §12 for the procedure.

--- a/tests/scripts/test-acceptance.sh
+++ b/tests/scripts/test-acceptance.sh
@@ -1238,6 +1238,145 @@ phase_4_hook() {
 }
 
 # -----------------------------------------------------------------------------
+# --promote algorithm
+# -----------------------------------------------------------------------------
+# Per plan §3.2. Promotes logs/<TS>/cascade/ to examples/<NAME>/docs/ when
+# all phases passed.
+#
+# Steps:
+#   1. Resolve version from platforms/claude-code-plugin/VERSION
+#   2. Refuse if working tree has uncommitted changes
+#   3. Refuse if examples/<NAME>/docs/ has uncommitted changes
+#   4. Archive existing docs/ to docs-archive/v<previous-version>/ (if non-empty)
+#   5. rsync -a --delete logs/<TS>/cascade/ → examples/<NAME>/docs/
+#   6. Commit: chore(examples): promote <example> cascade for v<X.Y.Z>
+#   7. Push only if --push was also passed
+
+_overall_outcome() {
+  # Echo PASS|FAIL|SKIP based on in-memory outcome state
+  local name fail_n=0 pass_n=0
+  for name in "${ELEMENT_ORDER[@]}"; do
+    case "${OUTCOME_BY_NAME[$name]}" in
+      PASS) pass_n=$((pass_n + 1)) ;;
+      FAIL) fail_n=$((fail_n + 1)) ;;
+    esac
+  done
+  if (( fail_n > 0 )); then
+    echo "FAIL"
+  elif (( pass_n == 0 )); then
+    echo "SKIP"
+  else
+    echo "PASS"
+  fi
+}
+
+promote_cascade() {
+  section "Promote — cascade → examples/<NAME>/docs/"
+
+  local outcome
+  outcome="$(_overall_outcome)"
+  if [[ "$outcome" != "PASS" ]]; then
+    log_err "overall outcome is $outcome; refusing to promote a non-PASS run"
+    return 1
+  fi
+
+  local cascade_src="$LOG_DIR/cascade"
+  if [[ ! -d "$cascade_src" ]] || [[ -z "$(find "$cascade_src" -name '*.md' -print -quit 2>/dev/null)" ]]; then
+    log_err "no cascade output to promote: $cascade_src"
+    return 1
+  fi
+
+  # Step 1 — version
+  local plugin_version_file="$PLUGIN_DIR/VERSION"
+  if [[ ! -f "$plugin_version_file" ]]; then
+    log_err "VERSION file missing: $plugin_version_file"
+    return 1
+  fi
+  local plugin_version
+  plugin_version="$(cat "$plugin_version_file" | tr -d '[:space:]')"
+  log_info "plugin version: $plugin_version"
+
+  # Step 2 — working tree clean
+  if ! git -C "$FRAMEWORK" diff-index --quiet HEAD 2>/dev/null; then
+    log_err "framework working tree has uncommitted changes; refusing to promote"
+    log_err "  (commit or stash, then re-run with --promote)"
+    return 1
+  fi
+  log_info "✓ working tree clean"
+
+  # Step 3 — docs/ has no uncommitted changes (redundant with step 2 but explicit)
+  if ! git -C "$FRAMEWORK" diff-index --quiet HEAD -- "examples/$EXAMPLE/docs" 2>/dev/null; then
+    log_err "examples/$EXAMPLE/docs has uncommitted changes; refusing to promote"
+    return 1
+  fi
+
+  # Step 4 — archive existing docs/ (if non-empty)
+  local archive_root="$EXAMPLE_DIR/docs-archive"
+  if [[ -d "$EXAMPLE_DOCS" ]] && [[ -n "$(find "$EXAMPLE_DOCS" -name '*.md' -print -quit 2>/dev/null)" ]]; then
+    # Previous version: read the last committed VERSION at the time the
+    # docs/ was promoted. For first-time we cannot know exactly, so use
+    # the current plugin_version as the archive key — but only if it
+    # differs from the run's version. If they match, skip archive (the
+    # docs/ already represents this version's cascade).
+    #
+    # Heuristic: if a marker file exists at examples/<NAME>/docs/.version,
+    # use it. Otherwise use plugin_version.
+    local prev_version="$plugin_version"
+    if [[ -f "$EXAMPLE_DOCS/.version" ]]; then
+      prev_version="$(cat "$EXAMPLE_DOCS/.version" | tr -d '[:space:]')"
+    fi
+    local archive_dir="$archive_root/v$prev_version"
+    if [[ -d "$archive_dir" ]]; then
+      log_err "archive dir already exists: $archive_dir (refusing to overwrite history)"
+      return 1
+    fi
+    mkdir -p "$archive_dir"
+    log_info "archiving existing docs/ → $archive_dir"
+    rsync -a "$EXAMPLE_DOCS/" "$archive_dir/"
+  else
+    log_info "first-time bootstrap: no existing docs/ to archive"
+  fi
+
+  # Step 5 — copy cascade into docs/
+  log_info "promoting cascade → $EXAMPLE_DOCS"
+  rm -rf "$EXAMPLE_DOCS"
+  mkdir -p "$EXAMPLE_DOCS"
+  rsync -a --delete "$cascade_src/" "$EXAMPLE_DOCS/"
+  echo "$plugin_version" > "$EXAMPLE_DOCS/.version"
+
+  # Step 6 — commit
+  log_info "committing promoted chain"
+  git -C "$FRAMEWORK" add "examples/$EXAMPLE/docs" "examples/$EXAMPLE/docs-archive" 2>/dev/null || true
+  if git -C "$FRAMEWORK" diff --cached --quiet; then
+    log_info "no changes to commit (promoted content identical to previous)"
+  else
+    git -C "$FRAMEWORK" commit -m "chore(examples): promote $EXAMPLE cascade for v$plugin_version release
+
+Run: $LOG_TIMESTAMP
+Outcome: $outcome
+Source: $cascade_src" || {
+      log_err "commit failed"
+      return 1
+    }
+    log_info "✓ committed promoted chain"
+  fi
+
+  # Step 7 — push if requested
+  if (( PUSH == 1 )); then
+    log_info "pushing to origin"
+    git -C "$FRAMEWORK" push || {
+      log_err "push failed"
+      return 1
+    }
+    log_info "✓ pushed"
+  else
+    log_info "skipping push (use --push to push)"
+  fi
+
+  return 0
+}
+
+# -----------------------------------------------------------------------------
 # Summary writers
 # -----------------------------------------------------------------------------
 write_summary() {
@@ -1400,6 +1539,18 @@ done
 # Final summary
 write_summary
 RC=$?
+
+# Promote (if requested and run passed)
+if (( PROMOTE == 1 )); then
+  if (( RC != 0 )); then
+    log_err "--promote requested but overall run is FAIL; skipping promote"
+  else
+    promote_cascade || {
+      log_err "promote failed"
+      RC=1
+    }
+  fi
+fi
 
 # Cleanup: log final runtime
 END_EPOCH="$(date +%s)"


### PR DESCRIPTION
## Summary

Final framework-side PR in the acceptance-suite staged series. Builds on [#56 (Impl-4)](https://github.com/vladm3105/aidoc-flow-framework/pull/56).

Lands the `--promote` algorithm, the user-facing README rewrite, and the consolidated CHANGELOG entry covering the entire Impl-1..Impl-5 series.

## Staging plan recap

| # | What lands | Status |
|---:|---|:---:|
| Impl-1 #53 | Foundation + Phase 0 + Phase 1.1 + schemas + `--mock` | merged |
| Impl-2 #54 | Phase 1.2 negative + fixtures + CHG cycle | merged |
| Impl-3 #55 | Phase 3 — 14 utility probes | merged |
| Impl-4 #56 | Phase 4 — 11 agents + command + hook | merged |
| **Impl-5** | **`--promote` + README + CHANGELOG** | **this PR** |

## What's in this PR

**3 files, +304 -43 lines.**

### `--promote` algorithm (plan §3.2)

7-step procedure in `promote_cascade()`:

1. Resolve version from `platforms/claude-code-plugin/VERSION`
2. Refuse if working tree has uncommitted changes
3. Refuse if `examples/<NAME>/docs/` has uncommitted changes
4. Archive existing `docs/` to `docs-archive/v<previous-version>/` — reads from `docs/.version` marker, falls back to current plugin version. Refuses to overwrite an existing archive (preserves history)
5. `rsync -a --delete logs/<TS>/cascade/` → `examples/<NAME>/docs/`; writes `.version` marker
6. Commit: `chore(examples): promote <example> cascade for v<X.Y.Z>`
7. Push only if `--push` was also passed

Refused unless overall run outcome is PASS and cascade output exists.

### `examples/url-shortener/README.md` rewrite

Reframed from "seed-only walkthrough" to **pre-deployment acceptance gate**. Documents:

- Directory layout (`seed/`, `chg/`, `docs/`, `docs-archive/`, `logs/`)
- Four invocation modes (`--live`, `--live --promote`, `--live --promote --push`, `--no-live`, `--mock`)
- 63-element quick reference table by phase
- Retention policy (pre-1.0 keep uncompressed; post-1.0 compress beyond 5 most recent)
- Procedure for adding a second example

### `CHANGELOG.md` `[Unreleased] → Added`

One consolidated entry summarizing the whole acceptance-suite series. References driver script, schema, log layout, `--mock` + `--promote`, per-run dir keying, the 6 shared negative fixtures, url-shortener seed + CHG, and the parent-repo companion that wires `release.yml`.

## Verification

```text
$ bash tests/scripts/test-acceptance.sh url-shortener --no-live
Outcome: PASS (6 PASS, 0 FAIL, 43 SKIP, 49 total)

$ bash tests/scripts/test-acceptance.sh url-shortener --no-live --promote
Outcome: PASS; promote refused with "no cascade output to promote"
(correct — --no-live SKIPs the cascade so there's nothing to copy)
```

Pre-commit hooks all pass (markdownlint auto-fixed a list-bullet style; conformance suite passes).

## What's deferred to follow-up steps

After this PR merges, two remaining items complete the acceptance suite:

1. **Parent-repo companion PR**: updates `.github/workflows/release.yml` to invoke `bash framework/tests/scripts/test-acceptance.sh url-shortener --live --promote --push` on tag push, adds `actions/upload-artifact@v4` for the per-run log dir on failure, raises `T4L` token-ledger ceiling from 500K to 1M. Also bumps framework submodule.

2. **First live cascade run**: held back from this PR so the foundation merges cleanly without waiting on a multi-minute live run. Token cost ~$11–20. Kick off with:

   ```bash
   ANTHROPIC_API_KEY=... \
     bash framework/tests/scripts/test-acceptance.sh url-shortener --live --promote
   ```

   This populates `examples/url-shortener/docs/` for the first time (bootstrap path).

## Test plan

- [x] Pre-commit passes
- [x] `--no-live` smoke run still PASSes (6 PASS, 49 total)
- [x] `--promote` correctly refuses without a cascade output to promote
- [x] `--promote` correctly refuses if overall outcome != PASS (covered by `_overall_outcome()` guard)
- [ ] `--live --promote` end-to-end exercise — the first cascade is the runtime artifact