### PR TITLE
docs: post-session refresh (framework spec 0.13.0, plugin v0.6.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,65 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed — Claude Code plugin (plugin-only; no spec change)
+
+Plugin-side post-spec-0.13.0 work. The framework spec stays at `0.13.0`;
+the entries below describe how the plugin implements (and iterates on
+the implementation of) the saga-lifecycle contract codified in
+SAGA-PARITY-001 Phase 1. See
+[`platforms/claude-code-plugin/CHANGELOG.md`](platforms/claude-code-plugin/CHANGELOG.md)
+for the per-release plugin detail.
+
+- **Plugin v0.6.0 — BRD-layer saga via cooperative enforcement
+  (SAGA-PARITY-001 Phase 2).** First plugin implementation of the
+  framework saga lifecycle; SKILL-prompt-driven cooperative
+  enforcement of state-machine transitions. Empirically failed
+  end-to-end verification (invalid transitions, non-terminal final
+  status, no actual subprocess dispatch); fixed in Amendment 1
+  (below).
+- **Plugin v0.6.1 — preemptive saga driver
+  (SAGA-PARITY-001 Phase 2 Amendment 1).** New `tools/saga_driver.py`
+  (Python stdlib-only) replaces cooperative enforcement with
+  deterministic script-driven enforcement; vendored alongside the
+  framework bundle. 7 in-flight bugs (B1-B7) fixed on the same branch
+  per the submit-only-finalized-work principle. Verified end-to-end on
+  the 4th live BRD cascade: `status: CLOSED`, score 96/100, 10/10
+  pass criteria. PRD..IPLAN saga driver propagation deferred to
+  Phase 4.
+- **Plugin v0.6.2 — 5 content sub-checks across 8 audit SKILLs
+  (REVIEW-CALIBRATION-001).** Adds A1 cell-actionability + A2
+  assumption-capture + A3 cross-section pointer-validity (auditor
+  lens), BA1 acceptance-criterion testability (business_analyst
+  lens), SE1 deferred-decision safety (security_engineer lens) —
+  uniformly applied across all 8 layer audit SKILLs. Catches 5
+  substantive content-quality issues that v0.6.1's review missed
+  (visit-count AC untestable; sync-response content unspecified;
+  qualitative budget non-actionable; assumption-shaped prose buried
+  in FRs; Med/High risks with deferred mitigation). Verified
+  before/after on the saved BRD-01: all 5 issues remediated. No
+  spec touch, no new lens, no weight changes.
+
+### Added — Project-level conventions
+
+- **"Submit only finalized work" durable convention**
+  (CLAUDE.md, [#90](https://github.com/vladm3105/aidoc-flow-framework/pull/90)) —
+  every PR (plan or impl) must already have completed its
+  review-and-fix cycles locally; post-merge amendment PRs to recently-
+  merged work are forbidden.
+- **"Minimal-and-realistic plans" durable convention**
+  (CLAUDE.md, [#93](https://github.com/vladm3105/aidoc-flow-framework/pull/93)) —
+  a plan should be sized to the problem it addresses, not "a perfect
+  plan to do everything"; speculative scope gets parked as one-line
+  backlog enumeration, not drafted.
+- **Two-cycle plan review (mandatory)**
+  (CLAUDE.md, [#86](https://github.com/vladm3105/aidoc-flow-framework/pull/86) + [#90](https://github.com/vladm3105/aidoc-flow-framework/pull/90)) —
+  every plan must complete ≥2 full review→patch→re-review cycles
+  BEFORE the plan PR opens.
+- **Plugin-first development sequencing**
+  (ROADMAP.md, [#97](https://github.com/vladm3105/aidoc-flow-framework/pull/97)) —
+  features land on the plugin first; Hermes follow-on batches per
+  `plans/HERMES-BACKLOG.md`.
+
 ### Changed — Framework Spec 0.12.0 → 0.13.0 (CHG-gated)
 
 - **Review-saga lifecycle promoted to framework spec

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ The platforms share the `framework/` spec and nothing else. Both pass the same
 shared conformance suite (`tests/conformance/`). The `framework/` spec defines
 the 8-layer SDD flow (BRD → PRD → EARS → BDD → ADR → SPEC → TDD → IPLAN → Code).
 
-**Current state (as of 2026-06-01):** framework spec `0.11.0`, Claude Code plugin `0.4.0` (pre-1.0 preview, 52 skills = 50 active + 2 deprecated stubs). IPLAN ↔ iplanic integration deferred — see `plans/IPLAN-IPLANIC-DEFERRED.md`.
+**Current state (as of 2026-06-06):** framework spec `0.13.0`, Claude Code plugin `0.6.2` (pre-1.0 preview, 52 skills = 50 active + 2 deprecated stubs). Plugin BRD layer ships preemptive saga driver (SAGA-PARITY-001 Phase 2 Amendment 1) + 5 content sub-checks across all 8 layer audit SKILLs (REVIEW-CALIBRATION-001). Plugin-first development sequencing; Hermes follow-on tracked in [`plans/HERMES-BACKLOG.md`](plans/HERMES-BACKLOG.md). IPLAN ↔ iplanic integration deferred — see `plans/IPLAN-IPLANIC-DEFERRED.md`.
 
 ## Durable conventions
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ From Claude Code:
 
 The migration is complete (cutover shipped as `v1.0.0`); the project is now in
 **post-cutover development** — latest project release `v1.1.0`, framework spec
-`0.11.3`. The Claude Code plugin (`platforms/claude-code-plugin/`) is currently a **pre-1.0 preview** (v0.6.2); APIs and surfaces may change before 1.0. The framework spec is stable at `0.11.3`. Post-v1.0 work to date:
+`0.13.0`. The Claude Code plugin (`platforms/claude-code-plugin/`) is currently a **pre-1.0 preview** (v0.6.2); APIs and surfaces may change before 1.0. The framework spec is at `0.13.0`. Post-v1.0 work to date:
 
 - the project adaptation overlay (`framework/governance/ADAPTATION.md` + the closed-knob `ADAPTATION_SURFACE.yaml`);
 - the **GATE-SPEC** change-management gate (`framework/governance/chg/`);
@@ -78,6 +78,11 @@ The migration is complete (cutover shipped as `v1.0.0`); the project is now in
 - the **token-efficient authoring** governance (`framework/governance/AUTHORING_STYLE.md`) wired into every layer's `_size_target` and into every audit skill;
 - the **`.aidoc/` provenance tier** — committed audit/review/remediation/validation/security/quality reports (`framework/docs/AIDOC.md`);
 - the **pre-deployment acceptance test suite** (`tests/scripts/test-acceptance.sh` + [`tests/ACCEPTANCE.md`](tests/ACCEPTANCE.md)) that drives every active plugin surface element (50 skills + 11 agents + 1 command + 1 hook) against a named example's seed as the release gate, with resume on interrupt, partial-execution flags (`--element`, `--from-layer`, `--to-layer`, `--dry-run`), and `--promote` to commit the produced chain;
+- the **`adversary` lens partition** (CHAOS-SEC-SPLIT-001, framework `0.12.0`) — split into `chaos_engineer` (reliability/NFR/failure-mode) + `security_engineer` (threat-model/security-controls) with per-layer crew weight redistribution in `REVIEW_CREWS.yaml`;
+- the **review-saga lifecycle promoted to spec** (SAGA-PARITY-001 Phase 1, framework `0.13.0`) — `REVIEW_SAGA.md` + `saga.schema.json` codify the engine-agnostic state machine + journal schema + break-circuit policy that both platforms align to;
+- the **plugin BRD saga driver** (SAGA-PARITY-001 Phase 2 + Amendment 1, plugin `0.6.1`) — `tools/saga_driver.py` (Python stdlib-only) replaces cooperative-enforcement SKILL-prompt loop with preemptive script-driven enforcement; vendored alongside the framework bundle in the plugin distribution;
+- the **content sub-checks** (REVIEW-CALIBRATION-001, plugin `0.6.2`) — A1 cell-actionability + A2 assumption-capture + A3 cross-section pointer-validity (auditor) + BA1 acceptance-criterion testability (business_analyst) + SE1 deferred-decision safety (security_engineer), applied uniformly across all 8 layer audit SKILLs;
+- the **plugin-first development sequencing** (2026-06-06) — features land on the plugin first; Hermes follow-on batches per [`plans/HERMES-BACKLOG.md`](plans/HERMES-BACKLOG.md);
 - pre-commit + CI security tooling (CodeQL, bandit, detect-secrets, pip-audit, gitleaks, Dependabot).
 
 ## Contributing

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -120,7 +120,7 @@ Change Management for the full policy.
 ## Post-v1.0 — Shipped
 
 Delivered after the cutover (project release `v1.1.0`; framework spec `0.1.0 →
-0.11.2`):
+0.13.0`):
 
 - **Canonical plugin skill set** — the corpus was pruned/recreated to one
   standard (P3-T6/T7) and settled at **52 skills (50 active + 2 deprecated stubs)** in plugin v0.4.0, after `skill-recommender`/`workflow-optimizer`/`context-analyzer` folded into `doc-flow` and `doc-review`/`trace-check` were folded into `doc-validator` (the latter two retained as deprecation redirects through v0.5.0).
@@ -140,6 +140,11 @@ Delivered after the cutover (project release `v1.1.0`; framework spec `0.1.0 →
   markdownlint, yamllint, detect-secrets, **gitleaks**, pip-audit, conformance) and CI
   workflows for pre-commit, **CodeQL**, and the GATE-SPEC gate; `SECURITY.md`;
   refreshed `.github/` metadata (CODEOWNERS, dependabot, labeler — INFRA-1).
+- **`adversary` lens partition** (framework `0.12.0`, CHAOS-SEC-SPLIT-001, D-0030) — split the single `adversary` review lens into `chaos_engineer` (reliability / NFR / failure-mode) + `security_engineer` (threat-model / security-controls) with per-layer crew weight redistribution in `REVIEW_CREWS.yaml` (BRD: chaos 12 / security 8; ADR: chaos 8 / security 12; PRD/SPEC/TDD equal; IPLAN chaos-only). `REVIEW_TEAM.md` adds a `## Weight allocation rules` subsection codifying the four-category allocation protocol.
+- **Review-saga lifecycle promoted to framework spec** (framework `0.13.0`, SAGA-PARITY-001 Phase 1, D-0031) — `framework/governance/REVIEW_SAGA.md` codifies the engine-agnostic saga state machine (11 states), transition table, journal schema, break-circuit policy, and `FRAMEWORK_SPEC_VERSION` semantics; `framework/governance/saga.schema.json` is the formal JSON Schema for the per-run saga journal. Supersedes D-0005's scope-narrowing premise; both platforms declare intent to conform.
+- **Plugin BRD saga driver** (plugin `0.6.0` → `0.6.1`, SAGA-PARITY-001 Phase 2 + Amendment 1) — first plugin implementation of the saga lifecycle. v0.6.0 used cooperative enforcement (SKILL-prompt-driven) and empirically failed live verification. Amendment 1 (v0.6.1) replaced it with `tools/saga_driver.py` (Python stdlib-only, vendored alongside the framework bundle): preemptive script-driven enforcement; reads/writes `saga.json` directly; validates every transition against an embedded table; dispatches each phase as a separate `claude -p` subprocess with `timeout 1800s`. 7 in-flight bugs (B1-B7) fixed on the same branch per the submit-only-finalized-work principle. Verified end-to-end on the 4th live BRD cascade (`status: CLOSED`, score 96/100, 10/10 pass criteria). PRD..IPLAN propagation deferred to Phase 4.
+- **5 content sub-checks across 8 audit SKILLs** (plugin `0.6.2`, REVIEW-CALIBRATION-001) — adds A1 cell-actionability + A2 assumption-capture + A3 cross-section pointer-validity (auditor lens), BA1 acceptance-criterion testability (business_analyst lens), SE1 deferred-decision safety (security_engineer lens) uniformly across all 8 layer audit SKILLs. Catches 5 substantive content-quality issues that v0.6.1's review missed; before/after BRD comparison confirmed remediation. Section references use concept names not § numbers so wording is uniform across layer templates. No spec touch, no new lens.
+- **Project-level conventions** — "Submit only finalized work" + "Minimal-and-realistic plans" + "Two-cycle plan review" + "Plugin-first sequencing" — codified in CLAUDE.md and ROADMAP.md. Deferred Hermes work tracked in `plans/HERMES-BACKLOG.md`.
 
 ## Post-v1.0 — Planned Capabilities
 

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -1,5 +1,47 @@
 # Session Handoff
 
+> **🟢 PLUGIN BRD LAYER COMPLETE — 2026-06-06.** Framework spec `0.13.0` /
+> plugin `0.6.2` / project `v1.1.0`. The plugin's BRD-layer machinery is
+> shipped and end-to-end verified. **Five PRs landed this session:**
+> #92 (plugin v0.6.1 — SAGA-PARITY-001 Phase 2 Amendment 1: preemptive
+> `tools/saga_driver.py` replaces cooperative-enforcement SKILL prompts;
+> 7 in-flight bugs B1-B7 fixed on the same branch); #93 (CLAUDE.md
+> "Minimal-and-realistic plans" durable convention); #95 (plan PR for
+> REVIEW-CALIBRATION-001); #96 (plugin v0.6.2 — 5 content sub-checks
+> across 8 audit SKILLs; verified end-to-end against a saved
+> before-fix BRD-01); #97 (plugin-first development-sequencing policy
+>
+> + `plans/HERMES-BACKLOG.md`).
+>
+> **Three new auto-memory entries** (in
+> `~/.claude/projects/-opt-data-aidoc-flow/memory/`):
+> `feedback-skill-drift-under-preemptive-driver`,
+> `feedback-plans-minimal-and-realistic`,
+> `feedback-plugin-first-then-hermes`.
+>
+> **Plugin BRD layer is the testbed** — saga driver + sub-checks both
+> verified by the url-shortener acceptance cascade. The 5 sub-checks
+> already shipped to PRD..IPLAN audit SKILLs (same wording, generic
+> section concepts); only the autopilot SKILLs for those 7 layers
+> still need the saga-driver dispatch pattern.
+>
+> **Hermes work explicitly deferred** —
+> [`HERMES-BACKLOG.md`](HERMES-BACKLOG.md) is the single source of
+> truth for what Hermes needs to catch up on (currently H-1
+> SAGA-PARITY-001 Phase 3 G-R1 invariant; H-2 REVIEW-CALIBRATION-001
+> lens sub-checks). Hermes-side iteration batches later.
+>
+> **Natural next item:** SAGA-PARITY-001 Phase 4 — propagate the saga
+> driver from BRD to PRD..IPLAN (7 layer `doc-*-autopilot` SKILLs need
+> the same slim-and-dispatch pattern Amendment 1 brought to
+> `doc-brd-autopilot`).
+>
+> **Local branches remaining** (no remote): `plan/prd-rt-001-team-mode`
+> (older draft); `plan/saga-parity-001-phase-3` (predates Amendment 1,
+> needs refresh per HERMES-BACKLOG H-1 — do not open as-is).
+>
+> ---
+>
 > **🟢 CONSOLIDATION REVIEW FIXES — 2026-05-27.** A code review of the 55→50
 > consolidation (3 finder passes) caught a real **correctness regression** and
 > some capability flattening; all fixed on `claude/multi-platform-migration-AamWB`.


### PR DESCRIPTION
## Summary

Refreshes 5 docs that were stale after this session's 5 merged PRs (#92, #93, #95, #96, #97). Docs-only; no code changes; no SemVer impact.

## Files changed

| File | What |
|---|---|
| `CLAUDE.md` | "Current state" line: framework spec `0.11.0` → `0.13.0`, plugin `0.4.0` → `0.6.2`. Brief mention of saga driver, sub-checks, plugin-first sequencing. |
| `README.md` | Status line: framework spec `0.11.3` → `0.13.0`. Added 5 new "Post-v1.0 work to date" bullets for CHAOS-SEC-SPLIT-001, SAGA-PARITY-001 (Phase 1 spec + Phase 2 + Amendment 1 plugin), REVIEW-CALIBRATION-001, and plugin-first sequencing. |
| `CHANGELOG.md` (root) | New entries under `[Unreleased]`: "Changed — Claude Code plugin" (v0.6.0 → v0.6.1 → v0.6.2 summary) + "Added — Project-level conventions" (the 4 durable conventions added this session). Existing framework-spec `0.12.0 → 0.13.0` entry preserved. |
| `ROADMAP.md` | "Post-v1.0 — Shipped" header range bumped (`0.1.0 → 0.11.2` → `0.1.0 → 0.13.0`). 5 new bulleted items appended for the post-spec-0.13.0 work. |
| `plans/HANDOFF.md` | New 2026-06-06 current-state header prepended at top (existing journal entries preserved as history). Names the 5 PRs, 3 new memory entries, testbed status, Hermes deferral, and natural next item (Phase 4). |

## What's NOT touched

Per the minimal-and-realistic plans rule (CLAUDE.md): only update what's stale, don't expand beyond that.

- `docs/PARITY.md`, `docs/TAGGING.md` — already at v0.6.2 (updated in PR #96).
- `ROADMAP.md` "Development sequencing — plugin-first" section — already added in PR #97.
- `platforms/claude-code-plugin/CHANGELOG.md` — already current.
- Older session-handoff entries in `HANDOFF.md` — preserved as history.

## Test plan

- [x] `pre-commit run` on all 5 files → green (markdownlint applied minor autofixes; conformance unaffected)
- [x] No code changes — docs-only PR
- [x] Cross-references between docs verified (README ↔ ROADMAP ↔ HANDOFF ↔ HERMES-BACKLOG.md)