### PR TITLE
docs(claude-md): mandate two-cycle plan review before impl

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,8 +42,19 @@ verify → land:
 
 1. **Plan** into `plans/` (start from `plans/PLAN-TEMPLATE.md`) before touching
    code.
-2. **Review (≥2 passes)** — record findings in the plan's `## Review log`;
-   harden until a pass finds nothing.
+2. **Two-cycle gap review (mandatory)** — once a plan is created, it MUST
+   complete at least **two full review cycles** before implementation begins.
+   Each cycle = *review to identify gaps → patch the plan to address every
+   gap → re-review the patched plan*. The plan is ready for impl only when
+   the second cycle's re-review surfaces no new substantive gaps (or all
+   surfaced gaps have been folded into the plan via further patches).
+   Record every cycle in the plan's `## Review log` with an ISO-stamped
+   `Pass N` entry that lists the gaps found and how each was resolved.
+   Cycle N+1 must always re-validate that cycle N's patches did not
+   introduce new inconsistencies. Continue cycling until a review surfaces
+   nothing; minimum is two cycles. Skipping the second cycle is forbidden
+   — the rule exists because every plan touched in this repo so far has
+   surfaced material gaps in the second pass that the first pass missed.
 3. **Implement**, updating the plan with ISO-stamped progress.
 4. **Verify** — run the conformance suite + the platform's own tests; nothing
    is "done" until they pass.


### PR DESCRIPTION
## Summary

Adds a durable rule to `CLAUDE.md` §"Development workflow" item 2: every plan must complete at least **two full review→patch→re-review cycles** before implementation begins.

## Rule (verbatim)

> **Two-cycle gap review (mandatory)** — once a plan is created, it MUST complete at least **two full review cycles** before implementation begins. Each cycle = *review to identify gaps → patch the plan to address every gap → re-review the patched plan*. The plan is ready for impl only when the second cycle's re-review surfaces no new substantive gaps (or all surfaced gaps have been folded into the plan via further patches). Record every cycle in the plan's `## Review log` with an ISO-stamped `Pass N` entry that lists the gaps found and how each was resolved. Cycle N+1 must always re-validate that cycle N's patches did not introduce new inconsistencies. Continue cycling until a review surfaces nothing; minimum is two cycles. Skipping the second cycle is forbidden — the rule exists because every plan touched in this repo so far has surfaced material gaps in the second pass that the first pass missed.

## Why

Every plan in this repo so far has surfaced material gaps in Pass 2 or later that the initial draft missed:

- **CHAOS-SEC-SPLIT-001 Pass 4** (post-merge) caught 9 critical gaps — including the missing `synthesizer.md` hardcoded reference and the missing conformance fixture updates — both would have broken CI mid-impl.
- **SAGA-PARITY-001 Phase 1 Pass 4** caught the engine-token hygiene violation that would have made the framework spec engine-specific.
- **BRD-RT-002 Pass 3** caught 10 gaps including the verdict-chain consistency requirement that prevented driver-vs-synthesizer score divergence.
- **PRD-RT-001 Pass 3** caught 7 gaps about multi-agent same-lens dispatch.

The pattern is: first pass catches structural issues; second pass catches consequences of the first pass's fixes; third pass (when needed) catches downstream cite drift. Two cycles is the minimum that catches both layers.

## Companion auto-memory

The rule is also captured in the user's auto-memory at `~/.claude/projects/-opt-data-aidoc-flow/memory/feedback_two_cycle_plan_review.md` (not in the repo) so any Claude session working in this directory sees the rule even before reading CLAUDE.md.

## Test plan

- [x] Pre-commit + conformance pass locally
- [ ] No behavioral impact — pure documentation change

🤖 Generated with [Claude Code](https://claude.com/claude-code)