### PR TITLE
fix(acceptance): suppress spurious --from-layer warning for first layer

### DIFF
--- a/tests/scripts/test-acceptance.sh
+++ b/tests/scripts/test-acceptance.sh
@@ -767,14 +767,18 @@ phase_1_cascade() {
   local resume_idx=0
   if [[ -n "$FROM_LAYER" ]]; then
     local idx=0
+    local found=0
     for l in "${LAYERS[@]}"; do
       if [[ "$l" == "$FROM_LAYER" ]]; then
         resume_idx=$idx
+        found=1
         break
       fi
       idx=$((idx + 1))
     done
-    if (( resume_idx > 0 )); then
+    if (( found == 0 )); then
+      log_warn "--from-layer=$FROM_LAYER not found in LAYERS list; running full cascade"
+    elif (( resume_idx > 0 )); then
       local prev_idx=$((resume_idx - 1))
       local prev_layer="${LAYERS[$prev_idx]}"
       local prev_type="${LAYER_TYPES[$prev_idx]}"
@@ -787,7 +791,7 @@ phase_1_cascade() {
       fi
       log_info "--from-layer=$FROM_LAYER (resuming with upstream $prev_output)"
     else
-      log_warn "--from-layer=$FROM_LAYER not found in LAYERS list; running full cascade"
+      log_info "--from-layer=$FROM_LAYER (first layer; no upstream required)"
     fi
   fi
 


### PR DESCRIPTION
## Summary

The `resume_idx=0` check at line 777 was ambiguous: 0 could mean either *first layer (brd) matched* or *layer name not found in LAYERS*. Both paths landed in the same else-branch that warns 'not found in LAYERS list; running full cascade' — misleading users who run `--from-layer=brd --to-layer=brd` to restrict to BRD only.

Fix: track a separate `found` flag alongside `resume_idx`. The warning now fires only when no layer matched; the 'first layer, no upstream required' path gets its own informational log line.

## How it surfaced

During the BRD-only live cascade smoke test:

```bash
bash tests/scripts/test-acceptance.sh url-shortener --live --phase=cascade --from-layer=brd --to-layer=brd
```

The cascade still produced the correct output (BRD only, audit score 96/100) — the bug was warning-only, not behavioural — but the output now matches user expectations.

## Test plan

- [x] Manual: `--from-layer=brd` no longer emits the spurious warning.
- [x] Manual: `--from-layer=spec` still emits the upstream-presence check.
- [x] Pre-commit (whitespace, EOF, conformance) green.
- [ ] CI on the PR remains green.