### PR TITLE
feat(acceptance): consolidate --dry-run + --no-live into single behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,17 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- **Acceptance suite: `--dry-run` and `--no-live` consolidated into a
+  single behaviour.** The two modes overlapped on Phase 0 preflight
+  (manifest validate, profile check, fixtures presence) — running
+  both back-to-back wasted a Phase 0 pass. `--no-live` now prints the
+  planned-execution summary (phases, cost cap, timeouts, live status)
+  at the top of every run, *then* continues into the full
+  deterministic suite (negative fixtures + hook). `--dry-run` is kept
+  as a clean alias of `--no-live` (the conventional name is widely
+  expected). One mode is now sufficient for both "preview before
+  spending" and "verify deterministic infrastructure" — strictly more
+  coverage than the old `--dry-run` (which exited after Phase 0).
 - **Acceptance methodology consolidated into permanent docs.** The
   example-scoped `examples/url-shortener/ACCEPTANCE_TEST_PLAN.md`
   (733 lines) was split into framework-wide permanent locations so

--- a/examples/url-shortener/README.md
+++ b/examples/url-shortener/README.md
@@ -92,11 +92,10 @@ Quick reference; for the full flag inventory see
 ```bash
 cd framework
 
-# Smoke (no LLM cost, ~5s)
+# Smoke + plan preview (no LLM cost, ~9s).
+# Prints the planned execution at the top, then runs the deterministic
+# phases. LLM-dependent elements record SKIP. `--dry-run` is an alias.
 bash tests/scripts/test-acceptance.sh url-shortener --no-live
-
-# Preview before spending
-bash tests/scripts/test-acceptance.sh url-shortener --dry-run
 
 # Full live run (60-120 min, ~$15-25)
 bash tests/scripts/test-acceptance.sh url-shortener --live

--- a/tests/ACCEPTANCE.md
+++ b/tests/ACCEPTANCE.md
@@ -57,11 +57,11 @@ tracked as Phase B work).
 # Full live run against a named example
 bash tests/scripts/test-acceptance.sh <example> --live
 
-# Cheap deterministic smoke (~5s, no LLM)
+# Cheap deterministic smoke (~9s, no LLM). Prints the planned execution
+# at the top, then runs the deterministic phases (Phase 0 preflight,
+# negative fixtures, hook). LLM-dependent elements record SKIP.
+# `--dry-run` is a clean alias.
 bash tests/scripts/test-acceptance.sh <example> --no-live
-
-# Preview the planned execution without spending tokens
-bash tests/scripts/test-acceptance.sh <example> --dry-run
 
 # Generate a single element only (e.g. only the PRD against existing BRD)
 bash tests/scripts/test-acceptance.sh <example> --live --element=doc-prd-autopilot
@@ -382,7 +382,7 @@ This is the only Phase-4 check that runs in `--no-live` mode.
 | `--from-layer=<name>` | Resume cascade from named layer; previous layer in `docs/` becomes upstream | Resume after partial cascade aborts |
 | `--to-layer=<name>` | Cascade stops after the named layer | With `--from-layer` gives single-layer-only |
 | `--element=<name>` | Run only the named element; infer phase; resolve upstream | "Generate just the PRD" iteration |
-| `--dry-run` | Prints planned execution table and exits | Preview before spending tokens |
+| `--no-live` / `--dry-run` | Prints the planned-execution summary, then runs the full deterministic suite (Phase 0 preflight + 3 of 6 negative fixtures + hook). Any element requiring LLM records SKIP. `--dry-run` is a clean alias kept for the conventional name. | Preview + infrastructure check before spending tokens |
 | `--force` | Bypass docs/`.aidoc/` unstaged-changes safety belt | Allow intentional overwrites |
 | Per-skill timeout | `SKILL_TIMEOUT=600` default, `REVIEW_TEAM_TIMEOUT=1800`, `AGENT_TIMEOUT=600`; wrapped via `timeout` | Single stuck skill no longer hangs the run |
 | Per-layer runtime cap | `MAX_LAYER_SEC=900` (15 min). Cascade aborts if a layer exceeds | Detects stuck-skill scenarios early |

--- a/tests/scripts/test-acceptance.sh
+++ b/tests/scripts/test-acceptance.sh
@@ -31,7 +31,10 @@
 #   bash tests/scripts/test-acceptance.sh <example-name> [flags]
 #
 #   Flags:
-#     --no-live              skip live LLM calls (Phase 0 only effectively)
+#     --no-live              skip live LLM calls; prints plan summary, then
+#                            runs the full deterministic suite (Phase 0
+#                            preflight + Phase 1.2 negative fixtures that
+#                            don't require LLM + Phase 4.3 hook). ~9s, $0.
 #     --live                 enable live LLM calls (default ON)
 #     --phase=<name>         run one phase: bootstrap | cascade | negative |
 #                            chg | utilities | agents | command | hook
@@ -43,6 +46,7 @@
 #     --force                bypass the "docs/ or .aidoc/ have unstaged
 #                            changes" safety belt
 #     --fail-fast            halt on first failure
+#     --dry-run              alias for --no-live (common convention)
 #     -h | --help            show this usage block
 
 set -uo pipefail
@@ -98,7 +102,8 @@ FORCE=0
 FAIL_FAST=0
 FROM_LAYER=""     # A7 — resume cascade from this layer name (e.g. "spec")
 TO_LAYER=""       # P2 — stop cascade after this layer name
-DRY_RUN=0         # P5 — print planned execution and exit
+# --dry-run is a clean alias of --no-live (both set LIVE_FLAG=0). Kept as
+# a separate flag because the name is conventional in CLI tooling.
 
 usage() {
   sed -n '2,48p' "$0"
@@ -134,7 +139,7 @@ for arg in "$@"; do
     --fail-fast)       FAIL_FAST=1 ;;
     --from-layer=*)    FROM_LAYER="${arg#--from-layer=}" ;;
     --to-layer=*)      TO_LAYER="${arg#--to-layer=}" ;;
-    --dry-run)         DRY_RUN=1; LIVE_FLAG="0" ;;
+    --dry-run)         LIVE_FLAG="0" ;;  # alias for --no-live
     -h|--help)         usage 0 ;;
     *) echo "ERROR: unknown flag: $arg" >&2; usage 2 ;;
   esac
@@ -1794,20 +1799,22 @@ if [[ -n "$ELEMENT" ]]; then
   PHASES_TO_RUN=("$_elem_phase")
 fi
 
-# P5 — Dry-run: print planned execution without invoking anything.
-if (( DRY_RUN == 1 )); then
-  echo
-  echo "=== DRY RUN — planned execution ==="
-  echo "Phases: ${PHASES_TO_RUN[*]}"
-  [[ -n "$ELEMENT" ]] && echo "Element filter: $ELEMENT"
-  [[ -n "$FROM_LAYER" ]] && echo "From layer: $FROM_LAYER"
-  [[ -n "$TO_LAYER" ]] && echo "To layer: $TO_LAYER"
-  echo "Live: $([[ $LIVE_FLAG == 1 ]] && echo yes || echo no)"
-  echo "Cost cap: $MAX_TOTAL_OUTPUT_TOKENS tokens output"
-  echo "Per-skill timeout: ${SKILL_TIMEOUT}s (review-team ${REVIEW_TEAM_TIMEOUT}s, agents ${AGENT_TIMEOUT}s)"
-  echo "(No LLM calls will be made.)"
-  exit 0
+# Plan summary — printed on every run after Phase 0 + planning so the user
+# sees what will execute before the first LLM call (if any) is made.
+echo
+echo "=== Acceptance plan ==="
+echo "Phases: ${PHASES_TO_RUN[*]}"
+[[ -n "$ELEMENT" ]] && echo "Element filter: $ELEMENT"
+[[ -n "$FROM_LAYER" ]] && echo "From layer: $FROM_LAYER"
+[[ -n "$TO_LAYER" ]] && echo "To layer: $TO_LAYER"
+echo "Live: $([[ $LIVE_FLAG == 1 ]] && echo yes || echo no)"
+echo "Cost cap: $MAX_TOTAL_OUTPUT_TOKENS tokens output"
+echo "Per-skill timeout: ${SKILL_TIMEOUT}s (review-team ${REVIEW_TEAM_TIMEOUT}s, agents ${AGENT_TIMEOUT}s)"
+if [[ "$LIVE_FLAG" != "1" ]] && [[ -z "$MOCK_SOURCE" ]]; then
+  echo "(No LLM calls will be made; LLM-dependent elements will SKIP.)"
 fi
+echo "======================="
+echo
 
 for phase_name in "${PHASES_TO_RUN[@]}"; do
   # R4 — bail out of remaining phases if cost cap fired or user


### PR DESCRIPTION
## Summary

`--dry-run` and `--no-live` previously overlapped on Phase 0 preflight (manifest validate, profile check, fixtures presence). Running both back-to-back wasted a Phase 0 pass for users who wanted both "preview the plan" and "verify the deterministic infrastructure." Consolidate them:

- **`--no-live`** now prints the planned-execution summary (phases, cost cap, timeouts, live status) at the top of every run, then continues into the full deterministic suite (Phase 0 + 3 of 6 negative fixtures + hook). Single mode covers preview + infra check.
- **`--dry-run`** is kept as a clean alias of `--no-live` — the conventional CLI name is widely expected, so we retain it without a deprecation warning.

Plan summary appears between Phase 0 and the main phase loop, so users see what will execute before the first LLM call (if any) is made. The `(No LLM calls will be made…)` note is conditional on `LIVE_FLAG=0` and no `--mock`.

## Behaviour change

Old `--dry-run` exited after Phase 0 (~1s). New `--dry-run` matches `--no-live` (~9s) and runs negative fixtures + hook. Net: 8s slower, strictly more coverage. No silent regressions; both produce identical `summary.txt`/`summary.json` with outcome PASS (7 PASS, 0 FAIL, 44 SKIP, 51 total) for the `url-shortener` example.

## Files changed

| File | Change |
|---|---|
| `tests/scripts/test-acceptance.sh` | Hoist plan-summary out of dry-run branch into unconditional pre-loop print. `--dry-run` parsed as `LIVE_FLAG=0` alias. Usage block updated. |
| `tests/ACCEPTANCE.md` | §3 quick-reference drops separate `--dry-run` example. §11 flag table folds both flags into one row. |
| `examples/url-shortener/README.md` | Drops the `--dry-run` example; notes `--dry-run` is an alias. |
| `CHANGELOG.md` | New `[Unreleased] → Changed` entry recording the consolidation. |

No `framework/**` content touched — **GATE-SPEC not applicable**.

## Test plan

- [x] `bash tests/scripts/test-acceptance.sh url-shortener --no-live` → PASS (7/0/44/51) in ~9s, plan summary printed.
- [x] `bash tests/scripts/test-acceptance.sh url-shortener --dry-run` → identical PASS (7/0/44/51) in ~9s, no warning.
- [x] Pre-commit (whitespace, EOF, markdownlint, secrets, conformance) green on all 4 changed files.
- [x] `framework/platform conformance suite` hook PASSED — confirms no framework spec content moved.
- [ ] CI on the PR remains green.