### PR TITLE
docs(plans): record BRD-RT-002 live-verification findings + add TODO-RT0

### DIFF
--- a/plans/REVIEW-TEAM-FOLLOWUPS.md
+++ b/plans/REVIEW-TEAM-FOLLOWUPS.md
@@ -30,6 +30,63 @@ sketched in PR #69's caching-analysis discussion.
 
 ## Follow-up items
 
+### TODO-RT0 — BRD-RT-003: operational fixes from BRD-RT-002 live verification
+
+- **Status:** PENDING — 2026-06-04T12:30:00Z
+- **Source:** BRD-RT-002 live verification (Run #1 team mode + Run #2
+  single_pass) on 2026-06-04. Verification confirmed verdict-chain
+  consistency end-to-end (the architectural contract works) but
+  surfaced three operational gaps in the BRD layer that don't impact
+  the contract but cause failures under realistic team-mode timing.
+- **Scope:** three small fixes that together unblock per-layer team
+  mode for routine use:
+  - **G11 — Autopilot timeout too short.** `doc-brd-autopilot` hit
+    the default 600s `SKILL_TIMEOUT` (exit 124) in team mode because
+    the autopilot now internally orchestrates a sub-team (drafter →
+    audit → fixer loop). BRD-RT-002's `AUDIT_TIMEOUT=1200` name-match
+    only covered `*-audit`. Fix: extend the name-match in
+    `tests/scripts/test-acceptance.sh:_pick_timeout_for` to also
+    catch `*-autopilot`, OR introduce a separate
+    `AUTOPILOT_TIMEOUT=1800`.
+  - **G12 — Per-layer cap exceeded.** Run #1's BRD layer ran 2569s
+    > 1800s cap. Breakdown: autopilot timeout (600s wasted) + first
+    audit (~580s) + fixer (487s) + re-audit (~900s) = ~2569s.
+    Resolution may follow from fixing G11 (autopilot succeeds in
+    one shot, no driver-level duplicate audit). If 1800s still
+    tight after G11, raise to 3600s.
+  - **G13 — Fixer team-mode lens-validation unverified.** Run #1's
+    fixer ran (487s, outcome PASS) but produced no
+    `<persona>.fix_<N>.json` slots. The 1 P1 finding spanned
+    architect + business_analyst lenses; possibly the fixer skipped
+    lens validation when no single lens "owned" the finding, or the
+    BRD-RT-001 SKILL text describing the team-mode patch-validation
+    loop is under-specified. Investigate: read
+    `doc-brd-fixer/SKILL.md` Remediate Mode §4 (Validate
+    non-regression), trace what actually happened in the live run,
+    add explicit dispatch-decision rules for multi-lens findings if
+    needed.
+- **Estimated effort:** ~1-2 hours of script + skill edits; one live
+  re-verification (~$5-7, ~15-20 min) to confirm Run #1's pass
+  criteria reach 6/6 instead of 4/6.
+- **Plugin version:** plugin v0.4.3 → v0.4.4 (small patch). Could
+  also ride along in PRD-RT-001 (TODO-RT1 below) if scheduling
+  aligns — same script + same fixer-SKILL touchpoints.
+- **DECISIONS.md entry:** D-0027 — "Autopilot timeout extends to
+  match audit (`*-autopilot` in the name-match); multi-lens fixer
+  findings dispatch all responsible lenses for validation."
+- **Verification artifacts to inspect** (already on disk from
+  2026-06-04 live runs but not committed):
+  - `examples/url-shortener/.aidoc/review/01_BRD/BRD-01/verdict.json`
+    (from Run #1) — confirms verdict.json schema is correct
+  - `examples/url-shortener/logs/2026-06-04T113650/elements/doc-brd-fixer.log`
+    — fixer reported outcome PASS but no slot dispatch
+  - `examples/url-shortener/logs/2026-06-04T122110/.aidoc/audit/01_BRD-audit.md`
+    (Run #2) — confirms single_pass advisory note works
+- **Sequencing note:** BRD-RT-003 should land **before** PRD-RT-001
+  if PRD-RT-001 wants its first live verification to reach 6/6
+  cleanly. Otherwise PRD-RT-001 will inherit the same G11/G12/G13
+  gaps and produce the same "4/6 pass" pattern.
+
 ### TODO-RT1 — PRD-RT-001: propagate BRD-RT pattern to the PRD layer
 
 - **Status:** PENDING — 2026-06-04T15:30:32Z
@@ -124,21 +181,45 @@ sketched in PR #69's caching-analysis discussion.
 
 ## Sequencing recommendation
 
-1. **First**: complete BRD-RT-002 live verification (~$10 for the two cheap
-   checks) — without it, both follow-ups risk building on a broken pattern.
-2. **Then PRD-RT-001** — propagates the pattern to the next layer at low
-   marginal cost. Forces the BRD-RT pattern to prove it generalises.
-   Validates the "Reusable from BRD-RT-002" claim before committing to
-   EARS/BDD/ADR/SPEC/TDD/IPLAN.
-3. **Then caching** — once 2 layers are proven on the Task-fan-out path,
-   the caching optimisation is a transparent perf improvement behind the
-   same contract. Saves real money when the full cascade starts running
-   regularly.
+Updated 2026-06-04 after BRD-RT-002 live verification (Run #1 + Run #2):
+
+1. **First — BRD-RT-003** (TODO-RT0): close G11/G12/G13 operational
+   gaps from Run #1. Without these, every per-layer team-mode run
+   will repeat the same 4/6 pass-criteria pattern (verdict-chain
+   works, but autopilot timeout + per-layer cap + fixer slot
+   dispatch all fail). Small PR (~1-2 hours + ~$7 re-verification).
+2. **Then PRD-RT-001** (TODO-RT1): propagates the BRD-RT pattern to
+   the PRD layer at low marginal cost once BRD-RT-003's fixes make
+   the pattern actually robust. Forces the pattern to prove it
+   generalises. Validates the "Reusable from BRD-RT-002" claim
+   before committing to EARS/BDD/ADR/SPEC/TDD/IPLAN.
+3. **Then caching** (TODO-RT2): once ≥2 layers are proven on the
+   Task-fan-out path, the caching optimisation is a transparent
+   perf improvement behind the same contract. Saves real money when
+   the full cascade starts running regularly.
 
 Reverse order is also viable (caching first, then PRD-RT) — that would
 mean PRD-RT-001 immediately inherits the cached runner. But it ships an
 unproven 2-layer wiring on top of a new dispatch mechanism, which is
-harder to debug if either breaks. Recommend PRD-RT-001 first.
+harder to debug if either breaks. Recommend BRD-RT-003 → PRD-RT-001 →
+caching.
+
+## BRD-RT-002 verification snapshot (2026-06-04)
+
+Two live runs against `examples/url-shortener` BRD layer:
+
+| | Run #1 (team mode) | Run #2 (single_pass) |
+|---|---|---|
+| Outcome | FAIL (7/1/1/9) | PASS (7/0/8/15) |
+| Wall-clock | 2569s (cap exceeded) | 764s (within cap) |
+| Pass criteria met | 4/6 | 5/5 |
+| Verdict-chain consistency | ✅ verified end-to-end | ✅ override-respect + advisory verified |
+
+Run #1 outcome FAIL is from `doc-brd-autopilot` timeout, not from
+verdict-chain drift. The architectural contract (synthesizer writes
+verdict.json, all consumers read it consistently) is **verified**;
+the operational issues are routine timeout tuning captured as
+TODO-RT0.
 
 ## Cross-references
 

--- a/plans/REVIEW-TEAM-FOLLOWUPS.md
+++ b/plans/REVIEW-TEAM-FOLLOWUPS.md
@@ -116,9 +116,10 @@ sketched in PR #69's caching-analysis discussion.
   (0.4.3 → 0.4.4) + plan PR + impl PR + live verification (~$5-7).
 - **Plugin version:** plugin v0.4.3 → v0.4.4. Framework spec unchanged.
   No GATE-SPEC.
-- **Decision register:** new D-0027 — "PRD-RT-001 inherits BRD-RT-002
+- **Decision register:** new D-0028 — "PRD-RT-001 inherits BRD-RT-002
   verdict-chain pattern; per-layer follow-ups for EARS-RT, BDD-RT,
   ADR-RT, SPEC-RT, TDD-RT, IPLAN-RT chain through the same pattern."
+  (D-0027 is reserved for BRD-RT-003 per TODO-RT0 above.)
 - **Next steps:** open plan PR `plans/PRD-RT-001-PLAN.md` covering the
   per-layer translation; verify against the BRD-RT-002 verification
   template; land impl PR.


### PR DESCRIPTION
## Summary

Records the BRD-RT-002 live verification (PR #73) results from 2026-06-04 and adds a new TODO entry covering three operational gaps surfaced by the runs.

**Tracking-only PR** — no code, skill, framework, or version changes.

## BRD-RT-002 verification outcome

Two live runs against `examples/url-shortener` BRD layer:

| | Run #1 (team mode) | Run #2 (single_pass) |
|---|---|---|
| Outcome | FAIL (7/1/1/9) | **PASS** (7/0/8/15) |
| Wall-clock | 2569s (cap exceeded) | 764s (within cap) |
| Pass criteria met | 4/6 | **5/5** |

**Architectural contract verified end-to-end** — `verdict.json` is written deterministically, all consumers (driver `parse_audit_score`, autopilot revise loop, audit-skill stdout, fixer) read consistent values, fallback chain works in both modes. The two Run #1 FAILs are operational timeout-sizing issues, not architectural defects.

## New TODO added — TODO-RT0 (BRD-RT-003)

Three gaps to close before per-layer team mode is robust for routine use:

| Gap | Issue | Fix |
|---|---|---|
| **G11** | `doc-brd-autopilot` hit 600s SKILL_TIMEOUT (exit 124) in team mode | Extend `AUDIT_TIMEOUT` name-match to `*-autopilot` OR new `AUTOPILOT_TIMEOUT=1800` |
| **G12** | BRD layer ran 2569s > 1800s cap (autopilot timeout + duplicate audit↔fix) | Likely resolved by G11; if not, raise cap to 3600s |
| **G13** | Fixer ran (487s, PASS) but produced no `<persona>.fix_<N>.json` slots — team-mode lens validation unverified | Investigate fixer behavior on multi-lens findings; add explicit dispatch rules |

Estimated effort: ~1-2 hours of script + skill edits + one re-verification (~\$7). Plugin v0.4.3 → v0.4.4.

## Sequencing update

Updated recommendation: **BRD-RT-003 → PRD-RT-001 → caching**. Reason: PRD-RT-001 would inherit the same G11/G12/G13 gaps if BRD-RT-003 doesn't ship first. Better to fix the BRD-layer ops issues once, then propagate the corrected pattern to PRD..IPLAN.

## Decision-register reservations

- D-0027 — BRD-RT-003 ("Autopilot timeout extends to match audit; multi-lens fixer findings dispatch all responsible lenses")
- D-0028 — PRD-RT-001 ("Per-layer follow-ups inherit BRD-RT-002 pattern")

## Verification artifacts on disk

Live-run logs from 2026-06-04 remain at:
- `examples/url-shortener/logs/2026-06-04T113650/` (Run #1, team mode)
- `examples/url-shortener/logs/2026-06-04T122110/` (Run #2, single_pass)

These are gitignored (per `examples/<NAME>/logs/<TS>/` rule) but accessible locally for BRD-RT-003 implementation.

## Commits

| Commit | Title |
|---|---|
| `dac97c0a` | record BRD-RT-002 live-verification findings + add TODO-RT0 |
| (follow-up) | D-0028 for PRD-RT-001 (D-0027 reserved for BRD-RT-003) |