### PR TITLE
docs(plan): BRD-RT-002 — wire the audit→autopilot verdict chain through the written reports

### DIFF
--- a/plans/BRD-RT-002-VERDICT-CHAIN-PLAN.md
+++ b/plans/BRD-RT-002-VERDICT-CHAIN-PLAN.md
@@ -4,72 +4,101 @@
 |------------|---------------------------------------------|
 | Task       | BRD-RT-002                                  |
 | Depends on | BRD-RT-001 (D-0024, merged), PROFILE-DELTA-001 (D-0025, merged) |
-| Status     | PLANNED — 2026-06-03T17:53:34Z              |
+| Status     | PLANNED — 2026-06-03T17:53:34Z (Pass 3 amendment 2026-06-03T18:25:00Z) |
 | Feeds      | PRD-RT, EARS-RT, BDD-RT, ADR-RT, SPEC-RT, TDD-RT, IPLAN-RT — these per-layer follow-ups inherit the corrected verdict-chain semantics from this PR |
 
 ## Objective
 
-Close five gaps surfaced by the BRD-RT-001 live verification runs
+Close ten gaps surfaced by the BRD-RT-001 live verification runs
 (2026-06-03) so team-mode review produces **the same verdict at every
 consumer** — audit-skill stdout, written audit report, driver script,
 autopilot revise loop — and the per-layer runtime cap stops aborting
 legitimate team-mode runs. After this PR, a team-mode audit that
-computes FAIL actually triggers the fixer; a `single_pass` audit at a
-gate is marked advisory; and a full-cascade team-mode run no longer
-hits the 900-second cap on every layer.
+computes FAIL actually triggers the fixer; the synthesizer writes a
+deterministic `verdict.json` that callers parse instead of scraping
+Markdown prose; a `single_pass` audit is always marked advisory; and a
+full-cascade team-mode run can complete inside its wall-clock and cost
+budgets.
 
 ## Scope
 
 **In:**
 
-- `doc-brd-audit/SKILL.md` — team-mode branch must instruct the model
-  to mirror the synthesizer's deterministic verdict in its stdout
-  response (the skill's "return value"). Today the model echoes the
-  autopilot's self-claim instead.
-- `doc-brd-autopilot/SKILL.md` — the create→review→revise loop must
-  read its PASS/FAIL decision from the *written* audit report at
-  `.aidoc/audit/01_BRD-audit.md` and the synthesizer's
-  `.aidoc/review/01_BRD/<BRD-id>/report.md`, not from the audit
-  subagent's verbal response.
-- `doc-brd-fixer/SKILL.md` — minor confirmation that the fixer consumes
-  the written report + slots (already does in the BRD-RT-001 text;
-  verify and add an assertion if needed).
-- `tests/scripts/test-acceptance.sh` — raise `MAX_LAYER_SEC` from 900 to
-  1800 (mode-agnostic; team-mode legitimately runs ~17-25 min per
-  layer). Optionally also cross-check the captured `audit_score`
-  against the written report file as belt-and-suspenders.
-- `doc-brd-audit/SKILL.md` Combined Report Format — when `review_mode:
-  single_pass` is used at a gate (`pre_promotion`/`pre_merge`), include
-  an explicit **advisory note**: result is informational only;
-  `team` mode is the canonical gate per `REVIEW_TEAM.md`. (Doc-only;
-  doesn't change behavior.)
+- `agents/synthesizer.md` — also write a structured **`verdict.json`**
+  companion next to `report.md` containing
+  `{combined_status, content_score, structural_status, coverage:
+  {expected, ran, quorum_met}, blocking_findings_count, lens_scores:
+  {<lens>: <score>}}`. The Markdown `report.md` stays as the human
+  narrative; downstream consumers parse the JSON.
+- `doc-brd-audit/SKILL.md` (frontmatter line ~18 + new section after
+  `### team mode` at line ~76):
+  - Add `## Output Contract` subsection inside the team-mode branch
+    that reads `verdict.json` and produces stdout in the structured
+    shape below.
+  - In Combined Report Format (line ~193), always include the
+    `single_pass` advisory note whenever `review_mode: single_pass` is
+    the resolved mode — not gated on "at a gate" (the audit skill
+    doesn't reliably know its trigger context).
+- `doc-brd-autopilot/SKILL.md` (Workflow §5 / "Revise" step at line
+  ~94-103) — the create→review→revise loop reads its PASS/FAIL
+  decision from `verdict.json` at
+  `.aidoc/review/01_BRD/<BRD-id>/verdict.json`, with fallback to the
+  written `01_BRD-audit.md` if verdict.json is absent (e.g. single_pass
+  runs without a synthesizer). Never reads the audit subagent's
+  stdout summary or the BRD's self-claimed PRD-Ready score.
+- `doc-brd-fixer/SKILL.md` — minor confirmation that the fixer
+  consumes the written report + slots. **First live exercise** of
+  team-mode fixer behaviour happens in this PR's Verification step 4
+  (BRD-RT-001's runs never reached the fixer because the autopilot
+  mis-read the verdict as PASS).
+- `tests/scripts/test-acceptance.sh`:
+  - `MAX_LAYER_SEC=900` → `1800` (line 63) with comment explaining team
+    mode legitimately runs 17-25 min per layer.
+  - `SKILL_TIMEOUT=600` → `1200` for the audit skill specifically (or
+    give `doc-brd-audit` the `REVIEW_TEAM_TIMEOUT` since it now
+    orchestrates a sub-team itself). Cleanest impl: name a new
+    `AUDIT_TIMEOUT=1200` and use it in `invoke_skill` when name matches
+    `doc-*-audit`.
+  - In `invoke_skill` (function defined around line 430), after
+    capturing `audit_score` from the skill's stdout response, also read
+    the synthesizer's `verdict.json` if present. If the values differ,
+    log a warning and prefer `verdict.json`. Belt-and-suspenders for
+    Gap A drift.
+- **`<BRD-id>` path codification** — the slot directory is
+  `.aidoc/review/01_BRD/<BRD-id>/` where `<BRD-id>` is the short
+  artifact ID (`BRD-01`), not the nested folder name
+  (`BRD-01_url_shortener`). BRD-RT-001's implementation already chose
+  the short form; this plan codifies it explicitly and updates the
+  BRD-RT-001 SKILL text wording retroactively in the same edits.
 - Plugin version bump 0.4.2 → 0.4.3.
 - Plugin CHANGELOG entry.
-- `plans/DECISIONS.md` D-0026 — "Audit skill's stdout response is its
-  verdict; written report is the authoritative reference."
+- `plans/DECISIONS.md` D-0026 — "Synthesizer writes a structured
+  `verdict.json`; every verdict consumer (audit skill stdout, driver,
+  autopilot, fixer) reads from it. Markdown `report.md` is the human
+  narrative, never the parse target."
 
 **Out:**
 
 - Framework spec changes — none required. `REVIEW_TEAM.md` already says
   the synthesiser's reduce is deterministic and authoritative; this PR
   is the plugin's binding catching up to the spec.
-- PRD..IPLAN layer wiring — propagation deferred until BRD-RT-002 is
-  verified live (full cascade) so the corrected pattern propagates
-  cleanly.
-- Driver script source-of-score refactor — the simplest fix is at the
-  skill side (Gap A). Driver cross-check is optional belt-and-suspenders;
-  keep minimal.
-- A new conformance test that asserts stdout/report score match —
-  potentially valuable but model-output behavior is hard to assert
-  deterministically; defer until BRD-RT-002 + PRD-RT show consistent
-  results across runs.
-- `single_pass` deprecation — single_pass remains a first-class fallback
-  (e.g. for `on_author`, partial-quorum runs, cost-constrained
-  environments). Only the *advisory framing* at gates changes.
+- **PRD..IPLAN layer wiring** — propagation deferred until BRD-RT-002
+  is verified live. **The Gap A/C/E fix pattern (Output Contract,
+  read-from-verdict.json, always-on advisory) is generic and reusable
+  verbatim** for `doc-<layer>-audit` and `doc-<layer>-autopilot` skills
+  at PRD, EARS, BDD, ADR, SPEC, TDD, IPLAN. Each per-layer follow-up
+  PR copies the pattern with the layer's name substituted.
+- A new conformance test that asserts stdout/`verdict.json` score
+  match — potentially valuable but model-output behavior is hard to
+  assert deterministically; defer until BRD-RT-002 + PRD-RT show
+  consistent results across runs.
+- `single_pass` deprecation — single_pass remains a first-class
+  fallback (cost-constrained runs, no-subagent contexts). Only the
+  advisory framing changes (now always shown when single_pass resolves).
 - Hermes-side parity — Hermes implements its own runtime; this PR is
   plugin-only.
-- Caching follow-up (`REVIEW-TEAM-RUNNER-CACHING-001`) — separate v0.4.4
-  work; orthogonal optimisation.
+- Caching follow-up (`REVIEW-TEAM-RUNNER-CACHING-001`) — separate
+  v0.4.4 work; orthogonal optimisation.
 
 ## Approach
 
@@ -90,19 +119,42 @@ line) rather than the synthesizer's deterministic computation (83).
 Every downstream consumer (driver, autopilot revise loop) reads the
 stdout, not the written report — so the FAIL never propagates.
 
-This is the root cause of Gaps A, B, and C from the post-Run-#1
-discussion. They share one fix: the audit skill's text must make the
-model output the synthesizer's verdict in its terminal response.
+### Why Markdown report.md is the wrong parse target
+
+The synthesizer's `report.md` is rendered as human-narrative Markdown:
+
+```markdown
+## Gate Decision
+
+| Item | Value |
+|---|---|
+| Readiness score (advisory) | **83 / 100** |
+| Gate threshold | 90 |
+| Verdict | **FAIL** |
+```
+
+Parseable by a model, but **fragile** — heading text, cell formatting,
+or value placement can drift between runs. Asking the audit skill's
+model to extract values from `report.md` to produce its stdout shifts
+fragility from one place to another.
+
+The structural fix is to have the synthesizer also write a
+deterministic, schema-checkable `verdict.json` companion. Then every
+consumer parses JSON, not prose.
 
 ### Fix shape per gap
 
 **Gap A — `doc-brd-audit/SKILL.md` team-mode branch.** Add an explicit
-"Output contract" subsection inside the team-mode branch:
+"Output Contract" subsection inside the team-mode branch (insertion
+point: immediately after the "Quorum & coverage" paragraph at line
+~125, before `### single_pass mode (fallback)` at line ~131):
 
 ```
-After the synthesizer writes `report.md`, read it back, extract
-`combined_status` / `content score` / `coverage.quorum_met`, and produce
-your terminal stdout response in the exact shape:
+## Output Contract
+
+After the synthesizer writes `verdict.json` (alongside `report.md`)
+read it back and produce your terminal stdout response in this exact
+shape, mirroring the JSON values verbatim:
 
   Combined status: PASS|FAIL
   Content score: <N>/100
@@ -111,42 +163,54 @@ your terminal stdout response in the exact shape:
   Report: .aidoc/audit/01_BRD-audit.md
 
 Do NOT echo the BRD's self-claimed PRD-Ready score. The synthesizer's
-report.md is the authoritative verdict; your response mirrors it.
+`verdict.json` is the authoritative verdict; your response mirrors it
+key-for-key.
 ```
 
-**Gap C — `doc-brd-autopilot/SKILL.md` Workflow §5 (revise step).** Make
-the read-source explicit:
+**Gap B — driver belt-and-suspenders.** In
+`tests/scripts/test-acceptance.sh`, modify the `invoke_skill` bash
+function (around line 430) to read the synthesizer's `verdict.json` (if
+present at `.aidoc/review/<NN>_<LAYER>/<artifact-id>/verdict.json`)
+after the skill returns. Cross-check the captured `audit_score`
+against `verdict.json:content_score`. If they differ, log a warning
+and store the JSON value. Catches future drift without depending on
+model-prompt compliance.
+
+**Gap C — `doc-brd-autopilot/SKILL.md` Workflow §5 (revise step at line
+94-103).** Make the read-source explicit and deterministic:
 
 ```
-After invoking `../doc-brd-audit/SKILL.md`, decide pass/fail by READING
-the written report at `.aidoc/audit/01_BRD-audit.md`:
-  - Combined status: FAIL → invoke `../doc-brd-fixer/SKILL.md`, GOTO step 4
-  - Coverage quorum: low_confidence → flag manual-review, halt
-  - Combined status: PASS → finalize
+After invoking `../doc-brd-audit/SKILL.md`, decide pass/fail by reading
+the synthesizer's `verdict.json` at
+`.aidoc/review/01_BRD/<BRD-id>/verdict.json`:
 
-Do NOT make this decision from the audit subagent's stdout summary or
-from the BRD's self-claimed PRD-Ready score. The written audit report
-is the gate; everything else is advisory.
+  - verdict.combined_status == "FAIL" → invoke `../doc-brd-fixer/SKILL.md`
+    (team mode), GOTO step 4 to re-audit.
+  - verdict.coverage.quorum_met == false → flag manual-review, halt.
+  - verdict.combined_status == "PASS" → finalize.
+
+When `verdict.json` is absent (e.g. single_pass run with no
+synthesizer), parse the written `.aidoc/audit/01_BRD-audit.md`
+combined-status line instead. Never make this decision from the audit
+subagent's stdout summary or from the BRD's self-claimed PRD-Ready
+score. The written verdict is the gate; everything else is advisory.
 ```
 
-**Gap B — driver belt-and-suspenders (optional).** In
-`tests/scripts/test-acceptance.sh`, after `invoke_skill "doc-brd-audit"`,
-parse `Content score:` from `.aidoc/audit/01_BRD-audit.md` and overwrite
-the captured `audit_score` if it differs. Logs a warning when the two
-disagree. This catches future drift without forcing the model to be
-perfect.
+**Gap D — per-layer cap.** Raise `MAX_LAYER_SEC=900` to `1800`
+(line 63 of `tests/scripts/test-acceptance.sh`) with an updated comment
+explaining the rationale.
 
-**Gap D — per-layer cap.** Raise `MAX_LAYER_SEC=900` to `MAX_LAYER_SEC=1800`
-with an updated comment explaining the rationale (team mode at one
-layer = 4 review subagents in parallel + synthesizer + author + fixer
-loop iteration, naturally 15-25 minutes).
-
-**Gap E — single_pass advisory note at gates.** Add to
-`doc-brd-audit/SKILL.md` combined report format:
+**Gap E — single_pass advisory note, always-on.** Add to
+`doc-brd-audit/SKILL.md` Combined Report Format (around line 193).
+**Always include** this advisory whenever the resolved mode is
+`single_pass`, regardless of the trigger context. The note is
+informational; showing it harmlessly at `on_author` is preferable to
+the audit skill trying to detect "am I at a gate?" — which it cannot
+reliably do without a caller-passed flag.
 
 ```
-When `review_mode: single_pass` is used at a gate (pre_promotion /
-pre_merge), include this advisory in the report summary:
+When the resolved `review_mode` is `single_pass`, include this
+advisory in the report Summary section:
 
   > **Advisory mode.** This audit ran in `single_pass` — one model
   > applying every lens in one context. Per REVIEW_TEAM.md §"Scoring,
@@ -156,62 +220,167 @@ pre_merge), include this advisory in the report summary:
   > production gate run should re-audit in `team` mode.
 ```
 
+### New: structured `verdict.json` schema
+
+`agents/synthesizer.md` instructs the synthesizer subagent to write
+this file alongside `report.md`:
+
+```json
+{
+  "combined_status": "PASS|FAIL",
+  "content_score": 83,
+  "structural_status": "PASS|FAIL",
+  "coverage": {
+    "expected": 4,
+    "ran": 4,
+    "quorum_met": true
+  },
+  "blocking_findings_count": 2,
+  "lens_scores": {
+    "architect": 93,
+    "business_analyst": 82,
+    "auditor": 92,
+    "adversary": 62
+  }
+}
+```
+
+Schema is intentionally flat — every consumer (audit skill, driver,
+autopilot, fixer) extracts what it needs by top-level key.
+
+### Per-skill timeout interaction (G1 resolution)
+
+`doc-brd-audit` in team mode internally orchestrates 4 review subagents
+
+- synthesizer. Its observed Run #1 duration was 580s — within the 600s
+default `SKILL_TIMEOUT` but close to the wall. After this PR, the same
+skill may also drive fixer iterations (which it didn't before), pushing
+duration higher.
+
+**Resolution**: introduce `AUDIT_TIMEOUT=1200` in `test-acceptance.sh`
+(or extend the existing per-skill name-matching: skills whose name ends
+in `-audit` get the longer timeout). The 1800s `REVIEW_TEAM_TIMEOUT`
+remains for the `review-team` skill itself.
+
+### Wall-clock budget for full-cascade runs (G4 resolution)
+
+Realistic projection per layer in team mode with fix iterations:
+
+| Component | Time |
+|---|---|
+| Autopilot (drafter subagent) | ~3-5 min |
+| Audit (4 lens subagents + synthesizer) | ~10-15 min |
+| Fixer (if triggered, with N lens validators) | ~5-8 min |
+| Re-audit after fix | ~10-15 min |
+| **Per-layer typical (no fix)** | **~15-20 min** |
+| **Per-layer with one fix iteration** | **~30-40 min** |
+| **Per-layer max (3 fix iterations)** | **~50-70 min** |
+
+Full cascade × 8 layers:
+
+| Scenario | Wall-clock | Cost (Sonnet pricing) |
+|---|---|---|
+| Optimistic (no fixes needed at any layer) | ~2 hours | ~$40-50 |
+| Typical (fix at 2-3 layers, 1 iter each) | ~3 hours | ~$60-80 |
+| Worst case (fix at every layer, 3 iter) | ~6-8 hours | ~$120-180 |
+
+Existing guards:
+
+- `MAX_TOTAL_OUTPUT_TOKENS=1_500_000` (~$22 worth of output tokens) —
+  may not be sufficient for worst-case full cascade; consider raising
+  to 5M (~$75) for explicit team-mode full-cascade runs.
+- Per-skill timeout (600s or new 1200s for audits) — catches stuck
+  subagents.
+- Per-layer cap (new 1800s) — catches stuck cascades on one layer.
+
+**Recommended operational pattern**: full team-mode cascades run via
+the existing `run_in_background: true` script invocation (which the
+acceptance suite already supports via the test-harness background
+mode) or via overnight `nohup`. Operators get notified at completion
+rather than blocking on the terminal.
+
 ## Step sequence
 
-1. **`doc-brd-audit/SKILL.md` — Gap A + Gap E**:
-   - Add `## Output Contract` subsection inside team-mode branch
-     describing the exact terminal-stdout shape (mirrors synthesizer's
-     verdict).
-   - Add `single_pass` advisory note paragraph in Combined Report
-     Format when the run is at a gate trigger.
+1. **`agents/synthesizer.md`** — instruct the synthesizer subagent to
+   write `verdict.json` alongside `report.md`. Include the schema
+   shown above. Ensure the lens-score map mirrors the framework's
+   per-layer crew weights.
 
-2. **`doc-brd-autopilot/SKILL.md` — Gap C**:
-   - Workflow §5 (revise) explicitly reads `.aidoc/audit/01_BRD-audit.md`
-     for the gate decision, not the audit subagent's stdout.
-   - Make the read-from-report behaviour symmetric across both team and
-     single_pass modes.
+2. **`doc-brd-audit/SKILL.md` — Gap A + Gap E + path codification**:
+   - Frontmatter `adapts:` line ~18 — unchanged (already has
+     `review_mode` from BRD-RT-001).
+   - Replace any wording about `<BRD-id>` matching the nested folder
+     name with the short artifact ID (`BRD-01`).
+   - Add `## Output Contract` subsection after the team-mode branch's
+     "Quorum & coverage" paragraph (insertion point ~line 125-130),
+     citing the verdict.json fields.
+   - In Combined Report Format (around line 193), add the always-on
+     `single_pass` advisory paragraph.
 
-3. **`doc-brd-fixer/SKILL.md` — confirmation**:
-   - Verify Input Contract already says "consume the latest audit
-     report from `.aidoc/audit/01_BRD-audit.md`". It does (post
-     BRD-RT-001). Add a one-sentence reminder that the report is
-     authoritative for fix triggering.
+3. **`doc-brd-autopilot/SKILL.md` — Gap C**:
+   - Workflow §5 (Revise) at line ~94-103: replace "if FAIL …" with
+     the explicit verdict.json read shown in the Approach section.
+   - Single_pass branch keeps existing read-from-audit-report
+     behaviour (with a one-line note that verdict.json is absent in
+     single_pass).
+   - Update `<BRD-id>` path references to the short form.
 
-4. **`tests/scripts/test-acceptance.sh` — Gaps B + D**:
-   - `MAX_LAYER_SEC=900` → `MAX_LAYER_SEC=1800` with comment.
-   - Optional belt-and-suspenders: after capturing audit_score from the
-     skill's stdout, also read the written report's "Content score"
-     line. Log warning if they differ; prefer the report's value.
+4. **`doc-brd-fixer/SKILL.md` — clarification + confirmation**:
+   - Confirm Input Contract reads `.aidoc/audit/01_BRD-audit.md` (it
+     does, from BRD-RT-001).
+   - Add one sentence: "When `verdict.json` is present, prefer it for
+     the blocking-findings list (deterministic JSON parse vs Markdown
+     extraction). Fall back to the audit report when verdict.json is
+     absent."
+   - Update `<BRD-id>` path references to the short form.
 
-5. **Plugin version bump** 0.4.2 → 0.4.3: VERSION + plugin.json +
-   marketplace.json + 52 skills' frontmatter `version:` + plugin README
-   - root README + docs/PARITY.md + docs/TAGGING.md (new tag row) +
-   SKILL_AUTHORING.md.
+5. **`tests/scripts/test-acceptance.sh` — Gaps B + D + audit timeout**:
+   - Line 63: `MAX_LAYER_SEC=900` → `1800` with comment.
+   - Lines 67-69: add `AUDIT_TIMEOUT=1200`; use it in `invoke_skill`
+     (line ~430) when the skill name matches `*-audit`.
+   - In `invoke_skill` after capturing `audit_score` from stdout, also
+     read `.aidoc/review/<NN>_<LAYER>/<artifact-id>/verdict.json` if
+     present. If `content_score` differs from the captured value, log
+     a warning and prefer the JSON value.
+   - Consider raising `MAX_TOTAL_OUTPUT_TOKENS` from `1_500_000` to
+     `5_000_000` to accommodate worst-case team-mode full cascades.
+     Decision deferred to operator preference; keep current value as
+     default.
 
-6. **Plugin CHANGELOG entry** at
-   `platforms/claude-code-plugin/CHANGELOG.md` under
-   `[Unreleased] → Changed` documenting Gaps A/B/C/D/E and the
-   underlying verdict-chain consistency fix.
+6. **Plugin version bump** 0.4.2 → 0.4.3: standard 9-place fanout —
+   VERSION + plugin.json + marketplace.json + 52 skills' frontmatter
+   `version:` + plugin README + root README + docs/PARITY.md +
+   docs/TAGGING.md (new tag row) + SKILL_AUTHORING.md. Use the same
+   Python bulk-bump pattern from BRD-RT-001 and PROFILE-DELTA-001.
 
-7. **DECISIONS.md entry D-0026** at `plans/DECISIONS.md`:
-   "Audit skill's stdout response is its verdict; the written report is
-   the authoritative reference, and every consumer (driver, autopilot
-   revise loop, fixer) reads from the report file."
+7. **Plugin CHANGELOG entry** at
+   `platforms/claude-code-plugin/CHANGELOG.md` under `[Unreleased] →
+   Changed`. Documents all five gaps + the new verdict.json contract +
+   per-skill audit timeout + per-layer cap raise.
 
-8. **Verify** (see Verification section).
+8. **DECISIONS.md entry D-0026** at `plans/DECISIONS.md`:
+   "Synthesizer writes a structured `verdict.json`; every verdict
+   consumer (audit-skill stdout, driver, autopilot, fixer) reads from
+   it. Markdown `report.md` is the human narrative, never the parse
+   target."
 
-9. **Land** — single PR. No framework/** content touched; GATE-SPEC not
-   applicable.
+9. **Verify** (see Verification section).
+
+10. **Land** — single PR. No `framework/**` content touched;
+    GATE-SPEC not applicable.
 
 ## Verification
 
 Cheap-to-expensive ladder. Steps 1-3 are free. Steps 4-5 spend ~$10
-total (two BRD-only live runs).
+total (two BRD-only live runs). Step 6 (full cascade) is the eventual
+end-to-end confirmation but explicitly deferred — see Wall-clock
+budget above.
 
 1. **Static lint + conformance** (free, < 30s):
 
    ```sh
    env -u LD_LIBRARY_PATH pre-commit run --files \
+     platforms/claude-code-plugin/agents/synthesizer.md \
      platforms/claude-code-plugin/skills/doc-brd-audit/SKILL.md \
      platforms/claude-code-plugin/skills/doc-brd-autopilot/SKILL.md \
      platforms/claude-code-plugin/skills/doc-brd-fixer/SKILL.md \
@@ -235,12 +404,18 @@ total (two BRD-only live runs).
    Pass criteria: PASS (7/0/44/51) — no regression on the deterministic
    path.
 
-3. **Skill-text inspection** (free):
+3. **Skill-text + script inspection** (free):
 
-   - `doc-brd-audit/SKILL.md` contains the new Output Contract block.
-   - `doc-brd-autopilot/SKILL.md` Workflow §5 cites
-     `.aidoc/audit/01_BRD-audit.md` as the gate-decision source.
-   - `tests/scripts/test-acceptance.sh` `MAX_LAYER_SEC=1800`.
+   - `agents/synthesizer.md` contains the `verdict.json` write
+     instructions and the schema.
+   - `doc-brd-audit/SKILL.md` contains the new Output Contract block
+     reading from `verdict.json`.
+   - `doc-brd-autopilot/SKILL.md` Workflow §5 cites `verdict.json` at
+     `.aidoc/review/01_BRD/<BRD-id>/verdict.json` as the gate-decision
+     source.
+   - All BRD skill text uses `<BRD-id>` = short artifact ID consistently.
+   - `tests/scripts/test-acceptance.sh` `MAX_LAYER_SEC=1800` and
+     `AUDIT_TIMEOUT=1200`; `invoke_skill` cross-checks the JSON.
 
 4. **Live BRD-only run, team mode** (~$5-7, ~15-20 min):
 
@@ -250,61 +425,75 @@ total (two BRD-only live runs).
    ```
 
    Pass criteria (the load-bearing checks):
+   - **`verdict.json` present** at
+     `.aidoc/review/01_BRD/BRD-01/verdict.json` — structured JSON
+     parseable by `json.loads`, all six top-level keys present.
    - **Driver and synthesizer agree**: the driver-reported
-     `audit_score` in `summary.txt` matches the synthesizer's
-     `Content score` in `.aidoc/audit/01_BRD-audit.md`.
-   - **Autopilot iterates on FAIL**: if synthesizer says FAIL with P1
-     findings, the autopilot invokes `doc-brd-fixer`. The fix-iteration
-     log (`elements/doc-brd-fixer.log`) shows non-zero
+     `audit_score` in `summary.txt` matches `verdict.json:content_score`.
+   - **Autopilot iterates on FAIL** (G3 — first live exercise of
+     fixer team-mode behaviour): if `verdict.combined_status == FAIL`,
+     the autopilot invokes `doc-brd-fixer`. The fix log
+     (`elements/doc-brd-fixer.log`) shows non-zero
      `audit_score_after_fixer`.
+   - **Fixer's lens-validation slots appear**:
+     `.aidoc/review/01_BRD/BRD-01/<persona>.fix_<N>.json` files exist
+     after the fix iteration.
    - **No per-layer cap abort**: the BRD layer completes within the
      new 1800-second cap.
-   - **`.aidoc/review/01_BRD/<BRD-id>/` slots present** (same as Run #1).
+   - **Slot files still produced** at
+     `.aidoc/review/01_BRD/BRD-01/{business_analyst,architect,auditor,adversary}.json`
+     (same as BRD-RT-001 Run #1).
 
    The expected outcome on the url-shortener BRD is that the autopilot
    tries to address BA-001 (visit-count contradiction) and other P1
    findings, re-audits, and either converges to PASS or escalates to
-   manual review after 3 iterations. Either way, the verdict chain is
+   manual-review after 3 iterations. Either way, the verdict chain is
    end-to-end consistent.
 
 5. **Live BRD-only run, single_pass mode** (~$2-3, ~10 min):
 
    ```sh
-   # Edit examples/url-shortener/.aidoc/profile.yaml — set review_mode: single_pass
+   # Edit examples/url-shortener/.aidoc/profile.yaml — set
+   # review_mode: single_pass
    bash tests/scripts/test-acceptance.sh url-shortener --live \
         --phase=cascade --from-layer=brd --to-layer=brd --force
    ```
 
    Pass criteria:
-   - **Audit report includes the new advisory note** about
-     `single_pass` being informational at gates.
+   - **Audit report includes the always-on advisory note** about
+     `single_pass` being informational.
    - **No slot files produced** (override-respect still works).
+   - **No `verdict.json`** (synthesizer doesn't run in single_pass —
+     autopilot falls back to reading the audit report directly).
    - **Driver and audit report agree on the score** (both should
      report the same single-context-computed score).
-   - **No regression vs Run #2's 93 PASS baseline**.
+   - **No regression** vs BRD-RT-001 Run #2's 93 PASS baseline.
 
 6. **Full cascade verification** (~$15-25, defer): only after steps 1-5
-   pass cleanly. With the new 1800-second cap and corrected verdict
-   chain, a full cascade should:
-   - Run all 8 layers without aborting.
-   - Each layer's driver-reported score matches its written audit
-     report.
-   - Layer FAIL verdicts actually trigger fixer cycles (which they
-     don't today on BRD).
+   pass cleanly. See Wall-clock budget above — recommend running via
+   `--run_in_background` or `nohup` overnight rather than blocking the
+   terminal for 2-4 hours. Confirms:
+   - Run all 8 layers without aborting under the new 1800s per-layer
+     cap.
+   - Each layer's driver-reported score matches its
+     `verdict.json:content_score`.
+   - Layer FAIL verdicts actually trigger fixer cycles.
    - Final summary reflects real per-layer team-mode verdicts.
 
 ## Risks
 
 | # | Risk | Mitigation |
 |---|------|------------|
-| R1 | Model still echoes the autopilot's self-claim despite the new Output Contract instructions | Belt-and-suspenders: driver cross-checks the written report's score (Gap B fix). When they disagree, log a warning and prefer the report. Catches stochastic drift without forcing the model to be perfect every time |
-| R2 | Autopilot's revise loop now triggers fixer cycles that the fixer can't actually resolve (e.g. BA-001 needs a human business decision: "exact counting" vs "1% tolerance") | The fixer's existing `manual-required` confidence tag (BRD-RT-001) handles this — it'll mark the finding manual-review and halt after max iterations. Logs a clear escalation message |
-| R3 | Raising `MAX_LAYER_SEC` to 1800s lets a stuck/runaway skill burn budget for twice as long before aborting | The `--cost-cap=$22` token-budget guard still fires across the run. Per-skill timeouts (600s default, 1800s review-team, 600s agents) remain as the inner backstop. Per-layer cap is the outer guard for "one layer accidentally runs forever" |
-| R4 | Full cascade with team mode at every layer × 3 fix iterations × 8 layers = potentially very long run | Realistic upper bound: 8 layers × 25 min/layer = ~3.3 hours wall-clock; cost-cap halts at $22 well before that. Operator can also use `--from-layer`/`--to-layer` for partial cascades. Same `--cost-cap` and per-layer caps remain in force |
-| R5 | The single_pass advisory note creates confusion about whether single_pass results are "trustworthy" | Note explicitly says "informational"; doesn't change PASS/FAIL outcome. Users picking `single_pass` are making a deliberate cost-vs-rigor tradeoff per `ADAPTATION_SURFACE.yaml` |
-| R6 | Gap E (single_pass leniency) is a structural property of single-context lens simulation, not fixable by note alone | The note is a UX patch; the structural fix is "don't use single_pass at gates", which the framework already recommends. This PR doesn't try to *prevent* single_pass at gates — that's a project-policy decision |
-| R7 | Per-layer cap raise to 1800s breaks any existing CI workflow that expected 900s | Search confirms no CI workflow hardcodes 900s; the cap is internal to `test-acceptance.sh`. Per-layer-cap is a runtime safety belt, not a contract |
-| R8 | Verification step 4 might not produce convergence to PASS (e.g., the BA-001 contradiction is unresolvable without a business decision) | Verification's pass criterion is "verdict chain is consistent", not "audit reaches PASS". Either PASS-after-fix OR manual-review-after-3-iterations is a valid demonstrative outcome — both prove the chain works |
+| R1 | Model still echoes the autopilot's self-claim despite the Output Contract instructions | Two layers: (a) verdict.json is structured JSON the synthesizer writes deterministically, so the audit skill's read-and-mirror task is now JSON parsing (more reliable than Markdown extraction). (b) Driver cross-check (Gap B) catches any remaining drift |
+| R2 | Synthesizer's `verdict.json` write may itself drift (model omits a field, uses wrong type) | Schema is flat (no nesting beyond `coverage`); audit-skill stdout instruction explicitly cites every field name. Driver's cross-check logs a structured warning when JSON parse fails or expected key missing. Add to future BRD-RT-003 if drift becomes a pattern: validate JSON against a JSONSchema |
+| R3 | Autopilot's revise loop now triggers fixer cycles that the fixer can't actually resolve (e.g. BA-001 needs a human business decision) | The fixer's existing `manual-required` confidence tag (BRD-RT-001) handles this — it'll mark the finding manual-review and halt after max iterations. Logs a clear escalation message |
+| R4 | Raising `MAX_LAYER_SEC` to 1800s lets a stuck/runaway skill burn budget for twice as long before aborting | Inner backstop unchanged: per-skill `SKILL_TIMEOUT` (default 600s, audits now 1200s, review-team 1800s, agents 600s). Outer backstop: `--cost-cap` (cumulative output tokens). Per-layer cap is the middle guard |
+| R5 | Full team-mode cascade exceeds the existing `MAX_TOTAL_OUTPUT_TOKENS=1_500_000` (~$22) cap | Plan recommends raising to 5M (~$75) for explicit team-mode full-cascade runs; default stays 1.5M for partial/single-layer runs. Operator can override per invocation. Verification step 4 (BRD-only) easily fits under 1.5M |
+| R6 | Full cascade wall-clock budget is 3-4 hours typical, 6-8 worst-case | Operational pattern documented in Approach: run via background/overnight. Operator notified at completion. Per-skill timeouts catch stuck runs early |
+| R7 | The always-on single_pass advisory note creates confusion ("am I supposed to ignore the score?") | Note explicitly says "informational"; doesn't change PASS/FAIL outcome. Shown only in audit report, not in driver summary. Users picking `single_pass` are making a deliberate cost-vs-rigor tradeoff per `ADAPTATION_SURFACE.yaml` |
+| R8 | `<BRD-id>` path change (codifying short artifact ID) breaks something that hard-coded the long form | Inspection shows BRD-RT-001's implementation already used the short form (`BRD-01`); only the SKILL text descriptions referenced the long form. No code consumers depend on either form. Slot files at the new short-form path are what BRD-RT-001 actually produced |
+| R9 | Per-skill audit timeout introduces inconsistency between layers (BRD audit at 1200s vs other-layer audits at 600s) | The name-match rule (`*-audit` → 1200s) applies uniformly across all 8 layers. When PRD-RT etc. propagate, their audits inherit the longer timeout automatically |
+| R10 | Verification step 4 might not produce convergence to PASS (e.g., the BA-001 contradiction is unresolvable without a business decision) | Verification's pass criterion is **verdict-chain consistency** (driver ↔ verdict.json ↔ audit report all agree), not "audit reaches PASS". Either PASS-after-fix OR manual-review-after-3-iterations is a valid demonstrative outcome — both prove the chain works |
 
 ## Review log
 
@@ -312,61 +501,88 @@ total (two BRD-only live runs).
 
 Initial draft. Findings folded back into the sections above:
 
-- The five gaps from the BRD-RT-001 live runs (A audit-stdout-mismatch,
-  B driver-parses-wrong-source, C autopilot-reads-wrong-source, D
-  per-layer-cap-too-tight, E single_pass-leniency) collapse into one
-  root cause for A/B/C: the audit skill's stdout response diverges
-  from the written report. Gap D is a one-line script tweak. Gap E is
-  a doc-only advisory note. All five fit in one PR.
-- Plugin version bump 0.4.2 → 0.4.3 plus standard fanout. No framework
-  spec change → no GATE-SPEC ceremony.
-- DECISIONS.md D-0026 captures the architectural principle: "audit
-  skill's stdout response IS its verdict; written report is the
-  authoritative reference; consumers read from the report".
-- Verification step 4 is the load-bearing check — it tests all three
-  Gap A/B/C fixes simultaneously. Step 5 tests Gap E. Step 6 (full
-  cascade) is the eventual end-to-end confirmation but deferred until
-  steps 1-5 pass.
-- R8: verification pass-criterion is verdict-chain consistency, NOT
-  reaching PASS on this specific BRD. The url-shortener BRD has real
-  spec issues (BA-001) that might be unresolvable by automated fixer
-  without a business decision — that's a valid outcome and still
-  proves the chain works.
-- Defer making single_pass advisory-mandatory at gates — that's a
-  project policy decision, not a framework rule.
+- Five gaps (A audit-stdout-mismatch, B driver-parses-wrong-source, C
+  autopilot-reads-wrong-source, D per-layer-cap-too-tight, E
+  single_pass-leniency) collapse into one root cause for A/B/C: the
+  audit skill's stdout response diverges from the written report. Gap
+  D is a one-line script tweak. Gap E is a doc-only advisory note.
+- DECISIONS.md D-0026 captures the principle.
+- Verification step 4 is the load-bearing check. Step 5 tests Gap E.
+  Step 6 (full cascade) is the eventual confirmation, deferred.
 
 ### Pass 2 — 2026-06-03T17:53:34Z
 
-Re-read whole plan. No new findings.
+Re-read whole plan. Verification calibration check confirmed each
+pass criterion in steps 4 and 5 maps to a specific transformation
+rule. No new findings.
 
-- **Verification calibration**: each pass criterion in steps 4 and 5
-  maps to a specific transformation:
-  - Gap A fix (audit Output Contract) → "driver and synthesizer
-    agree on score" (step 4)
-  - Gap B fix (driver cross-check) → same as above (the cross-check
-    is what guarantees the agreement)
-  - Gap C fix (autopilot reads written report) → "autopilot iterates
-    on FAIL" (step 4) — observable via fixer-loop activation
-  - Gap D fix (cap raise) → "no per-layer cap abort" (step 4)
-  - Gap E fix (advisory note) → "audit report includes advisory note"
-    (step 5)
-  No false positives (each rule's output trips a check) or false
-  negatives (no rule's output is unchecked).
-- **Scope check**: every "Out:" item has a clear deferral target.
-  PRD..IPLAN propagation is gated on this PR's verification success.
-  Single_pass deprecation is explicitly a project-policy decision.
-- **Risks check**: 8 risks identified. R1 (model behavior unreliable)
-  is the most material; mitigated by the driver cross-check
-  belt-and-suspenders. R8 (verification might not converge to PASS)
-  is real but doesn't invalidate the verification — chain consistency
-  is the metric, not score outcome.
-- **Backward-compat check**: no `framework/**` change; existing
-  projects continue working; team-mode runs that succeeded under
-  BRD-RT-001 continue to succeed. The new behaviour is purely
-  additive (more accurate verdict reporting, longer per-layer cap,
-  optional advisory note).
-- **Cost check**: verification cost ~$10 total (steps 4 + 5).
-  Full-cascade verification at step 6 is deferred and gates further
-  per-layer propagation. No surprise spend.
+### Pass 3 — 2026-06-03T18:25:00Z (gap-review amendment)
 
-Plan ready for implementation.
+Comprehensive gap review of the Pass 1+2 plan identified ten gaps
+(G1-G10). All folded back into the sections above:
+
+- **G1 — Per-skill timeout interaction**: doc-brd-audit's 580s Run #1
+  duration was perilously close to the 600s `SKILL_TIMEOUT`. With fix
+  iterations now possible, duration can grow. Resolution: new
+  `AUDIT_TIMEOUT=1200` applied via name-match (`*-audit`) in
+  `invoke_skill`. Documented in Approach and Step 5.
+- **G2 — Slot-directory path inconsistency** (`<BRD-id>`
+  long-vs-short form): BRD-RT-001's implementation already picked the
+  short artifact ID (`BRD-01`); only the SKILL text used the long
+  form. Codified the short form in Scope, Approach, and all Step
+  references. R8 captures the (low) backward-compat risk.
+- **G3 — Fixer team-mode behaviour unverified by any prior live
+  run**: BRD-RT-001's runs never reached the fixer because the
+  autopilot mis-read the verdict as PASS. Explicit Verification
+  step 4 sub-criterion added: "Fixer's lens-validation slots appear
+  at `<persona>.fix_<N>.json`". Step 4 description now calls out
+  "first live exercise of team-mode fixer behaviour".
+- **G4 — Full-cascade cost & wall-clock budget missing**: new
+  "Wall-clock budget" subsection in Approach quantifies per-layer and
+  full-cascade scenarios (~2-8 hours; ~$40-180). R5 and R6 add the
+  cost-cap-raise and operational-pattern mitigations.
+- **G5 — Markdown `report.md` is the wrong parse target**: structural
+  fix is to have the synthesizer write a deterministic `verdict.json`
+  companion. New file added to Scope (In):
+  `platforms/claude-code-plugin/agents/synthesizer.md`. New Step 1
+  added. Audit skill's Output Contract (Gap A) and autopilot's revise
+  loop (Gap C) now read JSON, not Markdown. R2 captures the
+  json-write-drift risk.
+- **G6 — "At a gate" condition for the single_pass advisory**: skill
+  cannot reliably know its trigger context. Simplified to "always
+  show advisory when single_pass resolves". R7 captures the
+  user-confusion risk (mitigated by explicit "informational" wording).
+- **G7 — PRD..IPLAN inherit the same pattern**: explicit note added in
+  Scope (Out). Per-layer follow-up PRs (PRD-RT-001, EARS-RT-001, etc.)
+  copy the verdict.json + Output Contract + always-on advisory
+  pattern verbatim per layer.
+- **G8 — Exact line/section anchors**: Step sequence now cites the
+  insertion point for each edit (line numbers + section names) so
+  reviewers can find the targets without grep.
+- **G9 — Reference `invoke_skill` bash function**: Gap B fix in
+  Approach and Step 5 now cite `invoke_skill` (line ~430 of
+  `test-acceptance.sh`) as the specific code location.
+- **G10 — Prose redundancy**: kept the per-gap fix shapes consolidated
+  in the Approach section. Step sequence cites the Approach
+  paragraphs by gap label rather than restating the fix.
+
+Additional consequential changes from the gap review:
+
+- Risks table grew from 8 to 10 entries (added R5 cost-cap, R9
+  per-skill timeout, R10 verification-doesn't-have-to-converge to
+  replace original R8 plus new framing).
+- Step sequence grew from 9 steps to 10 (new Step 1 for synthesizer
+  agent; old Steps 1-9 renumbered 2-10).
+- Scope (In) added `agents/synthesizer.md` and explicit
+  per-skill-timeout name-match rule.
+- Scope (Out) explicitly enumerates that PRD..IPLAN follow-ups reuse
+  this pattern verbatim — they don't need their own plans for the
+  verdict.json contract, only layer-specific applications.
+
+No false-positives or false-negatives in the gap analysis: each
+identified gap maps to a concrete fix shape in the Approach section
+and a verification criterion (where verifiable).
+
+Plan is ready for implementation. Scope grew modestly (added one file:
+`agents/synthesizer.md`; one new constant: `AUDIT_TIMEOUT`); the core
+architectural shape is unchanged.

--- a/plans/BRD-RT-002-VERDICT-CHAIN-PLAN.md
+++ b/plans/BRD-RT-002-VERDICT-CHAIN-PLAN.md
@@ -1,0 +1,372 @@
+# BRD-RT-002 Plan — Wire the audit → autopilot verdict chain through the written reports
+
+| Field      | Value                                       |
+|------------|---------------------------------------------|
+| Task       | BRD-RT-002                                  |
+| Depends on | BRD-RT-001 (D-0024, merged), PROFILE-DELTA-001 (D-0025, merged) |
+| Status     | PLANNED — 2026-06-03T17:53:34Z              |
+| Feeds      | PRD-RT, EARS-RT, BDD-RT, ADR-RT, SPEC-RT, TDD-RT, IPLAN-RT — these per-layer follow-ups inherit the corrected verdict-chain semantics from this PR |
+
+## Objective
+
+Close five gaps surfaced by the BRD-RT-001 live verification runs
+(2026-06-03) so team-mode review produces **the same verdict at every
+consumer** — audit-skill stdout, written audit report, driver script,
+autopilot revise loop — and the per-layer runtime cap stops aborting
+legitimate team-mode runs. After this PR, a team-mode audit that
+computes FAIL actually triggers the fixer; a `single_pass` audit at a
+gate is marked advisory; and a full-cascade team-mode run no longer
+hits the 900-second cap on every layer.
+
+## Scope
+
+**In:**
+
+- `doc-brd-audit/SKILL.md` — team-mode branch must instruct the model
+  to mirror the synthesizer's deterministic verdict in its stdout
+  response (the skill's "return value"). Today the model echoes the
+  autopilot's self-claim instead.
+- `doc-brd-autopilot/SKILL.md` — the create→review→revise loop must
+  read its PASS/FAIL decision from the *written* audit report at
+  `.aidoc/audit/01_BRD-audit.md` and the synthesizer's
+  `.aidoc/review/01_BRD/<BRD-id>/report.md`, not from the audit
+  subagent's verbal response.
+- `doc-brd-fixer/SKILL.md` — minor confirmation that the fixer consumes
+  the written report + slots (already does in the BRD-RT-001 text;
+  verify and add an assertion if needed).
+- `tests/scripts/test-acceptance.sh` — raise `MAX_LAYER_SEC` from 900 to
+  1800 (mode-agnostic; team-mode legitimately runs ~17-25 min per
+  layer). Optionally also cross-check the captured `audit_score`
+  against the written report file as belt-and-suspenders.
+- `doc-brd-audit/SKILL.md` Combined Report Format — when `review_mode:
+  single_pass` is used at a gate (`pre_promotion`/`pre_merge`), include
+  an explicit **advisory note**: result is informational only;
+  `team` mode is the canonical gate per `REVIEW_TEAM.md`. (Doc-only;
+  doesn't change behavior.)
+- Plugin version bump 0.4.2 → 0.4.3.
+- Plugin CHANGELOG entry.
+- `plans/DECISIONS.md` D-0026 — "Audit skill's stdout response is its
+  verdict; written report is the authoritative reference."
+
+**Out:**
+
+- Framework spec changes — none required. `REVIEW_TEAM.md` already says
+  the synthesiser's reduce is deterministic and authoritative; this PR
+  is the plugin's binding catching up to the spec.
+- PRD..IPLAN layer wiring — propagation deferred until BRD-RT-002 is
+  verified live (full cascade) so the corrected pattern propagates
+  cleanly.
+- Driver script source-of-score refactor — the simplest fix is at the
+  skill side (Gap A). Driver cross-check is optional belt-and-suspenders;
+  keep minimal.
+- A new conformance test that asserts stdout/report score match —
+  potentially valuable but model-output behavior is hard to assert
+  deterministically; defer until BRD-RT-002 + PRD-RT show consistent
+  results across runs.
+- `single_pass` deprecation — single_pass remains a first-class fallback
+  (e.g. for `on_author`, partial-quorum runs, cost-constrained
+  environments). Only the *advisory framing* at gates changes.
+- Hermes-side parity — Hermes implements its own runtime; this PR is
+  plugin-only.
+- Caching follow-up (`REVIEW-TEAM-RUNNER-CACHING-001`) — separate v0.4.4
+  work; orthogonal optimisation.
+
+## Approach
+
+### Root-cause: the audit skill's stdout ≠ the audit skill's written report
+
+Run #1 (team mode, default profile) of the BRD-only cascade produced:
+
+```
+$LOG_DIR/elements/doc-brd-audit.log:   audit_score: 92, outcome: PASS  ← reported
+.aidoc/audit/01_BRD-audit.md:          Content score: 83, Combined: FAIL  ← written
+```
+
+Same skill invocation. Two verdicts. The model running `doc-brd-audit`
+in team mode followed the SKILL's instructions to dispatch the crew and
+synthesizer, but then **its final stdout summary reflected the
+autopilot's self-claim** (92, from the BRD's traceability-matrix health
+line) rather than the synthesizer's deterministic computation (83).
+Every downstream consumer (driver, autopilot revise loop) reads the
+stdout, not the written report — so the FAIL never propagates.
+
+This is the root cause of Gaps A, B, and C from the post-Run-#1
+discussion. They share one fix: the audit skill's text must make the
+model output the synthesizer's verdict in its terminal response.
+
+### Fix shape per gap
+
+**Gap A — `doc-brd-audit/SKILL.md` team-mode branch.** Add an explicit
+"Output contract" subsection inside the team-mode branch:
+
+```
+After the synthesizer writes `report.md`, read it back, extract
+`combined_status` / `content score` / `coverage.quorum_met`, and produce
+your terminal stdout response in the exact shape:
+
+  Combined status: PASS|FAIL
+  Content score: <N>/100
+  Structural status: PASS|FAIL
+  Coverage quorum: met|low_confidence
+  Report: .aidoc/audit/01_BRD-audit.md
+
+Do NOT echo the BRD's self-claimed PRD-Ready score. The synthesizer's
+report.md is the authoritative verdict; your response mirrors it.
+```
+
+**Gap C — `doc-brd-autopilot/SKILL.md` Workflow §5 (revise step).** Make
+the read-source explicit:
+
+```
+After invoking `../doc-brd-audit/SKILL.md`, decide pass/fail by READING
+the written report at `.aidoc/audit/01_BRD-audit.md`:
+  - Combined status: FAIL → invoke `../doc-brd-fixer/SKILL.md`, GOTO step 4
+  - Coverage quorum: low_confidence → flag manual-review, halt
+  - Combined status: PASS → finalize
+
+Do NOT make this decision from the audit subagent's stdout summary or
+from the BRD's self-claimed PRD-Ready score. The written audit report
+is the gate; everything else is advisory.
+```
+
+**Gap B — driver belt-and-suspenders (optional).** In
+`tests/scripts/test-acceptance.sh`, after `invoke_skill "doc-brd-audit"`,
+parse `Content score:` from `.aidoc/audit/01_BRD-audit.md` and overwrite
+the captured `audit_score` if it differs. Logs a warning when the two
+disagree. This catches future drift without forcing the model to be
+perfect.
+
+**Gap D — per-layer cap.** Raise `MAX_LAYER_SEC=900` to `MAX_LAYER_SEC=1800`
+with an updated comment explaining the rationale (team mode at one
+layer = 4 review subagents in parallel + synthesizer + author + fixer
+loop iteration, naturally 15-25 minutes).
+
+**Gap E — single_pass advisory note at gates.** Add to
+`doc-brd-audit/SKILL.md` combined report format:
+
+```
+When `review_mode: single_pass` is used at a gate (pre_promotion /
+pre_merge), include this advisory in the report summary:
+
+  > **Advisory mode.** This audit ran in `single_pass` — one model
+  > applying every lens in one context. Per REVIEW_TEAM.md §"Scoring,
+  > conflicts & the gate", `team` mode is the canonical gate review;
+  > `single_pass` is a cost-constrained fallback whose lens
+  > independence is reduced. Score 0-100 here is informational; a
+  > production gate run should re-audit in `team` mode.
+```
+
+## Step sequence
+
+1. **`doc-brd-audit/SKILL.md` — Gap A + Gap E**:
+   - Add `## Output Contract` subsection inside team-mode branch
+     describing the exact terminal-stdout shape (mirrors synthesizer's
+     verdict).
+   - Add `single_pass` advisory note paragraph in Combined Report
+     Format when the run is at a gate trigger.
+
+2. **`doc-brd-autopilot/SKILL.md` — Gap C**:
+   - Workflow §5 (revise) explicitly reads `.aidoc/audit/01_BRD-audit.md`
+     for the gate decision, not the audit subagent's stdout.
+   - Make the read-from-report behaviour symmetric across both team and
+     single_pass modes.
+
+3. **`doc-brd-fixer/SKILL.md` — confirmation**:
+   - Verify Input Contract already says "consume the latest audit
+     report from `.aidoc/audit/01_BRD-audit.md`". It does (post
+     BRD-RT-001). Add a one-sentence reminder that the report is
+     authoritative for fix triggering.
+
+4. **`tests/scripts/test-acceptance.sh` — Gaps B + D**:
+   - `MAX_LAYER_SEC=900` → `MAX_LAYER_SEC=1800` with comment.
+   - Optional belt-and-suspenders: after capturing audit_score from the
+     skill's stdout, also read the written report's "Content score"
+     line. Log warning if they differ; prefer the report's value.
+
+5. **Plugin version bump** 0.4.2 → 0.4.3: VERSION + plugin.json +
+   marketplace.json + 52 skills' frontmatter `version:` + plugin README
+   - root README + docs/PARITY.md + docs/TAGGING.md (new tag row) +
+   SKILL_AUTHORING.md.
+
+6. **Plugin CHANGELOG entry** at
+   `platforms/claude-code-plugin/CHANGELOG.md` under
+   `[Unreleased] → Changed` documenting Gaps A/B/C/D/E and the
+   underlying verdict-chain consistency fix.
+
+7. **DECISIONS.md entry D-0026** at `plans/DECISIONS.md`:
+   "Audit skill's stdout response is its verdict; the written report is
+   the authoritative reference, and every consumer (driver, autopilot
+   revise loop, fixer) reads from the report file."
+
+8. **Verify** (see Verification section).
+
+9. **Land** — single PR. No framework/** content touched; GATE-SPEC not
+   applicable.
+
+## Verification
+
+Cheap-to-expensive ladder. Steps 1-3 are free. Steps 4-5 spend ~$10
+total (two BRD-only live runs).
+
+1. **Static lint + conformance** (free, < 30s):
+
+   ```sh
+   env -u LD_LIBRARY_PATH pre-commit run --files \
+     platforms/claude-code-plugin/skills/doc-brd-audit/SKILL.md \
+     platforms/claude-code-plugin/skills/doc-brd-autopilot/SKILL.md \
+     platforms/claude-code-plugin/skills/doc-brd-fixer/SKILL.md \
+     platforms/claude-code-plugin/VERSION \
+     platforms/claude-code-plugin/.claude-plugin/plugin.json \
+     .claude-plugin/marketplace.json \
+     tests/scripts/test-acceptance.sh \
+     platforms/claude-code-plugin/CHANGELOG.md \
+     plans/DECISIONS.md
+   python3 -m unittest discover -s tests/conformance -v
+   ```
+
+   Pass criteria: pre-commit green; 96/96 conformance tests pass.
+
+2. **Mock-mode acceptance** (free, < 1 min):
+
+   ```sh
+   bash tests/scripts/test-acceptance.sh url-shortener --no-live
+   ```
+
+   Pass criteria: PASS (7/0/44/51) — no regression on the deterministic
+   path.
+
+3. **Skill-text inspection** (free):
+
+   - `doc-brd-audit/SKILL.md` contains the new Output Contract block.
+   - `doc-brd-autopilot/SKILL.md` Workflow §5 cites
+     `.aidoc/audit/01_BRD-audit.md` as the gate-decision source.
+   - `tests/scripts/test-acceptance.sh` `MAX_LAYER_SEC=1800`.
+
+4. **Live BRD-only run, team mode** (~$5-7, ~15-20 min):
+
+   ```sh
+   bash tests/scripts/test-acceptance.sh url-shortener --live \
+        --phase=cascade --from-layer=brd --to-layer=brd --force
+   ```
+
+   Pass criteria (the load-bearing checks):
+   - **Driver and synthesizer agree**: the driver-reported
+     `audit_score` in `summary.txt` matches the synthesizer's
+     `Content score` in `.aidoc/audit/01_BRD-audit.md`.
+   - **Autopilot iterates on FAIL**: if synthesizer says FAIL with P1
+     findings, the autopilot invokes `doc-brd-fixer`. The fix-iteration
+     log (`elements/doc-brd-fixer.log`) shows non-zero
+     `audit_score_after_fixer`.
+   - **No per-layer cap abort**: the BRD layer completes within the
+     new 1800-second cap.
+   - **`.aidoc/review/01_BRD/<BRD-id>/` slots present** (same as Run #1).
+
+   The expected outcome on the url-shortener BRD is that the autopilot
+   tries to address BA-001 (visit-count contradiction) and other P1
+   findings, re-audits, and either converges to PASS or escalates to
+   manual review after 3 iterations. Either way, the verdict chain is
+   end-to-end consistent.
+
+5. **Live BRD-only run, single_pass mode** (~$2-3, ~10 min):
+
+   ```sh
+   # Edit examples/url-shortener/.aidoc/profile.yaml — set review_mode: single_pass
+   bash tests/scripts/test-acceptance.sh url-shortener --live \
+        --phase=cascade --from-layer=brd --to-layer=brd --force
+   ```
+
+   Pass criteria:
+   - **Audit report includes the new advisory note** about
+     `single_pass` being informational at gates.
+   - **No slot files produced** (override-respect still works).
+   - **Driver and audit report agree on the score** (both should
+     report the same single-context-computed score).
+   - **No regression vs Run #2's 93 PASS baseline**.
+
+6. **Full cascade verification** (~$15-25, defer): only after steps 1-5
+   pass cleanly. With the new 1800-second cap and corrected verdict
+   chain, a full cascade should:
+   - Run all 8 layers without aborting.
+   - Each layer's driver-reported score matches its written audit
+     report.
+   - Layer FAIL verdicts actually trigger fixer cycles (which they
+     don't today on BRD).
+   - Final summary reflects real per-layer team-mode verdicts.
+
+## Risks
+
+| # | Risk | Mitigation |
+|---|------|------------|
+| R1 | Model still echoes the autopilot's self-claim despite the new Output Contract instructions | Belt-and-suspenders: driver cross-checks the written report's score (Gap B fix). When they disagree, log a warning and prefer the report. Catches stochastic drift without forcing the model to be perfect every time |
+| R2 | Autopilot's revise loop now triggers fixer cycles that the fixer can't actually resolve (e.g. BA-001 needs a human business decision: "exact counting" vs "1% tolerance") | The fixer's existing `manual-required` confidence tag (BRD-RT-001) handles this — it'll mark the finding manual-review and halt after max iterations. Logs a clear escalation message |
+| R3 | Raising `MAX_LAYER_SEC` to 1800s lets a stuck/runaway skill burn budget for twice as long before aborting | The `--cost-cap=$22` token-budget guard still fires across the run. Per-skill timeouts (600s default, 1800s review-team, 600s agents) remain as the inner backstop. Per-layer cap is the outer guard for "one layer accidentally runs forever" |
+| R4 | Full cascade with team mode at every layer × 3 fix iterations × 8 layers = potentially very long run | Realistic upper bound: 8 layers × 25 min/layer = ~3.3 hours wall-clock; cost-cap halts at $22 well before that. Operator can also use `--from-layer`/`--to-layer` for partial cascades. Same `--cost-cap` and per-layer caps remain in force |
+| R5 | The single_pass advisory note creates confusion about whether single_pass results are "trustworthy" | Note explicitly says "informational"; doesn't change PASS/FAIL outcome. Users picking `single_pass` are making a deliberate cost-vs-rigor tradeoff per `ADAPTATION_SURFACE.yaml` |
+| R6 | Gap E (single_pass leniency) is a structural property of single-context lens simulation, not fixable by note alone | The note is a UX patch; the structural fix is "don't use single_pass at gates", which the framework already recommends. This PR doesn't try to *prevent* single_pass at gates — that's a project-policy decision |
+| R7 | Per-layer cap raise to 1800s breaks any existing CI workflow that expected 900s | Search confirms no CI workflow hardcodes 900s; the cap is internal to `test-acceptance.sh`. Per-layer-cap is a runtime safety belt, not a contract |
+| R8 | Verification step 4 might not produce convergence to PASS (e.g., the BA-001 contradiction is unresolvable without a business decision) | Verification's pass criterion is "verdict chain is consistent", not "audit reaches PASS". Either PASS-after-fix OR manual-review-after-3-iterations is a valid demonstrative outcome — both prove the chain works |
+
+## Review log
+
+### Pass 1 — 2026-06-03T17:53:34Z
+
+Initial draft. Findings folded back into the sections above:
+
+- The five gaps from the BRD-RT-001 live runs (A audit-stdout-mismatch,
+  B driver-parses-wrong-source, C autopilot-reads-wrong-source, D
+  per-layer-cap-too-tight, E single_pass-leniency) collapse into one
+  root cause for A/B/C: the audit skill's stdout response diverges
+  from the written report. Gap D is a one-line script tweak. Gap E is
+  a doc-only advisory note. All five fit in one PR.
+- Plugin version bump 0.4.2 → 0.4.3 plus standard fanout. No framework
+  spec change → no GATE-SPEC ceremony.
+- DECISIONS.md D-0026 captures the architectural principle: "audit
+  skill's stdout response IS its verdict; written report is the
+  authoritative reference; consumers read from the report".
+- Verification step 4 is the load-bearing check — it tests all three
+  Gap A/B/C fixes simultaneously. Step 5 tests Gap E. Step 6 (full
+  cascade) is the eventual end-to-end confirmation but deferred until
+  steps 1-5 pass.
+- R8: verification pass-criterion is verdict-chain consistency, NOT
+  reaching PASS on this specific BRD. The url-shortener BRD has real
+  spec issues (BA-001) that might be unresolvable by automated fixer
+  without a business decision — that's a valid outcome and still
+  proves the chain works.
+- Defer making single_pass advisory-mandatory at gates — that's a
+  project policy decision, not a framework rule.
+
+### Pass 2 — 2026-06-03T17:53:34Z
+
+Re-read whole plan. No new findings.
+
+- **Verification calibration**: each pass criterion in steps 4 and 5
+  maps to a specific transformation:
+  - Gap A fix (audit Output Contract) → "driver and synthesizer
+    agree on score" (step 4)
+  - Gap B fix (driver cross-check) → same as above (the cross-check
+    is what guarantees the agreement)
+  - Gap C fix (autopilot reads written report) → "autopilot iterates
+    on FAIL" (step 4) — observable via fixer-loop activation
+  - Gap D fix (cap raise) → "no per-layer cap abort" (step 4)
+  - Gap E fix (advisory note) → "audit report includes advisory note"
+    (step 5)
+  No false positives (each rule's output trips a check) or false
+  negatives (no rule's output is unchecked).
+- **Scope check**: every "Out:" item has a clear deferral target.
+  PRD..IPLAN propagation is gated on this PR's verification success.
+  Single_pass deprecation is explicitly a project-policy decision.
+- **Risks check**: 8 risks identified. R1 (model behavior unreliable)
+  is the most material; mitigated by the driver cross-check
+  belt-and-suspenders. R8 (verification might not converge to PASS)
+  is real but doesn't invalidate the verification — chain consistency
+  is the metric, not score outcome.
+- **Backward-compat check**: no `framework/**` change; existing
+  projects continue working; team-mode runs that succeeded under
+  BRD-RT-001 continue to succeed. The new behaviour is purely
+  additive (more accurate verdict reporting, longer per-layer cap,
+  optional advisory note).
+- **Cost check**: verification cost ~$10 total (steps 4 + 5).
+  Full-cascade verification at step 6 is deferred and gates further
+  per-layer propagation. No surprise spend.
+
+Plan ready for implementation.


### PR DESCRIPTION
## Summary

Adds `plans/BRD-RT-002-VERDICT-CHAIN-PLAN.md` (372 lines) documenting the fix for **five gaps** surfaced by the [BRD-RT-001](https://github.com/vladm3105/aidoc-flow-framework/pull/69) live verification runs on 2026-06-03.

## Context — the smoking gun

Run #1 (BRD-only, team mode) of the cascade produced inconsistent verdicts from the same skill invocation:

```
elements/doc-brd-audit.log:    audit_score: 92, outcome: PASS  ← reported to caller
.aidoc/audit/01_BRD-audit.md:  Content score: 83, FAIL         ← written to disk
```

The doc-brd-audit skill in team mode dispatches the 4 review lenses + synthesizer correctly — slot files appear at `.aidoc/review/01_BRD/<BRD-id>/`, the synthesizer's `report.md` computes the weighted/capped score deterministically — but the model's final stdout summary echoes the BRD's self-claimed PRD-Ready score (92) instead of the synthesizer's deterministic verdict (83). Every downstream consumer (driver, autopilot revise loop) reads stdout, not the written report — so team-mode FAIL verdicts never trigger fixer cycles.

## Five gaps in one PR

| # | Gap | Where |
|---|---|---|
| **A** | Audit skill's stdout response ≠ written report's verdict | `doc-brd-audit/SKILL.md` team-mode branch |
| **B** | Driver script parses score from stdout, not the report file | `tests/scripts/test-acceptance.sh` |
| **C** | Autopilot's revise loop reads stdout, not the report file | `doc-brd-autopilot/SKILL.md` Workflow §5 |
| **D** | Per-layer cap 900s too tight for team mode (Run #1 hit 1070s) | `tests/scripts/test-acceptance.sh:MAX_LAYER_SEC` |
| **E** | Single_pass at gates is structurally more lenient than team | `doc-brd-audit/SKILL.md` Combined Report Format |

Gaps A/B/C share one root cause and one fix: the audit skill's text must instruct the model to read the synthesizer's `report.md` and mirror its verdict in stdout. Gap D is a one-line script edit. Gap E is a doc-only advisory note added to the report when single_pass is used at a gate.

## Plan structure

Follows `plans/PLAN-TEMPLATE.md` per D-0007:

- Metadata header (Task BRD-RT-002; depends on D-0024 BRD-RT-001 + D-0025 PROFILE-DELTA-001)
- Objective + Scope (In/Out) — full-cascade PRD..IPLAN propagation explicitly deferred until verified live
- Approach — root-cause analysis with concrete Run #1 evidence; per-gap fix shape with the exact prompt text to inject; structural rationale for each
- Step sequence (9 steps in implementation order: audit → autopilot → fixer → script → version bump → CHANGELOG → DECISIONS → verify → land)
- Verification (6-step ladder; steps 4-5 spend ~\$10 total to verify the chain end-to-end with two live runs)
- Risks table (8 risks; R1 — model behavior unreliable — is the most material, mitigated by Gap B's driver cross-check)
- Review log with 2 passes complete

## What ships in the implementation PR

- `doc-brd-audit/SKILL.md` — new Output Contract subsection in team-mode branch + single_pass advisory note
- `doc-brd-autopilot/SKILL.md` — Workflow §5 cites `.aidoc/audit/01_BRD-audit.md` as the gate-decision source
- `doc-brd-fixer/SKILL.md` — confirmation of already-correct input contract
- `tests/scripts/test-acceptance.sh` — `MAX_LAYER_SEC=1800` + optional driver cross-check
- Plugin v0.4.2 → v0.4.3 (standard 9-place fanout)
- `platforms/claude-code-plugin/CHANGELOG.md` `[Unreleased] → Changed` entry
- `plans/DECISIONS.md` D-0026 — "Audit skill's stdout response is its verdict; written report is authoritative"
- No `framework/**` content touched → no GATE-SPEC ceremony

## Verification load-bearing check (step 4 of the ladder)

```sh
bash tests/scripts/test-acceptance.sh url-shortener --live \
     --phase=cascade --from-layer=brd --to-layer=brd --force
```

Pass criteria after fix:
- **Driver and synthesizer agree**: `audit_score` in driver's `summary.txt` matches `Content score` in `.aidoc/audit/01_BRD-audit.md`
- **Autopilot iterates on FAIL**: synthesizer FAIL triggers `doc-brd-fixer`; fix iteration log shows non-zero `audit_score_after_fixer`
- **No per-layer cap abort**: BRD layer completes within new 1800s cap
- **Slot files still present**: team-mode fan-out unchanged from BRD-RT-001

Verification's pass criterion is **verdict chain consistency**, not "audit reaches PASS on this BRD" — the url-shortener BRD has real spec issues (BA-001 visit-count contradiction) that may need a business decision the fixer can't make autonomously. Either PASS-after-fix or manual-review-after-3-iterations is a valid demonstration.

## Test plan

This is plan-only — no skill or script changes yet.

- [x] Pre-commit green (whitespace, EOF, markdownlint, secrets, conformance)
- [x] Plan structure matches `plans/PLAN-TEMPLATE.md` (metadata header, Review log with ≥2 passes)
- [x] Two passes complete; verification ladder calibrated against fix shapes
- [ ] Implementation PR opens after this plan PR is reviewed