### PR TITLE
fix(harness): saga driver wall-clock budget 60 → 90 min (SAGA-BUDGET-001)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,35 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed — SAGA-BUDGET-001 (saga driver wall-clock budget 60 → 90 min)
+
+- **Cascade-harness saga wall-clock budget bumped from 60 min to 90 min**
+  to accommodate larger / more iteration-prone layers. Three coordinated
+  constants updated in lockstep so the existing graceful-exit invariant
+  (300s margin between `SOFT_DEADLINE_SECONDS` and the wrapping
+  `ORCHESTRATOR_TIMEOUT`) holds:
+
+  | Variable | Was | Now | Where |
+  |---|---:|---:|---|
+  | `ORCHESTRATOR_TIMEOUT` | 3600 | **5400** | `tests/scripts/test-acceptance.sh` |
+  | `SOFT_DEADLINE_SECONDS` | 3300 | **5100** | `platforms/claude-code-plugin/tools/saga_driver.py` |
+  | `MAX_LAYER_SEC` | 3600 | **5400** | `tests/scripts/test-acceptance.sh` |
+
+  Origin: BDD-RT-001 live cascade run #2 converged to PASS at score 95
+  (verdict.json `combined_status: PASS`) in **58:38 of wall-clock** —
+  within 1:22 of the 3600s saga ceiling. The wrapper SIGTERM killed the
+  saga driver before its terminal output could flush, so summary.json
+  recorded `doc-bdd-autopilot: FAIL` despite verdict.json reading PASS.
+  The 5400s budget gives ~50% headroom over the BDD case and the same
+  margin over expected ADR / SPEC / TDD / IPLAN cascade durations
+  (those layers carry larger per-artifact content than BDD).
+
+  No SKILL changes. Per-claude-subprocess timeout
+  (`SUBPROCESS_TIMEOUT_SECONDS=1800` in saga_driver.py) and per-skill
+  leaf timeout (`SKILL_TIMEOUT=600` in test-acceptance.sh) unchanged —
+  no individual subprocess came close to those caps. Cost-cap
+  (`--cost-cap`, ~$22) remains the dollar guard.
+
 ### Fixed — sdd_doc_lint STY03 counted code-fenced content
 
 - **STY03 word-count now excludes code-fenced blocks**, mirroring STY02

--- a/platforms/claude-code-plugin/tools/saga_driver.py
+++ b/platforms/claude-code-plugin/tools/saga_driver.py
@@ -109,13 +109,18 @@ _LAYER_CREWS: dict[str, list[str]] = {
     ],
 }
 
-# Bumped from 1500s -> 3300s in Amendment 1 verification (2026-06-05):
-# a realistic BRD cycle with one fixer pass takes ~40-55 min wall-clock
+# Bumped 1500s -> 3300s (Amendment 1 verification, 2026-06-05): a
+# realistic BRD cycle with one fixer pass takes ~40-55 min wall-clock
 # (draft ~10 min + audit ~15 min + fixer ~10 min + re-audit ~15 min).
-# 1500s only covered draft+audit happy path and PARTIAL_TIMEOUT'd on
-# every fixer cycle. 3300s gives the full 4-phase chain plus margin
-# below the harness orchestrator timeout (3600s).
-SOFT_DEADLINE_SECONDS = 3300
+# 1500s only covered the draft+audit happy path and PARTIAL_TIMEOUT'd
+# on every fixer cycle.
+# Bumped 3300s -> 5100s (SAGA-BUDGET-001, 2026-06-08): BDD-RT-001's
+# 3-audit / 2-fixer convergence took 58:38 to PASS — within 1:22 of
+# the 3600s harness ceiling. 5100s gives the full ~5-phase chain plus
+# the 300s margin below the bumped ORCHESTRATOR_TIMEOUT (5400s) so
+# the driver can write its PARTIAL_TIMEOUT state gracefully before the
+# wrapper SIGTERMs.
+SOFT_DEADLINE_SECONDS = 5100
 SUBPROCESS_TIMEOUT_SECONDS = 1800
 MAX_ITERATIONS = 3
 

--- a/tests/scripts/test-acceptance.sh
+++ b/tests/scripts/test-acceptance.sh
@@ -68,8 +68,13 @@ FRAMEWORK_CREWS_FALLBACK="$FRAMEWORK/framework/governance/REVIEW_CREWS.yaml"
 # to 3600s: an autopilot that orchestrates a create→review→revise loop
 # (audit + fixer + re-audit) legitimately runs 30-45 min per layer in
 # team mode, and a multi-iteration fix cycle pushes that to ~60 min.
-# Lineage: 900s (BRD-RT-001) → 1800s (BRD-RT-002) → 3600s (BRD-RT-003).
-MAX_LAYER_SEC=3600   # 60 minutes per layer
+# Lineage: 900s (BRD-RT-001) → 1800s (BRD-RT-002) → 3600s (BRD-RT-003)
+# → 5400s (BDD-RT-001): BDD draft + 3 audit cycles + 2 fixer cycles
+# converged to PASS at 58:38 (run-2 verdict.json content_score=95).
+# 3600s cap killed the saga driver before its terminal output flushed;
+# 5400s gives ~50% headroom for stochastic LLM latency + future ADR /
+# SPEC / TDD / IPLAN layers whose artifacts are larger than BDD.
+MAX_LAYER_SEC=5400   # 90 minutes per layer
 
 # Per-skill timeout. Generalised in BRD-RT-004 / D-0028: collapse the
 # previously-separate AUDIT_TIMEOUT / AUTOPILOT_TIMEOUT / REVIEW_TEAM_TIMEOUT
@@ -89,13 +94,17 @@ MAX_LAYER_SEC=3600   # 60 minutes per layer
 #     + synthesizer). Generalised to one ORCHESTRATOR_TIMEOUT covering
 #     all three (audit, autopilot, fixer) + review-team itself.
 SKILL_TIMEOUT="${SKILL_TIMEOUT:-600}"                       # 10 min — leaf skills
-# Autopilot now wraps the saga driver, which itself dispatches up to 4
-# claude -p subprocesses per layer (draft, review, fixer, re-review).
-# A realistic BRD cycle with one fixer pass takes 40-55 min wall-clock,
-# so the autopilot subprocess needs ~60 min to outlive the driver's
-# break-circuit (SOFT_DEADLINE=3300s in saga_driver.py). See B5/B6 in
-# the SAGA-PARITY-001 Phase 2 Amendment 1 verification (2026-06-05).
-ORCHESTRATOR_TIMEOUT="${ORCHESTRATOR_TIMEOUT:-3600}"         # 60 min — autopilot+driver chain
+# Autopilot now wraps the saga driver, which itself dispatches up to 6
+# claude -p subprocesses per layer (draft, audit×N, fixer×N, re-audit×N).
+# A realistic BRD cycle with one fixer pass takes 40-55 min wall-clock;
+# the BDD-RT-001 cascade exercised the 2-fixer / 3-audit ceiling and
+# converged to PASS at 58:38 with score 95 — but the 3600s wrapper
+# killed the saga driver before its terminal output could flush, so
+# the harness recorded FAIL despite verdict.json reading PASS.
+# Bumped 3600 → 5400 in SAGA-BUDGET-001 (2026-06-08) to give ~50%
+# headroom and outlive the bumped driver SOFT_DEADLINE (5100s).
+# Original B5/B6 lineage: SAGA-PARITY-001 Phase 2 Amendment 1 (2026-06-05).
+ORCHESTRATOR_TIMEOUT="${ORCHESTRATOR_TIMEOUT:-5400}"         # 90 min — autopilot+driver chain
 AGENT_TIMEOUT="${AGENT_TIMEOUT:-600}"                       # 10 min for agents
 
 # Total token budget for the whole run (A8). When the cumulative

--- a/tools/saga_driver.py
+++ b/tools/saga_driver.py
@@ -109,13 +109,18 @@ _LAYER_CREWS: dict[str, list[str]] = {
     ],
 }
 
-# Bumped from 1500s -> 3300s in Amendment 1 verification (2026-06-05):
-# a realistic BRD cycle with one fixer pass takes ~40-55 min wall-clock
+# Bumped 1500s -> 3300s (Amendment 1 verification, 2026-06-05): a
+# realistic BRD cycle with one fixer pass takes ~40-55 min wall-clock
 # (draft ~10 min + audit ~15 min + fixer ~10 min + re-audit ~15 min).
-# 1500s only covered draft+audit happy path and PARTIAL_TIMEOUT'd on
-# every fixer cycle. 3300s gives the full 4-phase chain plus margin
-# below the harness orchestrator timeout (3600s).
-SOFT_DEADLINE_SECONDS = 3300
+# 1500s only covered the draft+audit happy path and PARTIAL_TIMEOUT'd
+# on every fixer cycle.
+# Bumped 3300s -> 5100s (SAGA-BUDGET-001, 2026-06-08): BDD-RT-001's
+# 3-audit / 2-fixer convergence took 58:38 to PASS — within 1:22 of
+# the 3600s harness ceiling. 5100s gives the full ~5-phase chain plus
+# the 300s margin below the bumped ORCHESTRATOR_TIMEOUT (5400s) so
+# the driver can write its PARTIAL_TIMEOUT state gracefully before the
+# wrapper SIGTERMs.
+SOFT_DEADLINE_SECONDS = 5100
 SUBPROCESS_TIMEOUT_SECONDS = 1800
 MAX_ITERATIONS = 3
 


### PR DESCRIPTION
## Summary

Three coordinated harness/driver constants bumped from 60-min budgets to 90-min so the saga driver outlives realistic multi-iteration cascades, with the graceful-exit invariant (300s margin between `SOFT_DEADLINE_SECONDS` and the wrapping `ORCHESTRATOR_TIMEOUT`) preserved.

| Variable | Was | Now | Where |
|---|---:|---:|---|
| `ORCHESTRATOR_TIMEOUT` | 3600 | **5400** | `tests/scripts/test-acceptance.sh` |
| `MAX_LAYER_SEC` | 3600 | **5400** | `tests/scripts/test-acceptance.sh` |
| `SOFT_DEADLINE_SECONDS` | 3300 | **5100** | `tools/saga_driver.py` (+ byte-identical vendored copy under `platforms/claude-code-plugin/tools/`) |

`SUBPROCESS_TIMEOUT_SECONDS` (1800s per `claude` call) and `SKILL_TIMEOUT` (600s per leaf skill) unchanged — no individual subprocess came close to those caps. `--cost-cap` (~$22) remains the dollar guard.

## Origin

BDD-RT-001 live cascade run #2 converged to PASS at **content_score=95** (verdict.json `combined_status: PASS`) in **58:38 wall-clock** — within 1:22 of the 3600s saga ceiling. The wrapper SIGTERM killed the saga driver before its terminal output could flush, so summary.json recorded `doc-bdd-autopilot: FAIL` despite verdict.json reading PASS. Future per-layer rollouts (ADR/SPEC/TDD/IPLAN) carry larger per-artifact content than BDD — they will trip the same ceiling without this bump.

## Test plan

- [x] `tests/unit` full suite — 26/26 PASS
- [x] `tests/conformance` full suite — 115/115 PASS (1 skipped, task #258 backlog)
- [x] `tools/sync-plugin-framework.sh` re-syncs cleanly (3 tools files mirrored; byte-parity holds)
- [x] `tests/conformance/platforms/test_plugin_framework_bundle.py` (byte-parity drift guard) — PASS
- [x] Pre-commit hooks (bandit, markdownlint, yamllint, detect-secrets, conformance, doc-of-record reminder) — all PASS

## Sequencing

Lands before BDD-RT-001 (which depends on this for its recorded test evidence to be against the new budget). Once merged, the BDD-RT-001 branch will rebase onto post-this-PR main; the cascade-2 PASS evidence already on disk doesn't need re-running.