### PR TITLE
docs(plans): IPLAN-LANG-001 plan + 08_IPLAN layer gap-audit record

### DIFF
--- a/plans/IPLAN-LANG-001-PLAN.md
+++ b/plans/IPLAN-LANG-001-PLAN.md
@@ -1,0 +1,277 @@
+# IPLAN-LANG-001 Plan — de-Python the IPLAN template; inherit language from SPEC
+
+| Field          | Value                                       |
+| -------------- | ------------------------------------------- |
+| Task           | IPLAN-LANG-001                              |
+| Type           | refactor                                    |
+| Status         | PLANNED — 2026-06-09T00:00:00Z             |
+| Depends on     | none                                        |
+| Feeds          | none                                        |
+| Version impact | framework spec **PATCH** (0.15.2 → 0.15.3); both `FRAMEWORK_SPEC_VERSION` pointers re-match (auto-synced); plugin + Hermes **product** versions unchanged |
+
+## Objective
+
+The Layer-8 `IPLAN-TEMPLATE.yaml` hardcodes Python toolchain commands and source
+paths (`pip install`, `pytest`, `mypy`, `ruff`, `src/[module]`,
+`tests/unit/test_[module].py`) in its example content. Language and dependency
+stack are already declared once, upstream, at Layer 6
+(`SPEC-TEMPLATE.yaml` `language:` + `dependencies:`). A Layer-8 deliverable that
+re-pins a language its own `@spec` already owns both (a) violates the framework's
+engine-agnostic principle and (b) duplicates a SPEC-owned decision at the wrong
+layer. This change makes the template language-neutral: its `file_manifest` paths
+and `execution_commands` strings become language-neutral guidance plus a clearly
+labelled Python *example*, with explicit instruction to derive concrete
+commands/paths from the language + dependencies declared in `@spec: SPEC-NN`. The
+template's structural contract (six sections; the three `execution_commands`
+categories) is preserved exactly, so no validator and no conformance check
+changes.
+
+## Scope
+
+**In:**
+
+- Edit `framework/layers/08_IPLAN/IPLAN-TEMPLATE.yaml`: Section 2
+  (`file_manifest`) and Section 3 (`execution_commands`) — replace Python-only
+  example content with language-neutral guidance + a labelled Python example;
+  add a `_guidance` line tying concrete commands/paths to the `@spec` language +
+  dependencies.
+- Bump `framework/VERSION` 0.15.2 → 0.15.3 — required by GATE-SPEC-E005 on any
+  `framework/**` change; the file must be **staged** so the version-sync hook and
+  the gate both fire.
+- Add a `CHANGELOG.md` entry in the **same diff** — required by GATE-SPEC-E008
+  (hard CI gate, not a soft doc).
+- Regenerate the plugin's vendored framework bundle via
+  `tools/sync-plugin-framework.sh` (never hand-edit the bundle).
+
+**Out of scope (deferred):**
+
+- Renaming the `execution_commands` categories (`setup` / `implementation` /
+  `validation`) to a build/test/lint phase vocabulary — these keys are a
+  **validated contract** (`iplan_rules.py:104`) and are already language-neutral;
+  renaming them would ripple into both platforms' validators and every golden
+  fixture for zero benefit to the named issue.
+- A predefined "action vocabulary" resolver / task-runner DSL for
+  `execution_commands` — speculative until a second, non-Python platform actually
+  consumes IPLANs and demands it.
+- Folding design-review governance (Review log / Claim ledger) into IPLAN —
+  rejected by design: that rigor lives upstream (BRD…SPEC) and in the markdown
+  development plan (`PLAN_STANDARD.md`); IPLAN stays a lean execution manifest.
+- De-Pythoning the golden acceptance fixtures
+  (`tests/acceptance/fixtures/**/IPLAN-01_golden.yaml`) — a fixture legitimately
+  picks one concrete language; Python is a valid choice and these are not derived
+  from the template.
+- Hand-editing the plugin README spec-version block or the conformance spec-version
+  literal — `scripts/sync-version-refs.sh` auto-propagates both on a staged
+  `framework/VERSION` bump (these were the "two gaps" closed in the 0.15.2
+  release; no longer manual).
+
+## Approach / Design
+
+**Root-cause framing.** Language is a SPEC-owned fact
+(`SPEC-TEMPLATE.yaml:96` `language:`, `:97-100` `dependencies:`). IPLAN
+references its SPEC (`@spec: SPEC-NN`, present in `traceability.upstream`). The
+fix is *inheritance*, not a new IPLAN field: the template instructs the author to
+read the `@spec` language/dependencies and express each phase in that toolchain.
+
+**What is preserved (the contract) — must not change:**
+
+- The six top-level sections (`document_control`, `file_manifest`,
+  `execution_commands`, `implementation_contracts`, `session_handoff`,
+  `traceability`) — enumerated by the plugin `doc-iplan` skill and by the
+  acceptance harness's top-level-key check.
+- The three `execution_commands` categories `setup` / `implementation` /
+  `validation`, each a non-empty list — required by Hermes
+  `iplan_rules.py:104`.
+- `metadata.layer: 8` and `metadata.document_type: "iplan-document"` — the only
+  template-body fields the conformance suite asserts (`test_layers.py:35`).
+
+**Edit A — `file_manifest.files` (Section 2).** Replace the three Python paths
+with language-neutral placeholders (`<unit test for the component>`,
+`<implementation file>`, `<integration test>`), keep test-first ordering, and
+extend `_guidance` with: "Paths follow the conventions of the language declared
+in `@spec: SPEC-NN`. Example (Python): `tests/unit/test_auth.py`,
+`src/auth/service.py`."
+
+**Edit B — `execution_commands` (Section 3).** Keep the three category keys.
+Replace the Python command strings with a language-neutral lead comment per
+category plus a labelled `# example (Python):` line, and extend the section
+`_guidance`: "Concrete commands depend on the language + dependencies declared in
+`@spec: SPEC-NN`; express each phase in that toolchain. The example lines below
+are illustrative (Python)." Each category remains a non-empty list of strings
+(comments are valid list items), so IPLAN-003 stays green.
+
+**Propagation.** Edit the canonical template only → run
+`tools/sync-plugin-framework.sh` to regenerate the byte-identical plugin bundle
+(the drift guard `tests/conformance/platforms/test_plugin_framework_bundle.py`
+enforces equality). Versions propagate automatically: staging `framework/VERSION`
+runs the `sync-version-refs.sh` pre-commit hook, which rewrites both
+`FRAMEWORK_SPEC_VERSION` pointers, the plugin README spec block, the conformance
+spec-version literal, and the SKILL/playbook frontmatter that quote the version.
+The only hand-authored version-adjacent file is the `CHANGELOG.md` entry.
+
+**Version reasoning.** Example-content + guidance edits that preserve every
+structural contract are a spec **PATCH** (`docs/PROJECT.md` defines MAJOR as a
+breaking contract change; there is none). This mirrors the immediately prior
+framework move (0.15.1 → 0.15.2), a doc-only PATCH that touched
+`framework/VERSION` + both `FRAMEWORK_SPEC_VERSION` pointers and left plugin
+(0.11.0) and Hermes (0.3.0) product versions unchanged.
+
+## File structure
+
+### Modified
+
+| Path | Change |
+| ---- | ------ |
+| `framework/layers/08_IPLAN/IPLAN-TEMPLATE.yaml` | Edits A + B — de-Python `file_manifest` + `execution_commands` example content; add `@spec`-derivation guidance |
+| `framework/VERSION` | 0.15.2 → 0.15.3 (staged so hook + GATE-SPEC fire) |
+| `CHANGELOG.md` | New entry (required by GATE-SPEC-E008) |
+| `platforms/claude-code-plugin/framework/layers/08_IPLAN/IPLAN-TEMPLATE.yaml` | Regenerated by `tools/sync-plugin-framework.sh` (not hand-edited) |
+| `platforms/*/FRAMEWORK_SPEC_VERSION`, plugin README spec block, conformance literal, SKILL/playbook frontmatter | Auto-rewritten by `sync-version-refs.sh` hook (no manual edit) |
+| `plans/HANDOFF.md`, `plans/DECISIONS.md` | Docs-of-record |
+
+## Implementation sequence
+
+### Task 1: Edit the canonical template
+
+- Apply Edit A to `file_manifest` and Edit B to `execution_commands` in
+  `framework/layers/08_IPLAN/IPLAN-TEMPLATE.yaml`.
+- Confirm the file still parses as YAML and that the six sections + three
+  `execution_commands` categories + `metadata.layer`/`document_type` are intact.
+
+### Task 2: Bump the framework spec version
+
+- `framework/VERSION` → 0.15.3, and **stage it** so the `sync-version-refs.sh`
+  pre-commit hook propagates the string to every dependent file.
+
+### Task 3: Regenerate the plugin bundle
+
+- Run `tools/sync-plugin-framework.sh`; do not hand-edit the bundle.
+
+### Task 4: CHANGELOG + docs of record
+
+- Add the `CHANGELOG.md` entry (framework spec 0.15.2 → 0.15.3, IPLAN-LANG-001) —
+  in the **same commit/diff** as the `framework/**` change (GATE-SPEC-E008).
+- `plans/HANDOFF.md` narrative; `plans/DECISIONS.md` the "IPLAN inherits language
+  from SPEC; no new field" decision.
+
+## Verification
+
+| #  | Check (command or observable) | Expected result | Maps to |
+| -- | ----------------------------- | --------------- | ------- |
+| V1 | `python -c "import yaml; d=yaml.safe_load(open('framework/layers/08_IPLAN/IPLAN-TEMPLATE.yaml')); assert d['metadata']['layer']==8 and d['metadata']['document_type']=='iplan-document'; assert set(d['execution_commands'])>={'setup','implementation','validation'} and all(d['execution_commands'][k] for k in ('setup','implementation','validation')); print('ok')"` | `ok` — contract preserved | Approach (preserved contract) |
+| V2 | `grep -nE 'pip install\|pytest\|mypy\|ruff\|src/\[module\]' framework/layers/08_IPLAN/IPLAN-TEMPLATE.yaml \| grep -v 'example (Python)'` | no matches (every remaining Python token is on a labelled example line) | Objective |
+| V3 | `python -m pytest tests/conformance/ -q` | green (incl. `test_layers.py`, `test_version.py`, plugin bundle drift guard) | Scope / propagation |
+| V4 | `diff -q framework/layers/08_IPLAN/IPLAN-TEMPLATE.yaml platforms/claude-code-plugin/framework/layers/08_IPLAN/IPLAN-TEMPLATE.yaml` | identical (bundle re-synced) | Task 3 |
+| V5 | `python -m pytest platforms/hermes/tests/unit/test_iplan_rules.py -q` | green — IPLAN-003 categories unchanged | Out-of-scope guarantee |
+| V6 | `python tests/chg/spec_gate.py` (or equivalent gate run) over the staged diff | OK — VERSION + CHANGELOG both present (E005 + E008 pass) | Tasks 2 + 4 |
+| V7 | `grep -rn '0.15.2' framework/VERSION platforms/*/FRAMEWORK_SPEC_VERSION` | no matches (all auto-moved to 0.15.3) | Task 2 propagation |
+
+## Docs to update
+
+- [ ] `CHANGELOG.md` — entry (hard gate GATE-SPEC-E008; tracked as Task 4)
+- [ ] `plans/HANDOFF.md` — narrative + next steps
+- [ ] `plans/DECISIONS.md` — "IPLAN inherits language from SPEC; no new field"
+- [ ] `ROADMAP.md` — bullet only if a roadmap line tracks IPLAN; else skip
+
+## Risks
+
+| #  | Risk | Likelihood | Mitigation |
+| -- | ---- | ---------- | ---------- |
+| R1 | Renaming/removing an `execution_commands` category breaks Hermes IPLAN-003 | low | Explicitly out of scope; V5 guards the validator stays green |
+| R2 | A category becomes an empty list (comments only) and trips IPLAN-003's non-empty check | low | Keep ≥1 string item per category; V1 asserts non-empty |
+| R3 | Bundle drift guard fails because canonical edited but bundle not re-synced | med | Task 3 runs the sync script; V4 + V3 (drift guard) verify equality |
+| R4 | `framework/VERSION` not staged → hook does not run → stale version strings + GATE-SPEC failure | med | Task 2 stages VERSION; V6 (gate) + V7 (no stale 0.15.2) catch it |
+
+## Claim ledger
+
+| #  | Claim | Symbol | Citation |
+| -- | ----- | ------ | -------- |
+| 1  | SPEC declares the implementation language (the upstream owner of this fact) | `language:` | framework/layers/06_SPEC/SPEC-TEMPLATE.yaml:96 |
+| 2  | SPEC also declares dependencies (name/version/purpose) | `dependencies:` | framework/layers/06_SPEC/SPEC-TEMPLATE.yaml:97 |
+| 3  | The IPLAN template hardcodes Python in execution_commands setup | `pip install -r requirements.txt` | framework/layers/08_IPLAN/IPLAN-TEMPLATE.yaml:89 |
+| 4  | The IPLAN template hardcodes Python validation commands | `--cov=src/[module]` | framework/layers/08_IPLAN/IPLAN-TEMPLATE.yaml:95 |
+| 5  | The IPLAN template hardcodes Python file paths | `tests/unit/test_[module].py` | framework/layers/08_IPLAN/IPLAN-TEMPLATE.yaml:63 |
+| 6  | IPLAN references its SPEC, so language is inheritable via `@spec` | `@spec: SPEC-NN` | framework/layers/08_IPLAN/IPLAN-TEMPLATE.yaml:159 |
+| 7  | Hermes validates the three execution_commands categories (contract — must not rename) | `required_categories = ["setup", "implementation", "validation"]` | platforms/hermes/src/mcp_server/validation/iplan_rules.py:104 |
+| 8  | Each category must be a non-empty list | `if not isinstance(commands, list) or len(commands) == 0` | platforms/hermes/src/mcp_server/validation/iplan_rules.py:107 |
+| 9  | Conformance asserts only `metadata.layer` + `document_type` from the template body | `test_template_parses_and_metadata_matches_registry` | tests/conformance/test_layers.py:35 |
+| 10 | Plugin ships a byte-identical GENERATED bundle; edit canonical + re-run the sync script | `dest="$repo_root/platforms/claude-code-plugin/framework"` | tools/sync-plugin-framework.sh:21 |
+| 11 | A drift guard fails CI if the bundle diverges from canonical | `test_plugin_framework_bundle.py` | tools/sync-plugin-framework.sh:12 |
+| 12 | The plugin doc-iplan skill enumerates the six sections (preserve them) | `**Six sections**` | platforms/claude-code-plugin/skills/doc-iplan/SKILL.md:192 |
+| 13 | Current framework spec version is 0.15.2 (PATCH target 0.15.3) | `0.15.2` | framework/VERSION:1 |
+| 14 | `sync-version-refs.sh` auto-rewrites the plugin README spec block on a framework bump (NOT a manual gap) | `marker { if ($0 == prev)` | scripts/sync-version-refs.sh:183 |
+| 15 | `sync-version-refs.sh` auto-rewrites the conformance spec-version literal (NOT a manual gap) | `replace_in_file tests/conformance/platforms/test_plugin_release_metadata.py` | scripts/sync-version-refs.sh:197 |
+| 16 | GATE-SPEC-E005 requires `framework/VERSION` to change on any `framework/**` change | `failures.append("GATE-SPEC-E005")` | tests/chg/spec_gate.py:86 |
+| 17 | GATE-SPEC-E008 requires `CHANGELOG.md` in the same diff (hard gate) | `if "CHANGELOG.md" not in files` | tests/chg/spec_gate.py:87 |
+
+## Review log
+
+### Pass 1 — 2026-06-09T00:00:00Z — self-review
+
+- **Initial mis-scope corrected (pre-draft):** first framing called this a
+  framework MINOR and proposed phase-labelling `execution_commands`. Reading
+  `iplan_rules.py:104` showed the category keys are a validated contract and
+  already language-neutral, so the rename was dropped to Out-of-scope and the
+  change reduced to example-content de-Pythoning → **PATCH**. The named issue is
+  exactly one thing (Python hardcoding); scope now matches it.
+- **Propagation completeness:** confirmed the plugin `framework/` is a vendored
+  *generated* bundle, not a symlink, so added Task 3 (`sync-plugin-framework.sh`)
+  + V4/V3 drift checks.
+- **Governance question resolved:** the user's "should IPLAN include governance?"
+  is answered No in Out-of-scope with the layer-boundary rationale.
+
+### Pass 2 — 2026-06-09T00:00:00Z — independent (fresh-context)
+
+A fresh-context reviewer verified all 13 original ledger citations against source
+(all correct) and surfaced one load-bearing error plus two refinements:
+
+- **LOAD-BEARING — "two known sync-version-refs gaps" were already closed.** The
+  prior draft added a Task 4 to hand-edit the plugin README spec block + the
+  conformance literal, citing the 0.15.1→0.15.2 precedent. That precedent's
+  *problem statement* was read, not its *fix*: `sync-version-refs.sh:183,197`
+  now auto-rewrite both, and `CHANGELOG.md` (0.15.2 entry) documents closing
+  exactly those gaps. **Resolution:** deleted the manual Task 4, the two
+  File-structure rows, risk R4-old, the scope bullet, and V6-old; added an
+  Out-of-scope bullet stating both are auto-synced; added ledger rows 14–15.
+  *Verified independently:* read `scripts/sync-version-refs.sh:179-199` and the
+  `CHANGELOG.md` 0.15.2 entry before folding in.
+- **CHANGELOG is a hard gate, not a soft doc.** `spec_gate.py:86-88` fails
+  GATE-SPEC-E005 (VERSION) and GATE-SPEC-E008 (CHANGELOG) for any `framework/**`
+  change absent from the diff. **Resolution:** promoted CHANGELOG to Task 4,
+  added verification V6 (gate run), added ledger rows 16–17, and noted in Task 2
+  that `framework/VERSION` must be *staged* for both the hook and the gate.
+- **De-Python safety re-confirmed by the reviewer beyond Hermes:** the acceptance
+  harness reads only top-level section keys (not `execution_commands` content),
+  no JSON schema validates IPLAN content, and no plugin/Hermes skill embeds its
+  own Python command examples — so the edit has no hidden downstream consumer.
+  No change needed; recorded for the audit trail.
+- **Housekeeping:** stripped the `[REQUIRED]`/`[IF APPLICABLE]` section-tag
+  markers per the PLAN-TEMPLATE authoring rule (finalized plans delete them),
+  which also lets the `check_plan.py` gate recognize the Claim ledger / Review
+  log sections.
+
+### Pass 3 — 2026-06-09T00:00:00Z — independent (fresh-context) re-validation
+
+A second fresh-context reviewer re-validated the Pass 2 patches against source:
+
+- Both auto-syncs the Pass 2 correction depends on are real and fire on a
+  `framework/VERSION` bump — plugin README block (`sync-version-refs.sh:179-190`)
+  and conformance literal (`:197-199`, with the sibling `assertEqual(...,
+  framework_version())` guard intact so the literal-sync does not weaken the
+  gate). Pass 2's central correction holds.
+- GATE-SPEC-E005 + E008 confirmed as hard failures (`spec_gate.py:85-88`,
+  exit 1 on any failure); Tasks 2 + 4 satisfy both.
+- All eight rewritten ledger symbols + the nine spot-checked rows resolve to
+  their cited `file:line`.
+- No dangling reference left by deleting the old manual Task 4: the only
+  surviving "manual"/"MINOR"/"rename" mentions are inside this Review log as
+  audit history; the live body (Out-of-scope, File-structure, version-impact,
+  Tasks, V6/V7, R4) is internally consistent.
+- De-Python edit stays green: each `execution_commands` category remains a
+  non-empty list, and no conformance test / acceptance fixture / schema reads
+  `execution_commands` content (only top-level section keys, `_harness.py:63`).
+- Two non-blocking nits noted (V2 grep escaping is shell-fragile but renders
+  correctly; ledger row 11 cites the guard's documentation line rather than the
+  enforcing assertion in the test file). Neither affects correctness.
+
+**Result:** ready — two independent passes, the final surfacing zero load-bearing findings.

--- a/plans/IPLAN-LANG-001-PLAN.md
+++ b/plans/IPLAN-LANG-001-PLAN.md
@@ -216,7 +216,7 @@ framework move (0.15.1 → 0.15.2), a doc-only PATCH that touched
   exactly one thing (Python hardcoding); scope now matches it.
 - **Propagation completeness:** confirmed the plugin `framework/` is a vendored
   *generated* bundle, not a symlink, so added Task 3 (`sync-plugin-framework.sh`)
-  + V4/V3 drift checks.
+  plus V4/V3 drift checks.
 - **Governance question resolved:** the user's "should IPLAN include governance?"
   is answered No in Out-of-scope with the layer-boundary rationale.
 

--- a/plans/IPLAN-LAYER-TODO.md
+++ b/plans/IPLAN-LAYER-TODO.md
@@ -1,0 +1,114 @@
+# 08_IPLAN — TODO (execution-management gap audit)
+
+Status: open items from the 2026-06-09 IPLAN layer review session.
+Origin: discussion of IPLAN-TEMPLATE.yaml language-coupling (→
+`plans/IPLAN-LANG-001-PLAN.md`, plan ready, not yet implemented) followed by an
+adversarial fresh-context audit of the layer against proposed
+execution-management requirements. All file:line citations were verified
+against source during that session.
+
+## Context facts (verified 2026-06-09)
+
+- **No project has ever reached Layer 8.** `examples/url-shortener/docs/`
+  stops at `06_SPEC`; every `doc-iplan-autopilot` acceptance-log entry is
+  `outcome: SKIP`. No IPLAN has ever been executed end-to-end. All
+  execution-management additions below are therefore designed against zero
+  runtime evidence until a first real run exists.
+- Capability classification of the current template
+  (`IPLAN-TEMPLATE.yaml`):
+
+  | Capability | State | Evidence |
+  | --- | --- | --- |
+  | Task completion marking | EXISTS | `file_manifest.files[].status` markers + `verified` flag (template :62-77); enforced by Hermes `iplan_rules.py:70-71` |
+  | Session-summary logging | EXISTS | `session_handoff.sessions[]` (template :137-150); `traceability.code_inventory` (:167-176) |
+  | Per-command execution logging | MISSING | no field for command output / error text / failed-attempt history; only 3 booleans + free text |
+  | Re-runnability (clean interruption) | EXISTS | resume protocol README:54-57, template :127-130 (`PARTIAL` path) |
+  | Re-runnability (crash) | DEFECT | see Named defect 1 |
+  | Post-execution retrospective | MISSING | per-session `validation_results` only (:147-150); index `on_plan_completed` updates counters only (`IPLAN-00_index.TEMPLATE.yaml:160-163`) |
+  | Plan-level parallelism | EXISTS | index `parallel_with[]` (:42) + `execution_path.tiers` (:64-89) |
+  | Intra-plan parallelism (multiple agents, one IPLAN) | MISSING | no claim/lease field; `session_count` assumes serial sessions (:51); single YAML updated in place → concurrent read-modify-write loses updates |
+
+## Named defects (evidence-backed; design now or with first Layer-8 run)
+
+1. **`IN_PROGRESS` orphan hole (crash recovery).** The resume protocol
+   instructs successors to pick the next `NOT_STARTED` or `PARTIAL` file —
+   `IN_PROGRESS` is not in the search (README:54-57; template :127-130;
+   restated in plugin `doc-iplan/SKILL.md:100-106`). A session that crashes
+   after flipping a file to `IN_PROGRESS` but before writing its handoff
+   entry orphans that file permanently: no staleness rule, no reclaim
+   semantics, no specified write ordering (when to flip status relative to
+   doing the work and appending the session entry). Fix is a few protocol
+   lines: an `IN_PROGRESS`-stale reclaim rule + explicit write ordering, in
+   README §Session Handoff Protocol and template Section 5 `_guidance`.
+2. **Hermes ↔ template contract break: `iplan_ready_score`.** Hermes
+   `check_iplan_readiness_score` errors when
+   `document_control.iplan_ready_score` is missing
+   (`platforms/hermes/src/mcp_server/validation/iplan_rules.py:30-32`), but
+   the template's `document_control` (:39-51) defines no such field; neither
+   does the acceptance golden fixture. A template-conforming IPLAN fails
+   Hermes validation today. Belongs on `plans/HERMES-BACKLOG.md` (Hermes
+   parity), not in a template change.
+
+## Backlog (no named issue yet — do NOT design until a real Layer-8 run surfaces the need)
+
+Per the minimal-and-realistic-plans convention (CLAUDE.md §Durable
+conventions), these stay one-liners until an end-to-end IPLAN execution
+names and sizes them:
+
+- Per-command execution logging (command output / error capture per session).
+- Post-execution retrospective section (manifest deviations, deferred items
+  closed, lessons; completion gate analog of `doc-iplan-audit`, which today
+  only gates pre-code).
+- Intra-plan claim/lease mechanism for concurrent agents — requires solving
+  single-file write contention (lost-update races on one YAML), not just a
+  `claimed_by` field.
+- Heterogeneous agent/model routing per task — per-file/per-task complexity
+  or capability hints so an orchestrator can route simple files to a cheap
+  model and complex ones to a strong model + matching skills. Embryonic
+  hooks exist (`session_handoff.sessions[].agent`, document-level
+  `complexity: 1-5`). Likely split: the *hint* lives in IPLAN, the routing
+  logic lives in the platform (manifest/engine split). Depends on the
+  intra-plan parallelism item.
+
+## SemVer impact notes (verified against consumers)
+
+- A new **required** top-level section = framework spec **MINOR**: must
+  update `metadata.total_sections: 6` (template :16), five section
+  enumerations in plugin `doc-iplan/SKILL.md` (:77, :80, :127, :144, :192),
+  `doc-iplan-autopilot/SKILL.md:74`, `doc-iplan-fixer/SKILL.md:53`, and
+  3 acceptance golden fixtures (`tests/acceptance/_harness.py:24-32` treats
+  every top-level key as required by default). `doc-iplan-audit` enumerates
+  dynamically and auto-adapts.
+- New **optional fields** on existing sections (e.g. lease/routing hints on
+  manifest entries) are additive ≈ **PATCH**: Hermes `IPLAN-002` errors only
+  on missing fields; acceptance checks only ordering/directive; neither
+  rejects extra keys.
+
+## Decisions already taken (do not reopen without new evidence)
+
+- **No design-review governance in IPLAN** (Review log / Claim ledger): that
+  rigor lives upstream (BRD…SPEC) and in the markdown development plan —
+  `PLAN_STANDARD.md` §Scope and boundary. IPLAN stays a lean execution
+  manifest; its governance is execution-evidence (`verified`,
+  `validation_results`, `code_inventory`).
+- **Review-pass minimum stays 2.** Empirics across 65 plans with review
+  logs: 42 converged at 2 passes, 13 at 3, 5 at 4, 4 at 5, 1 at 6. The
+  zero-findings stop-condition already extends to 3-6 passes when content
+  demands; a floor of 3 adds ritual passes to the ~65% that converge at 2.
+- **`execution_commands` category keys (`setup`/`implementation`/
+  `validation`) are a validated contract** (`iplan_rules.py:104`) — already
+  language-neutral; do not rename.
+
+## Sequencing recommendation
+
+1. Implement `plans/IPLAN-LANG-001-PLAN.md` (de-Python template example
+   content; spec PATCH 0.15.2 → 0.15.3). Plan is ready (3 review passes,
+   17 verified citations).
+2. Fix Named defect 1 (small spec-text change) — standalone or folded into
+   the first Layer-8 end-to-end plan.
+3. Record Named defect 2 on `plans/HERMES-BACKLOG.md`.
+4. **Drive an example project (url-shortener) through 07_TDD → 08_IPLAN →
+   execution.** This first real run converts the backlog items from
+   speculation into named, sized issues.
+5. Only then design execution-management additions, sized to what the run
+   actually surfaced.


### PR DESCRIPTION
## What this is

A **plan PR** (no code/spec change yet, per the plan-before-impl workflow). It adds two development records under `plans/`:

1. **`plans/IPLAN-LANG-001-PLAN.md`** — a `refactor` plan to de-Python the Layer-8 `IPLAN-TEMPLATE.yaml` so it **inherits the implementation language from its `@spec`** (the SPEC layer already owns `language:` + `dependencies:`) instead of hardcoding Python in example commands/paths. The structural contract (six sections; the `setup`/`implementation`/`validation` `execution_commands` categories Hermes validates) is preserved exactly → **framework-spec PATCH**, no validator/conformance impact.

2. **`plans/IPLAN-LAYER-TODO.md`** — the execution-management gap-audit produced this session: capability classification (EXISTS/MISSING/DEFECT), two **named defects** (session-handoff `IN_PROGRESS` crash-recovery hole; Hermes `iplan_ready_score` template divergence), four **deferred backlog** items (per-command logging, post-execution retrospective, intra-plan parallel claim/lease, per-task agent/model routing), and SemVer/consumer-impact analysis. Backlog items stay one-liners until a project executes Layer 8 end-to-end (none has — `url-shortener` stops at `06_SPEC`).

## Review status (plan)

`IPLAN-LANG-001-PLAN.md` passed the verified-planning gate: **17 cited claims, 3 review passes (2 independent fresh-context), zero load-bearing findings.** Pass 2 caught and corrected a wrong assumption — the two version-string "sync gaps" the draft proposed to hand-edit were already auto-handled by `sync-version-refs.sh` as of the 0.15.2 release.

## Scope discipline

- **Plan-only PR.** No `framework/**` files touched, so GATE-SPEC does not apply here.
- The engine-agnostic spec stub (`framework/layers/08_IPLAN/TODO.md`) is **intentionally excluded** — it is a `framework/**` change and will ship in the **implementation PR** alongside the `framework/VERSION` 0.15.2 → 0.15.3 bump + CHANGELOG entry that GATE-SPEC-E005/E008 require.

## Next steps (separate PRs)

1. Implement IPLAN-LANG-001 (template edit + 0.15.3 bump + CHANGELOG + plugin-bundle re-sync + the spec stub).
2. Record the Hermes `iplan_ready_score` divergence on `HERMES-BACKLOG.md`.
3. Drive `url-shortener` through `07_TDD → 08_IPLAN → execution` to convert the backlog items into named issues.