### PR TITLE
docs: reflect acceptance suite + .aidoc/ provenance tier in top-level docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,23 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- **Acceptance methodology consolidated into permanent docs.** The
+  example-scoped `examples/url-shortener/ACCEPTANCE_TEST_PLAN.md`
+  (733 lines) was split into framework-wide permanent locations so
+  future examples (`payment-gateway`, etc.) reuse a single source of
+  methodology truth: [`tests/ACCEPTANCE.md`](tests/ACCEPTANCE.md) —
+  the engine-agnostic methodology (driver, log layout, schema,
+  `--promote` algorithm, phase definitions, design decisions, cost
+  ballpark, CI integration); [`plans/ACCEPTANCE-SUITE-HISTORY.md`](plans/ACCEPTANCE-SUITE-HISTORY.md)
+  — per-PR implementation timeline + v1→v4 plan evolution + lessons
+  learned; and a thin
+  [`examples/url-shortener/README.md`](examples/url-shortener/README.md)
+  (~120 lines) covering only what is unique about that seed. Adding a
+  sibling example is now just `seed/` + `chg/` + a ~50-line README
+  pointing at the methodology — no duplication of phase definitions,
+  schema docs, or design decisions. Framework spec **0.11.1 → 0.11.2**
+  (patch) covers the engine-agnostic doc-link relocations (see
+  immediately below).
 - Framework spec **0.11.1 → 0.11.2** (patch) — doc-only refs in
   `framework/README.md` and `framework/docs/AIDOC.md` updated to
   point at `tests/ACCEPTANCE.md` (relocated from
@@ -230,6 +247,25 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **Acceptance suite: resume + partial-execution support.** The driver
+  (`tests/scripts/test-acceptance.sh`) now survives long-running
+  interruptions and supports targeted re-runs without re-spending the
+  full $15–25 of a cascade. **Resume** (R1–R6): SIGINT/TERM trap saves
+  an incremental `summary.json` and marks in-flight elements
+  `INTERRUPTED`; `RUNNING` stubs distinguish in-progress from
+  PASS/FAIL/SKIP; `--skip-completed=<path>` resumes against a prior
+  run's summary, replaying only `FAIL` / `INTERRUPTED` / `RUNNING`
+  elements; schema bumped v1.1 → v1.2 to add the `RUNNING` and
+  `INTERRUPTED` outcomes. **Partial execution** (P1–P5): `--element=<name>`
+  runs a single named element (skill, agent, command, or hook);
+  `--from-layer=<N>` / `--to-layer=<N>` constrain the cascade range
+  (e.g. *"generate only the PRD against the existing BRD"*); `--dry-run`
+  previews which elements would invoke without spending tokens;
+  `--cost-cap=<USD>` halts the run when the running token estimate
+  reaches the cap. The companion `summary.json` is the single source of
+  truth — `_should_invoke()` consults it before every skill call, so a
+  resumed or partial run re-uses prior-PASS outputs as upstream inputs
+  for downstream layers.
 - **`.aidoc/` — third committed documentation tier formalized.** Per
   every project, four tiers now: inputs (`seed/`, `chg/`, committed),
   outputs (`docs/`, committed), provenance (`.aidoc/`, committed),

--- a/README.md
+++ b/README.md
@@ -69,11 +69,16 @@ From Claude Code:
 
 The migration is complete (cutover shipped as `v1.0.0`); the project is now in
 **post-cutover development** — latest project release `v1.1.0`, framework spec
-`0.11.0`. The Claude Code plugin (`platforms/claude-code-plugin/`) is currently a **pre-1.0 preview** (v0.4.0); APIs and surfaces may change before 1.0. The framework spec is stable at `0.11.0`. Post-v1.0 work to date: the project adaptation overlay, the
-GATE-SPEC change-management gate (`framework/governance/chg/`), the
-authoring-style/spec quality updates through framework `0.11.0`, and the
-pre-commit + CI security tooling (CodeQL, bandit, detect-secrets, pip-audit,
-Dependabot).
+`0.11.2`. The Claude Code plugin (`platforms/claude-code-plugin/`) is currently a **pre-1.0 preview** (v0.4.0); APIs and surfaces may change before 1.0. The framework spec is stable at `0.11.2`. Post-v1.0 work to date:
+
+- the project adaptation overlay (`framework/governance/ADAPTATION.md` + the closed-knob `ADAPTATION_SURFACE.yaml`);
+- the **GATE-SPEC** change-management gate (`framework/governance/chg/`);
+- the **review-team** model (multi-persona crews + scoring/conflict policy — `framework/governance/REVIEW_TEAM.md` / `REVIEW_CREWS.yaml`);
+- the **C4 + DFD + sequence** diagram standards (`framework/governance/DIAGRAM_STANDARDS.md`);
+- the **token-efficient authoring** governance (`framework/governance/AUTHORING_STYLE.md`) wired into every layer's `_size_target` and into every audit skill;
+- the **`.aidoc/` provenance tier** — committed audit/review/remediation/validation/security/quality reports (`framework/docs/AIDOC.md`);
+- the **pre-deployment acceptance test suite** (`tests/scripts/test-acceptance.sh` + [`tests/ACCEPTANCE.md`](tests/ACCEPTANCE.md)) that drives every active plugin surface element (50 skills + 11 agents + 1 command + 1 hook) against a named example's seed as the release gate, with resume on interrupt, partial-execution flags (`--element`, `--from-layer`, `--to-layer`, `--dry-run`), and `--promote` to commit the produced chain;
+- pre-commit + CI security tooling (CodeQL, bandit, detect-secrets, pip-audit, gitleaks, Dependabot).
 
 ## Contributing
 
@@ -96,6 +101,10 @@ for the vulnerability-reporting policy.
 - `docs/TAGGING.md` — git-tag policy (release + bookmark tags).
 - `docs/PARITY.md` — Hermes ↔ plugin capability comparison.
 - `framework/README.md` — the engine-agnostic SDD specification.
+- [`framework/docs/AIDOC.md`](framework/docs/AIDOC.md) — the `.aidoc/` provenance tier (third committed documentation tier).
+- [`tests/ACCEPTANCE.md`](tests/ACCEPTANCE.md) — pre-deployment acceptance-test methodology (driver, log layout, schema, `--promote`, phase definitions, partial-execution flags, CI integration).
+- [`tests/README.md`](tests/README.md) — tiered test-suite navigation hub.
+- [`plans/ACCEPTANCE-SUITE-HISTORY.md`](plans/ACCEPTANCE-SUITE-HISTORY.md) — per-PR implementation timeline + design evolution + lessons learned for the acceptance suite.
 - [`docs/STARTUP_HANDOFF.md`](docs/STARTUP_HANDOFF.md) — historical session brief from the Phase-3/4 migration period.
 
 ## Pre-migration history

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -101,7 +101,7 @@ Change Management for the full policy.
 ## Post-v1.0 — Shipped
 
 Delivered after the cutover (project release `v1.1.0`; framework spec `0.1.0 →
-0.3.1`):
+0.11.2`):
 
 - **Canonical plugin skill set** — the corpus was pruned/recreated to one
   standard (P3-T6/T7) and settled at **52 skills (50 active + 2 deprecated stubs)** in plugin v0.4.0, after `skill-recommender`/`workflow-optimizer`/`context-analyzer` folded into `doc-flow` and `doc-review`/`trace-check` were folded into `doc-validator` (the latter two retained as deprecation redirects through v0.5.0).
@@ -111,8 +111,14 @@ Delivered after the cutover (project release `v1.1.0`; framework spec `0.1.0 →
 - **Change management returned** (CHG-D1/D2 above) — **GATE-SPEC**, the
   framework-spec change gate, enforced by skills + CI + branch protection;
   recorded as **GD-01** in `framework/governance/DECISIONS.md`.
+- **Review-team model** (framework `0.8.0`) — `framework/governance/REVIEW_TEAM.md` defines the multi-persona review crews, the hub blackboard, the deterministic weighted/capped scoring + conflict policy with the structural gate as a reproducible floor, and the create/review/remediate shapes; `REVIEW_CREWS.yaml` declares the per-layer crews + weights. `ADAPTATION_SURFACE.yaml` gains the `review_mode` knob (`team`|`single_pass`).
+- **C4 + DFD + sequence diagram standards** (framework `0.8.1`) — `framework/governance/DIAGRAM_STANDARDS.md` is the authority for per-layer diagrams: BRD c4-l1/dfd-l1, PRD c4-l2/dfd-l2/sequence, ADR decision sequence (now required, not optional), SPEC c4-l3/dfd-l3. Both platforms' review and creation agents wired to the standard.
+- **Token-efficient authoring governance** (framework `0.9.0` → `0.10.0`) — `framework/governance/AUTHORING_STYLE.md` canonicalises the elimination list, form enforcement, form-preference order, and per-section size targets; promoted to canonical via `DOC_GOVERNANCE_CORE.md` principle 7. Every section in every layer template (76 sections) gains a `_size_target` key; `sdd_doc_lint` STY02 reads the per-section target instead of a flat default. Wired into every `doc-<layer>` (creation) and `doc-<layer>-audit` skill.
+- **`.aidoc/` provenance tier** (framework `0.11.1`) — `framework/docs/AIDOC.md` formalises a third committed documentation tier per project: audit, review consensus, remediation, validation, security, and quality reports — the AI's working notes that answer *"how did the AI arrive at the output in `docs/`?"* without a re-run. Four-tier layout: `seed/`+`chg/` (inputs), `docs/` (outputs), `.aidoc/` (provenance), `logs/<TS>/` (tool internals, gitignored).
+- **Pre-deployment acceptance test suite** — `tests/scripts/test-acceptance.sh` drives every active plugin surface element (50 skills + 11 agents + 1 command + 1 hook = 63 total) against a named example's seed as the release gate. Methodology lives at `tests/ACCEPTANCE.md` (engine-agnostic, applies to any future example). Driver supports `--mock`/`--no-live`/`--dry-run`/`--live`, `--promote` (archives prior chain to `docs-archive/v<X.Y.Z>/` and commits the freshly-produced chain), `--push`, resume on SIGINT/TERM with incremental `summary.json` + RUNNING stubs, partial execution via `--element=<name>` / `--from-layer=<N>` / `--to-layer=<N>`, retry-on-transient-HTTP, per-skill timeout, per-layer runtime cap, `--cost-cap=<USD>`, and `--skip-completed=<path>`. Schema v1.2 (`tests/scripts/test-acceptance.schema.json`) covers the combined summary + per-element shape. First seed: `examples/url-shortener/` (URL-shortener service + visit-rate analytics dashboard CHG). Adding a sibling example is a `seed/` + `chg/` + thin README — no script changes. Wired into `release.yml` on tag push.
+- **Test runners co-located under `tests/scripts/`** — `test-plugin.sh`, `test-layer.sh`, `test-fullpath.sh`, `test-acceptance.sh` all live inside the framework; the framework is fully self-testable with no parent-repo dependency.
 - **Pre-commit + security tooling** — `.pre-commit-config.yaml` (ruff, bandit,
-  markdownlint, yamllint, detect-secrets, pip-audit, conformance) and CI
+  markdownlint, yamllint, detect-secrets, **gitleaks**, pip-audit, conformance) and CI
   workflows for pre-commit, **CodeQL**, and the GATE-SPEC gate; `SECURITY.md`;
   refreshed `.github/` metadata (CODEOWNERS, dependabot, labeler — INFRA-1).
 


### PR DESCRIPTION
## Summary

Bring the project's top-level docs in sync with the acceptance suite + `.aidoc/` provenance work that landed across PRs #51, #53, #55, #57, #59, #60, #61, #62, #63, and #64.

All edits are project-level (`README.md`, `CHANGELOG.md`, `ROADMAP.md`); **no `framework/**` content was touched, so GATE-SPEC does not apply**. The framework spec stays at `0.11.2`.

### README.md

- Bump framework-spec mention from `0.11.0` to `0.11.2`.
- Expand the "Post-v1.0 work to date" summary from 4 items to 9 — adding **review-team** model, **C4+DFD+sequence** diagram standards, **token-efficient authoring** governance, **`.aidoc/` provenance tier**, and the **pre-deployment acceptance test suite**.
- Documentation section gains pointers to `framework/docs/AIDOC.md`, `tests/ACCEPTANCE.md`, `tests/README.md`, and `plans/ACCEPTANCE-SUITE-HISTORY.md`.

### ROADMAP.md

Extend the "Post-v1.0 — Shipped" section with five new entries:

- Review-team model (framework `0.8.0`)
- C4+DFD+sequence diagram standards (framework `0.8.1`)
- Token-efficient authoring governance (framework `0.9.0 → 0.10.0`)
- `.aidoc/` provenance tier (framework `0.11.1`)
- Pre-deployment acceptance test suite with full flag inventory
- Test-runner co-location under `tests/scripts/`

Spec range updated to `0.1.0 → 0.11.2`.

### CHANGELOG.md

Two new `[Unreleased]` entries, merged into the existing `Changed` and `Added` subsections (no MD024 duplicate headings):

- **Added — acceptance suite resume + partial-execution support** (PR #62): SIGINT/TERM trap, RUNNING/INTERRUPTED schema v1.2, `--skip-completed`, `--element` / `--from-layer` / `--to-layer` / `--dry-run` / `--cost-cap`.
- **Changed — methodology consolidated into permanent docs** (PR #64): `examples/url-shortener/ACCEPTANCE_TEST_PLAN.md` (733 lines) split into `tests/ACCEPTANCE.md` + `plans/ACCEPTANCE-SUITE-HISTORY.md` + thin example README so future sibling examples reuse one source of methodology truth.

## Test plan

- [x] Pre-commit (whitespace, EOF, markdownlint, secrets, conformance) green locally against all three files.
- [x] CHANGELOG.md `[Unreleased]` section verified to have exactly one each of `### Fixed`, `### Changed`, `### Added` — no MD024 violations.
- [x] Remote pushed content verified byte-identical to local commit `49f61940` via `git diff` (zero output).
- [ ] CI on the PR remains green (conformance + pre-commit).