### PR TITLE
docs(claude-md): minimal-and-realistic plans rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,24 @@ the 8-layer SDD flow (BRD → PRD → EARS → BDD → ADR → SPEC → TDD → 
   feature request that builds on the merged work, a follow-up phase)
   is legitimate as a NEW plan + impl pair — not as a retroactive
   "amendment" to plug gaps that should have been caught pre-PR.
+- **Minimal-and-realistic plans.** A plan should be sized to the
+  problem it addresses, not "a perfect plan to do everything." A plan
+  that addresses N substantive issues should propose ~N fixes, not N
+  speculative features bundled with them. **Signal that you've
+  over-engineered:** Pass 1 review surfaces more gaps than the original
+  problem had substantive issues, and most of those gaps trace to
+  speculative scope (designs without a named issue) rather than the
+  core fixes. When you catch this mid-draft, cut to the minimum
+  sufficient design that catches every discovered issue, and park the
+  speculative items as a one-line backlog enumeration in the plan's
+  "Out of scope" section. Do NOT draft those speculative items here.
+  The next iteration can build on this one if the deferred items
+  actually surface in practice. *Origin:* REVIEW-CALIBRATION-001
+  (2026-06-06) — 5 missed BRD review findings drafted as 9 designs
+  (532 lines); Pass 1 surfaced 18 gaps, 14 of which originated from
+  speculative scope; slim rewrite to 3 designs (315 lines) caught the
+  same 5 findings and eliminated 14 of 18 gaps, dropping plugin SemVer
+  from MINOR + framework MINOR (GATE-SPEC) to plugin PATCH alone.
 - **The framework spec is the contract.** Engine-agnostic; carries no platform
   names or runtime code. Each platform declares the spec version it conforms to
   in `platforms/<name>/FRAMEWORK_SPEC_VERSION`, which must match


### PR DESCRIPTION
## Summary

Adds a new Durable convention to \`CLAUDE.md\`: **plans should be sized to the problem they address, not "perfect plans to do everything."**

## Why

A plan that addresses N substantive issues should propose ~N fixes, not N speculative features bundled with them. Signal that you've over-engineered: Pass 1 review surfaces more gaps than the original problem had substantive issues, and most of those gaps trace to speculative scope (designs without a named discovered issue) rather than the core fixes.

When you catch this mid-draft, cut to the minimum sufficient design that catches every discovered issue, and park the speculative items as a one-line backlog enumeration in the plan's "Out of scope" section. Trust the iteration loop.

## Origin

REVIEW-CALIBRATION-001 (drafted 2026-06-06):

- Initial draft: 532 lines, 9 designs, for 5 missed BRD-01 review findings.
- Pass 1 review: 18 gaps surfaced. **14 of 18 originated from speculative scope** (a new \`consumer_simulator\` lens, weight rebalance across 8 layers, framework-spec change with GATE-SPEC, per-lens-min PASS gate, \`sdd_doc_lint\` extension).
- Slim rewrite: 315 lines, 3 designs (lens-prompt sub-checks for \`auditor\` + \`business_analyst\` + \`security_engineer\`). Caught the same 5 findings; eliminated 14 of 18 gaps.
- SemVer impact dropped from plugin MINOR + framework MINOR (GATE-SPEC) to plugin PATCH alone.

## Companion auto-memory

Captured as \`feedback-plans-minimal-and-realistic\` in \`~/.claude/projects/-opt-data-aidoc-flow/memory/\` so future sessions inherit the rule.

## Test plan

- [x] \`pre-commit run --files CLAUDE.md\` green
- [x] Markdownlint passes
- [x] No code or behavior changes — docs-only PR