### PR TITLE
fix(sdd_doc_lint): STY03 word count excludes code-fenced blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — sdd_doc_lint STY03 counted code-fenced content
+
+- **STY03 word-count now excludes code-fenced blocks**, mirroring STY02
+  and AS3 (`tools/sdd_doc_lint/__init__.py`, plus byte-identical
+  vendored copies under `platforms/{claude-code-plugin,hermes}/sdd_doc_lint/`).
+  Before this fix the whole-document body-size check counted every word
+  inside ``` … ``` blocks, which made any non-trivial BDD body trip the
+  blocking threshold: the `doc-bdd` SKILL allows ~50k tokens of fenced
+  Gherkin per artifact, while STY03's BDD target is 1500 words (blocking
+  at 2250). A prose-light, scenario-heavy BDD-01.md hit STY03 at 2977
+  words despite only ~1013 prose words.
+
+  Regression test at `tests/unit/test_sdd_doc_lint_sty03_fences.py`
+  (two cases: fenced-heavy doc must not trip STY03; prose-only doc over
+  the blocking threshold must still trip STY03). Surfaced during
+  BDD-RT-001 live cascade; the `doc-bdd-autopilot` orchestrator
+  correctly diagnosed the framework workflow gap and refused to
+  hand-edit the artifact. No SKILL changes, no VERSION bump (matches
+  precedent commit `b777c08f` for the BRD-INDEX STRUCT01 fix).
+
 ### Added — AUTO-REMEDIATE-001 (cascade bootstrap auto-remediation)
 
 - **Cascade bootstrap auto-remediation for STY03 lint failures.** When

--- a/platforms/claude-code-plugin/sdd_doc_lint/__init__.py
+++ b/platforms/claude-code-plugin/sdd_doc_lint/__init__.py
@@ -379,10 +379,22 @@ def _check_style(
                     severity="warning",
                 )
             )
-    # STY03 — document body over the +50% target (blocking).
+    # STY03 — document body over the +50% target (blocking). Word count
+    # excludes code-fenced blocks (``` … ```), mirroring STY02 / AS3. BDD
+    # bodies are mostly fenced Gherkin and the doc-bdd skill allows ~50k
+    # tokens of it before a split; counting fences here would block any real
+    # BDD suite far below that allowance.
     target = _DOC_TARGET_WORDS.get(artifact)
     if target is not None:
-        words = sum(len(line.split()) for line in body)
+        words = 0
+        in_fence = False
+        for line in body:
+            if line.lstrip().startswith("```"):
+                in_fence = not in_fence
+                continue
+            if in_fence:
+                continue
+            words += len(line.split())
         if words > target * 3 // 2:
             findings.append(
                 Finding(

--- a/platforms/hermes/sdd_doc_lint/__init__.py
+++ b/platforms/hermes/sdd_doc_lint/__init__.py
@@ -379,10 +379,22 @@ def _check_style(
                     severity="warning",
                 )
             )
-    # STY03 — document body over the +50% target (blocking).
+    # STY03 — document body over the +50% target (blocking). Word count
+    # excludes code-fenced blocks (``` … ```), mirroring STY02 / AS3. BDD
+    # bodies are mostly fenced Gherkin and the doc-bdd skill allows ~50k
+    # tokens of it before a split; counting fences here would block any real
+    # BDD suite far below that allowance.
     target = _DOC_TARGET_WORDS.get(artifact)
     if target is not None:
-        words = sum(len(line.split()) for line in body)
+        words = 0
+        in_fence = False
+        for line in body:
+            if line.lstrip().startswith("```"):
+                in_fence = not in_fence
+                continue
+            if in_fence:
+                continue
+            words += len(line.split())
         if words > target * 3 // 2:
             findings.append(
                 Finding(

--- a/tests/unit/test_sdd_doc_lint_sty03_fences.py
+++ b/tests/unit/test_sdd_doc_lint_sty03_fences.py
@@ -1,0 +1,49 @@
+"""Unit: STY03 (whole-document body size) excludes code-fenced blocks.
+
+Regression for the fence-counting bug: a BDD body is mostly fenced Gherkin,
+which the doc-bdd skill allows up to ~50k tokens before a split. STY03 must
+count prose only — like STY02 — so a fenced-heavy but prose-light document
+does not trip the blocking gate, while a prose-heavy document still does.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "conformance"))
+from _spec import plugin_bundle_root
+
+sys.path.insert(0, str(plugin_bundle_root()))
+from sdd_doc_lint import _check_style  # noqa: E402
+
+# BDD STY03 target is 1500 words; blocking at >2250.
+_FILLER = " ".join(["word"] * 400)  # 400 prose words per repeat
+
+
+def _doc(prose_blocks: int, fenced_blocks: int) -> str:
+    lines = ["---", "artifact_id: BDD-01", "layer: 4", "---", "# BDD-01", ""]
+    for _ in range(prose_blocks):
+        lines += ["## Prose", _FILLER, ""]
+    for _ in range(fenced_blocks):
+        lines += ["## Scenarios", "```gherkin", _FILLER, "```", ""]
+    return "\n".join(lines)
+
+
+def _codes(text: str) -> set[str]:
+    return {f.code for f in _check_style(text, "BDD", "BDD-01.md", 0)}
+
+
+class Sty03FenceExclusionTests(unittest.TestCase):
+    def test_fenced_content_does_not_trip_sty03(self):
+        # ~800 prose words (under 1500 target) + ~4000 fenced words.
+        text = _doc(prose_blocks=2, fenced_blocks=10)
+        self.assertNotIn("STY03", _codes(text), "fenced Gherkin must not count toward STY03")
+
+    def test_prose_over_blocking_still_trips_sty03(self):
+        # ~2800 prose words, above the 2250 blocking threshold.
+        text = _doc(prose_blocks=7, fenced_blocks=0)
+        self.assertIn("STY03", _codes(text), "prose over blocking must trip STY03")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/sdd_doc_lint/__init__.py
+++ b/tools/sdd_doc_lint/__init__.py
@@ -379,10 +379,22 @@ def _check_style(
                     severity="warning",
                 )
             )
-    # STY03 — document body over the +50% target (blocking).
+    # STY03 — document body over the +50% target (blocking). Word count
+    # excludes code-fenced blocks (``` … ```), mirroring STY02 / AS3. BDD
+    # bodies are mostly fenced Gherkin and the doc-bdd skill allows ~50k
+    # tokens of it before a split; counting fences here would block any real
+    # BDD suite far below that allowance.
     target = _DOC_TARGET_WORDS.get(artifact)
     if target is not None:
-        words = sum(len(line.split()) for line in body)
+        words = 0
+        in_fence = False
+        for line in body:
+            if line.lstrip().startswith("```"):
+                in_fence = not in_fence
+                continue
+            if in_fence:
+                continue
+            words += len(line.split())
         if words > target * 3 // 2:
             findings.append(
                 Finding(


### PR DESCRIPTION
## Summary

- STY03 (whole-document body-size, blocking) previously counted words inside ``` … ``` fences; STY02 / AS3 already skip them. Now STY03 matches their behaviour.
- BDD bodies are mostly fenced Gherkin (the `doc-bdd` skill allows ~50k tokens of it per artifact) while STY03's BDD target is 1500 words (blocking at 2250). A prose-light, scenario-heavy `BDD-01.md` tripped STY03 at 2977 words despite only ~1013 prose words, making any non-trivial BDD body un-passable.
- Canonical edit in `tools/sdd_doc_lint/__init__.py`; vendored copies under `platforms/{claude-code-plugin,hermes}/sdd_doc_lint` synced (byte-parity holds — `test_doc_lint_vendoring` passes).
- Regression test `tests/unit/test_sdd_doc_lint_sty03_fences.py` covers both directions (fenced-heavy doc must NOT trip; prose-only over threshold must still trip).
- No SKILL changes, no VERSION bump — precedent: `b777c08f` (BRD-INDEX STRUCT01 fix).

## Origin

Surfaced during the BDD-RT-001 live cascade. The `doc-bdd-autopilot` orchestrator correctly diagnosed the framework workflow gap (per the *"Never hand-edit example artifacts → fix the SKILL/workflow, never the artifact"* durable convention) rather than trimming `BDD-01.md` by hand. Extracted to its own PR per *"minimal and realistic plans"* — the BDD-RT-001 work-in-progress branch (`feat/bdd-rt-001`) will rebase onto main after this lands and re-run the cascade.

## Test plan

- [x] `tests/unit/test_sdd_doc_lint_sty03_fences.py` (2 new) — PASS
- [x] `tests/unit` full suite — 26/26 PASS
- [x] `tests/conformance` full suite — 115/115 PASS (1 skipped, task #258 backlog)
- [x] `tools/sdd_doc_lint/sync-vendored.sh` — idempotent; md5 byte-parity holds across the 3 copies
- [x] Pre-commit hooks (bandit, markdownlint, yamllint, detect-secrets, conformance suite, doc-of-record reminder) — all PASS