### PR TITLE
docs(claude-md): clarify two-cycle rule + add 'submit only finalized work' principle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,19 @@ the 8-layer SDD flow (BRD → PRD → EARS → BDD → ADR → SPEC → TDD → 
 
 ## Durable conventions
 
+- **Submit only finalized work.** Any PR (plan or impl) must already
+  have completed its review-and-fix cycles locally — what gets pushed
+  is the *final* version, not a draft awaiting later amendment. The
+  pattern of "submit, then review post-merge, then patch via amendment
+  PR" is explicitly forbidden (see §"Development workflow" item 2 for
+  plan-specific cycles; the same principle applies to impl PRs:
+  self-review locally, fix, re-review, only then push). Amendment PRs
+  to recently-merged work are a smell that the original PR was
+  submitted prematurely. **Exception**: real new work that emerges
+  AFTER a PR lands (a bug discovered during user-facing testing, a
+  feature request that builds on the merged work, a follow-up phase)
+  is legitimate as a NEW plan + impl pair — not as a retroactive
+  "amendment" to plug gaps that should have been caught pre-PR.
 - **The framework spec is the contract.** Engine-agnostic; carries no platform
   names or runtime code. Each platform declares the spec version it conforms to
   in `platforms/<name>/FRAMEWORK_SPEC_VERSION`, which must match
@@ -42,25 +55,55 @@ verify → land:
 
 1. **Plan** into `plans/` (start from `plans/PLAN-TEMPLATE.md`) before touching
    code.
-2. **Two-cycle gap review (mandatory)** — once a plan is created, it MUST
-   complete at least **two full review cycles** before implementation begins.
-   Each cycle = *review to identify gaps → patch the plan to address every
-   gap → re-review the patched plan*. The plan is ready for impl only when
-   the second cycle's re-review surfaces no new substantive gaps (or all
-   surfaced gaps have been folded into the plan via further patches).
+2. **Two-cycle gap review (mandatory, BEFORE the plan PR opens)** —
+   once a plan draft exists, it MUST complete at least **two full review
+   cycles BEFORE the plan PR is opened**. Each cycle =
+   *review to identify gaps → patch the plan to address every gap →
+   re-review the patched plan*. The plan PR opens ONLY when a review
+   pass has surfaced no new substantive gaps. Implementation begins
+   ONLY after the plan PR has been merged.
+
    Record every cycle in the plan's `## Review log` with an ISO-stamped
    `Pass N` entry that lists the gaps found and how each was resolved.
    Cycle N+1 must always re-validate that cycle N's patches did not
-   introduce new inconsistencies. Continue cycling until a review surfaces
-   nothing; minimum is two cycles. Skipping the second cycle is forbidden
-   — the rule exists because every plan touched in this repo so far has
-   surfaced material gaps in the second pass that the first pass missed.
+   introduce new inconsistencies. Continue cycling until a review
+   surfaces nothing; minimum is two cycles.
+
+   **What is forbidden:**
+   - Opening a plan PR with a draft that has not completed at least
+     two review cycles.
+   - Performing post-merge review of a plan and then opening
+     "amendment" PRs against that plan to patch gaps that should have
+     been caught pre-PR. Such amendments amount to merging unreviewed
+     plans, which defeats the rule's purpose.
+   - Starting implementation while gap-review cycles are still open.
+
+   **Worked sequence:**
+
+   ```
+   draft plan → Pass 1 (self-review, fold in gaps)
+              → Pass 2 (re-review, may surface new gaps from Pass 1 patches)
+              → Pass 3 (codebase cross-check, fold in)
+              → [continue if any pass surfaces gaps]
+              → final pass surfaces zero substantive gaps
+              → OPEN plan PR
+              → review/merge
+              → impl PR (with TodoWrite, code changes, verification)
+   ```
+
+   The rule exists because every plan touched in this repo so far has
+   surfaced material gaps in the second-or-later pass that the first
+   pass missed. Merging an under-reviewed plan and amending later
+   wastes PR overhead and obscures the design history. All cycles
+   happen against the draft, in the same branch, before PR submission.
 3. **Implement**, updating the plan with ISO-stamped progress.
 4. **Verify** — run the conformance suite + the platform's own tests; nothing
    is "done" until they pass.
 5. **Land** — one logical change per commit, conventional prefix (`docs:`,
    `feat:`, `fix:`, `refactor:`, `chore:`); update `CHANGELOG.md` / `ROADMAP.md`
-   as needed.
+   as needed. **Submit only the final, reviewed-and-fixed version**
+   (see §"Durable conventions" — no intermediate WIP submissions
+   awaiting follow-up amendment PRs).
 
 Record non-obvious choices in `plans/DECISIONS.md` (ISO-stamped).
 


### PR DESCRIPTION
## Summary

Two related fixes to `CLAUDE.md`, motivated by the user spotting the pattern of merging unreviewed plans + amending post-merge.

## 1. Clarify the two-cycle rule (Development workflow item 2)

Original rule (PR #86) said "two cycles before implementation begins" but didn't bound WHEN those cycles run. This led to:

```text
a. Draft plan with 3 inline passes
b. Open plan PR (WITH UNREVIEWED GAPS)
c. Merge plan PR
d. Do Pass 4 gap-review POST-MERGE
e. Open "Pass-4 amendment" PR
f. Merge that
g. Then impl
```

This merged unreviewed plans, then reviewed them, then patched via separate PRs — defeating the rule's purpose. **5 amendment PRs followed this pattern** (CHAOS-SEC-SPLIT-001, SAGA-PARITY-001 Phase 1, Phase 2, Amendment 1).

**Fix**: rule now explicitly says all review cycles happen BEFORE the plan PR opens. Plus:

- Explicit "forbidden" list: opening PR before two cycles complete; post-merge gap review + amendment PRs against the plan; starting impl while cycles are still open
- Worked sequence: draft → Pass 1 → Pass 2 → Pass 3 → … → final pass surfaces zero → OPEN PR → merge → impl

## 2. New "Submit only finalized work" principle (Durable conventions)

Generalizes the plan-specific rule to ALL PRs (plan and impl):

> Any PR must already have completed its review-and-fix cycles locally — what gets pushed is the *final* version, not a draft awaiting later amendment. Amendment PRs to recently-merged work are a smell that the original PR was submitted prematurely.

Includes the legitimate-follow-up **exception**: real new work that emerges AFTER a PR lands (bug discovered during user-facing testing; feature request; follow-up phase) is legitimate as a NEW plan + impl pair, not a retroactive amendment.

§"Land" step 5 lightly reinforces with a one-line cross-reference.

## Auto-memory updates

Three changes in `~/.claude/projects/-opt-data-aidoc-flow/memory/`:

- `feedback_two_cycle_plan_review.md` — updated for the "before PR" clarification; cites the four post-merge-amendment examples that motivated this fix
- `feedback_submit_only_final.md` (NEW) — captures the broader principle for all PRs
- `MEMORY.md` index updated

## What this means for in-flight work

- The **SAGA-PARITY-001 Phase 2 Amendment 1 Pass 4** I was about to draft is the LAST acceptable post-merge amendment under the clarified rule
- The 7 gap-fixes I found (A1, A3, A4, A5/A6, A7, A8, A9) still need landing — they go in **`plan/saga-parity-001-phase-2-amend-001-pass4`** PR as a one-time cleanup, NOT as a new pattern
- Going forward, all review-and-fix cycles run pre-PR

## Test plan

- [x] Pre-commit + conformance pass locally
- [ ] No behavioral impact — pure documentation change

🤖 Generated with [Claude Code](https://claude.com/claude-code)