### PR TITLE
fix(sdd_doc_lint): skip STRUCT01 for *-INDEX docs (task #239)

### DIFF
--- a/platforms/claude-code-plugin/sdd_doc_lint/__init__.py
+++ b/platforms/claude-code-plugin/sdd_doc_lint/__init__.py
@@ -768,10 +768,24 @@ def _check_required_template_sections(
     artifact: str | None,
     registry: Path | None,
 ) -> list[Finding]:
-    """STRUCT01: every required <TYPE>-TEMPLATE.yaml section must appear as a ## heading."""
+    """STRUCT01: every required <TYPE>-TEMPLATE.yaml section must appear as a ## heading.
+
+    Frontmatter `artifact_type` overrides the path-inferred artifact when the
+    document declares an `<X>-INDEX` variant (e.g. `BRD-INDEX` for
+    `BRD-00_index.md`). Index docs have their own template
+    (`<X>-NN_index.TEMPLATE.md`) and intentionally diverge from the standard
+    `<X>-TEMPLATE.yaml` section set; applying the standard template's
+    required-sections check to an index would produce spurious STRUCT01
+    findings.
+    """
     findings: list[Finding] = []
     if not artifact:
         return findings
+    fm = _extract_frontmatter(text)
+    if fm:
+        declared = str(fm.get("artifact_type") or "").strip()
+        if declared.endswith("-INDEX"):
+            return findings
     targets = _load_section_targets(artifact, registry)
     if not targets:
         return findings

--- a/platforms/hermes/sdd_doc_lint/__init__.py
+++ b/platforms/hermes/sdd_doc_lint/__init__.py
@@ -768,10 +768,24 @@ def _check_required_template_sections(
     artifact: str | None,
     registry: Path | None,
 ) -> list[Finding]:
-    """STRUCT01: every required <TYPE>-TEMPLATE.yaml section must appear as a ## heading."""
+    """STRUCT01: every required <TYPE>-TEMPLATE.yaml section must appear as a ## heading.
+
+    Frontmatter `artifact_type` overrides the path-inferred artifact when the
+    document declares an `<X>-INDEX` variant (e.g. `BRD-INDEX` for
+    `BRD-00_index.md`). Index docs have their own template
+    (`<X>-NN_index.TEMPLATE.md`) and intentionally diverge from the standard
+    `<X>-TEMPLATE.yaml` section set; applying the standard template's
+    required-sections check to an index would produce spurious STRUCT01
+    findings.
+    """
     findings: list[Finding] = []
     if not artifact:
         return findings
+    fm = _extract_frontmatter(text)
+    if fm:
+        declared = str(fm.get("artifact_type") or "").strip()
+        if declared.endswith("-INDEX"):
+            return findings
     targets = _load_section_targets(artifact, registry)
     if not targets:
         return findings

--- a/tests/unit/test_sdd_doc_lint_struct01.py
+++ b/tests/unit/test_sdd_doc_lint_struct01.py
@@ -26,6 +26,19 @@ class Struct01Tests(unittest.TestCase):
             )
             return json.loads(result.stdout or "[]")
 
+    def _run_lint_with_name(self, body: str, filename: str) -> list[dict]:
+        with tempfile.TemporaryDirectory() as td:
+            f = Path(td) / filename
+            f.write_text(body, encoding="utf-8")
+            result = subprocess.run(
+                [sys.executable, "-m", "sdd_doc_lint", td, "--format=json"],
+                env={"PYTHONPATH": str(plugin_bundle_root()), "PATH": "/usr/bin:/bin"},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            return json.loads(result.stdout or "[]")
+
     def test_struct01_fires_when_required_section_missing(self):
         body = textwrap.dedent("""
             ---
@@ -40,6 +53,34 @@ class Struct01Tests(unittest.TestCase):
         findings = self._run_lint(body)
         codes = {f["code"] for f in findings}
         self.assertIn("STRUCT01", codes, f"expected STRUCT01, got {codes}")
+
+    def test_struct01_skipped_for_brd_index(self):
+        """BRD-00_index.md (artifact_type: BRD-INDEX) has its own template
+        (BRD-00_index.TEMPLATE.md); applying the standard BRD-TEMPLATE.yaml
+        sections to it produces spurious STRUCT01 findings. Regression for
+        task #239."""
+        body = textwrap.dedent("""
+            ---
+            artifact_type: BRD-INDEX
+            doc_id: BRD-00
+            layer: 1
+            ---
+            # BRD-00: Business Requirements Document Index
+
+            Master index of all BRDs for the project.
+
+            ## Position in Document Workflow
+
+            (intentionally lacks the 15 required BRD sections — this is an
+            index doc, not a BRD instance)
+        """).strip()
+        findings = self._run_lint_with_name(body, "BRD-00_index.md")
+        struct01 = [f for f in findings if f["code"] == "STRUCT01"]
+        self.assertEqual(
+            struct01,
+            [],
+            f"STRUCT01 should not fire on artifact_type: BRD-INDEX; got {struct01}",
+        )
 
 
 if __name__ == "__main__":

--- a/tools/sdd_doc_lint/__init__.py
+++ b/tools/sdd_doc_lint/__init__.py
@@ -768,10 +768,24 @@ def _check_required_template_sections(
     artifact: str | None,
     registry: Path | None,
 ) -> list[Finding]:
-    """STRUCT01: every required <TYPE>-TEMPLATE.yaml section must appear as a ## heading."""
+    """STRUCT01: every required <TYPE>-TEMPLATE.yaml section must appear as a ## heading.
+
+    Frontmatter `artifact_type` overrides the path-inferred artifact when the
+    document declares an `<X>-INDEX` variant (e.g. `BRD-INDEX` for
+    `BRD-00_index.md`). Index docs have their own template
+    (`<X>-NN_index.TEMPLATE.md`) and intentionally diverge from the standard
+    `<X>-TEMPLATE.yaml` section set; applying the standard template's
+    required-sections check to an index would produce spurious STRUCT01
+    findings.
+    """
     findings: list[Finding] = []
     if not artifact:
         return findings
+    fm = _extract_frontmatter(text)
+    if fm:
+        declared = str(fm.get("artifact_type") or "").strip()
+        if declared.endswith("-INDEX"):
+            return findings
     targets = _load_section_targets(artifact, registry)
     if not targets:
         return findings


### PR DESCRIPTION
## Summary

Fixes pre-existing bug (task #239): `sdd_doc_lint` mishandled `BRD-00_index.md` (which declares `artifact_type: BRD-INDEX`) by treating it as a standard BRD requiring the 15-section template. The structural check produced 17 spurious STRUCT01 findings for the legitimate index doc.

## Root cause

`detect_layer(path, layers)` infers the artifact code purely from path/filename — `BRD-00_index.md` matches the `BRD-NN` filename pattern → artifact = "BRD" → `_check_required_template_sections` loads `BRD-TEMPLATE.yaml` (15 sections) → all 15 missing in the index doc → 17 errors.

The frontmatter `artifact_type: BRD-INDEX` was ignored, even though `framework/layers/01_BRD/BRD-00_index.TEMPLATE.md` is the actual canonical template for index docs (with a different, intentionally smaller section set).

## Fix

In `_check_required_template_sections`, parse the frontmatter early. If `artifact_type` ends in `-INDEX`, return without emitting any STRUCT01 findings. Index docs use their own template and are not subject to the standard-template structural check.

Surgical change: 12 added lines (frontmatter check + docstring) in `tools/sdd_doc_lint/__init__.py`. Vendored copies in `platforms/{claude-code-plugin,hermes}/sdd_doc_lint/` re-synced via `tools/sdd_doc_lint/sync-vendored.sh`.

## Test plan

- [x] New regression test `test_struct01_skipped_for_brd_index` in `tests/unit/test_sdd_doc_lint_struct01.py` — verifies STRUCT01 does NOT fire on `artifact_type: BRD-INDEX` content lacking the 15 standard sections
- [x] Existing test `test_struct01_fires_when_required_section_missing` still PASSES (no regression on normal BRD docs)
- [x] Full unit suite: 24/24 PASS
- [x] Full conformance suite: 115 PASS + 1 skipped (the playbook-coverage test from #258, unrelated)

## Workaround being retired

Prior workaround was "move BRD-00_index.md aside before running lint-smoke." This fix removes that need entirely.