### PR TITLE
docs(parity): update lens names — CHAOS-SEC-SPLIT-001 sweep follow-up

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -119,9 +119,9 @@ deterministic gate, and reduced findings).
 
 | Concern | Plugin | Hermes |
 |---------|--------|--------|
-| Crew runtime | `Task` subagents (`review-team` skill; lenses incl. `adversary`, `synthesizer`) | `saga_orchestrator` per-persona executor branches |
+| Crew runtime | `Task` subagents (`review-team` skill; lenses incl. `chaos_engineer`, `security_engineer`, `synthesizer`) | `saga_orchestrator` per-persona executor branches |
 | Blackboard | git-ignored `.aidoc/review/<artifact-id>/<persona>.json` slots | saga journal + branch summaries |
-| Persona names | framework names natively (`adversary`, `synthesizer`) | runtime names (`chaos_engineer`, `chairperson`) + alias map |
+| Persona names | framework names natively (`chaos_engineer`, `security_engineer`, `synthesizer`, …) | framework names natively (`chaos_engineer`, `security_engineer`, …); single remaining alias `chairperson` → `synthesizer` |
 | Reduce / score | `synthesizer` subagent (rule-driven) | `saga_reducer` + `review_scoring.py` (code) |
 | Resilience | partial-crew → coverage; below quorum → low-confidence (D-0005: blackboard, no saga) | saga retries/compensation; degrade above quorum, escalate below |
 | Report | unified report (`UCR_OUTPUT_UNIFIED` / audit report) | `PERSONA_REVIEW_REPORT` / saga summary |


### PR DESCRIPTION
## Summary

Closes a residual gap from CHAOS-SEC-SPLIT-001 (#79): two stale `adversary` references in `docs/PARITY.md`'s "Review team (multi-persona review)" comparison table.

PR #79's Step 7a grep paths covered `framework/`, `platforms/`, `tests/scripts/`, and `tests/conformance/fixtures/` — but not `docs/`. This PR closes that residual gap.

## Changes

- **`docs/PARITY.md:122`** — "Crew runtime" row: plugin lens enumeration `adversary, synthesizer` → `chaos_engineer, security_engineer, synthesizer`.
- **`docs/PARITY.md:124`** — "Persona names" row: rewritten to reflect post-CHAOS-SEC-SPLIT-001 state where both platforms use framework names natively; only non-identity alias remaining in Hermes is `chairperson → synthesizer`.

## What stays unchanged

- Output-parity contract (`tests/conformance/test_review_report_parity.py`) — both runners still validate against the same `review_report.schema.json`.
- D-0005 (plugin uses blackboard, not saga) — functional parity philosophy intact.

## Process note

A note has been added in the commit body for future per-layer plans (PRD-RT-001 etc): add `docs/` to the adversary/lens-rename sweep paths to avoid this class of miss.

## Test plan

- [x] Lint passes locally (pre-commit + conformance)
- [ ] CI parity check (`test_review_report_parity.py`) stays green — only display-table text changed, no schema or fixture changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)