### PR TITLE
fix(legacy): drop SDD depth tiers from sdd-orchestrator skill

### DIFF
--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -24,6 +24,24 @@
 
 ## Open
 
+### `[legacy]` Scan for v3.2-era anachronisms across the codebase
+
+- *Context:* user-surfaced (2026-06-12) — the `sdd-orchestrator`
+  agent-skill still carried `sdd_depth: lite | standard | full` tiers
+  from the SDD v3.2 era. The current framework spec has settled on a
+  single SDD path (BRD..IPLAN, all 8 required per necessary-upstream)
+  with an adaptive loop (MVP → PROD → New MVP → Updated PROD). The
+  legacy-sdd-depth follow-up PR removed the depth references but
+  surfaced that the orchestrator's broader worldview (15-persona
+  model, ucx_hermes templates, SDD v3.2 versioning) is also stale.
+- *Fix shape:* dedicated v3.2-residue scan pass: grep across all
+  non-`legacy-ucx-v3.2-read-only` paths for: `SDD v3`, `v3.2`,
+  `sdd_depth`, `lite|standard|full` triples in SDD context, `15
+  personas`, `ucx_hermes/templates`, `sdd_create` / `sdd_validate`
+  CLI invocations. Hermes-side scope tracked separately in
+  HERMES-BACKLOG H-11.
+- *Status:* OPEN — file under `[legacy]` tag.
+
 ### `[layer-promotion]` Promote `component_decomposition` to a first-class `02b_DECOMP` layer (Option B from DECISION-GATE-D)
 
 - *Context:* DECISION-GATE-D (2026-06-11) resolved as Option A

--- a/plans/HERMES-BACKLOG.md
+++ b/plans/HERMES-BACKLOG.md
@@ -276,6 +276,37 @@ against url-shortener converged to PASS @ iter 3 score 95.
 once H-4 (team-mode) + H-5 (playbook injection) prerequisites are in
 place.
 
+### H-11 — sdd-orchestrator agent-skill v3.2-era modernization (legacy-sdd-depth cleanup origin)
+
+**Source:** legacy-sdd-depth cleanup PR (2026-06-12) — user-surfaced
+legacy bug: the v3.2-era `sdd_depth: lite | standard | full` tiers had
+survived in `platforms/hermes/agent-skills/spec-driven-development/sdd-orchestrator/`
+after the framework moved to the single-path adaptive-loop model
+(MVP → PROD → New MVP → Updated PROD). The legacy-sdd-depth PR removed
+the `sdd_depth` references from `sdd_config.yaml` + `root-docs/README.md`
+
+- added this entry. The orchestrator's broader v3.2-era worldview is
+deeper than this cleanup touched.
+
+**Substantive work for Hermes** (beyond the depth removal):
+
+- Modernize the orchestrator's persona model — the skill still
+  references "15 specialized review personas dispatched as parallel
+  subagents" from the v3.2 era. The current framework uses the closed
+  persona set in `REVIEW_CREWS.yaml` with per-layer crews of 5-6
+  lenses + per-lens playbooks at `framework/playbooks/<NN>_<LAYER>/`.
+- Cross-link the LAYER-PLAYBOOKS-001 contract.
+- Replace `sdd-review-personas` related-skill reference with the
+  current crew + playbook contract.
+- Update governance docs under the orchestrator's `governance/` for
+  the same v3.2-era anachronisms.
+- Live verification — confirm a Hermes user invoking
+  `sdd-orchestrator` against url-shortener follows the current 8-layer
+  path.
+
+**Dependency:** none specific. Independent of H-1..H-10. Can land
+incrementally.
+
 ## What's NOT in this backlog
 
 - **Anything plugin-side.** Plugin TODOs live in normal places —

--- a/platforms/hermes/agent-skills/spec-driven-development/sdd-orchestrator/governance/templates/sdd_config.yaml
+++ b/platforms/hermes/agent-skills/spec-driven-development/sdd-orchestrator/governance/templates/sdd_config.yaml
@@ -1,8 +1,20 @@
-# SDD v3 Project Configuration
+# SDD Project Configuration
 # Copy to project root and customize.
+#
+# NOTE (2026-06-12, legacy-sdd-depth cleanup): The framework no longer
+# supports the v3.2-era `sdd_depth: lite | standard | full` tiers. All
+# 8 SDD layers (BRD → PRD → EARS → BDD → ADR → SPEC → TDD → IPLAN) are
+# required by the **necessary-upstream contract** (NECESSARY-UPSTREAM-001,
+# framework spec `0.16.0`). Skipping a layer breaks the trace chain — a
+# downstream layer's `required_tags` cannot resolve to an absent upstream
+# document. The single SDD path is the adaptive loop
+# MVP → PROD → New MVP → Updated PROD; reality deltas enter via the CHG
+# overlay (CHG-RT-001, framework spec `0.21.0`).
+#
+# The broader sdd-orchestrator skill is still pre-LAYER-PLAYBOOKS-001
+# era; full Hermes-side modernization is tracked as HERMES-BACKLOG H-11.
 
-sdd_version: "3.2"
-sdd_depth: "standard"  # lite | standard | full
+sdd_version: "0.21.0"  # tracks framework spec version
 
 # v3 chain registry aliases
 layer_aliases:
@@ -15,28 +27,24 @@ layer_aliases:
   tdd: 7
   iplan: 8
 
+# All 8 layers are required per the necessary-upstream contract. A
+# layer's `required_tags` (declared in
+# `framework/registry/LAYER_REGISTRY.yaml`) cite the layers it consumes
+# directly; transitively the entire chain BRD..IPLAN must exist.
 required_artifacts:
-  lite:
-    - brd
-    - prd
-    - iplan
-  standard:
-    - brd
-    - prd
-    - ears
-    - adr
-    - spec
-    - tdd
-    - iplan
-  full:
-    - brd
-    - prd
-    - ears
-    - bdd
-    - adr
-    - spec
-    - tdd
-    - iplan
+  - brd
+  - prd
+  - ears
+  - bdd
+  - adr
+  - spec
+  - tdd
+  - iplan
+
+# CHG overlay (CHG-RT-001) sits across the chain — triggered on-demand
+# when modifying any of the 8 layers, not part of the cascade chain.
+overlays:
+  - chg
 
 change_management:
   chg_enabled: true
@@ -50,4 +58,3 @@ change_management:
 testing:
   unit_min_coverage: 80
   integration_min_coverage: 60
-  require_bdd_in_full: true

--- a/platforms/hermes/agent-skills/spec-driven-development/sdd-orchestrator/root-docs/README.md
+++ b/platforms/hermes/agent-skills/spec-driven-development/sdd-orchestrator/root-docs/README.md
@@ -223,10 +223,20 @@ Project UCX assets (personas, prompts, templates) scaffolded to `{project}/UCX/`
 
 ### For New Projects
 
-1. Choose your SDD depth (Lite / Standard / Full)
-2. Copy templates from `ucx_hermes/templates/` or layer directories
-3. Create documents using ucx_hermes `sdd_create`
-4. Validate with ucx_hermes `sdd_validate`
+The current framework runs a **single SDD path** with an adaptive
+loop — no `lite | standard | full` depth tiers (legacy SDD v3.2
+concept; removed 2026-06-12). All 8 layers are required per the
+**necessary-upstream contract** (NECESSARY-UPSTREAM-001).
+
+1. Author all 8 layer documents: BRD → PRD → EARS → BDD → ADR → SPEC
+   → TDD → IPLAN. Templates live in `framework/layers/<NN>_<LAYER>/`.
+2. Create documents using the framework's `doc-<layer>` SKILLs (e.g.
+   `doc-brd`, `doc-prd`, …).
+3. Validate with the layer audit SKILLs (`doc-<layer>-audit`) or run
+   the full `doc-<layer>-autopilot` cycle.
+4. The adaptive loop **MVP → PROD → New MVP → Updated PROD** absorbs
+   reality deltas via the CHG governance overlay
+   (`doc-chg-autopilot`, CHG-RT-001).
 
 ### Document Size Policy
 


### PR DESCRIPTION
## Summary

User-surfaced legacy bug (2026-06-12): the v3.2-era `sdd_depth: lite | standard | full` tiers had survived in 2 files under the `sdd-orchestrator` agent-skill, even though the current framework moved to a single SDD path under the **necessary-upstream contract** (NECESSARY-UPSTREAM-001) with an adaptive loop **MVP → PROD → New MVP → Updated PROD**.

## Why this is a bug

| Depth tier | Skipped layers | Problem |
|---|---|---|
| `lite` | EARS / BDD / ADR / SPEC / TDD | No path from PRD to IPLAN |
| `standard` | BDD | EARS has no downstream scenario layer → breaks trace chain |
| `full` | (none) | Matches current contract — but only because all 8 are required, not because "full" is special |

The framework's `required_tags` chain requires all 8 layers; a downstream layer's tags cannot resolve to an absent upstream document. Depth tiers contradict the contract.

## Files modified (minimal scope, ~10 lines net)

1. **`platforms/hermes/agent-skills/spec-driven-development/sdd-orchestrator/governance/templates/sdd_config.yaml`** —
   - Removed: `sdd_depth: "standard"` field + `required_artifacts.{lite,standard,full}` enumeration
   - Added: `required_artifacts` as a flat 8-layer list + `overlays: [chg]` + explanatory header noting the depth tiers were removed per NECESSARY-UPSTREAM-001
   - Bumped `sdd_version: "3.2"` → `"0.21.0"` (tracks framework spec version)
2. **`.../sdd-orchestrator/root-docs/README.md`** Quick Start —
   - Replaced "Choose your SDD depth (Lite / Standard / Full)" with single-path text + adaptive-loop reference + current `doc-<layer>` SKILL workflow

## Out of scope (cataloged for follow-up)

- **`plans/HERMES-BACKLOG.md` H-11**: broader `sdd-orchestrator` modernization — the skill still references "15 specialized review personas dispatched as parallel subagents" from the v3.2 era; the current framework uses the closed persona set + per-layer crews of 5-6 lenses + per-lens playbooks at `framework/playbooks/<NN>_<LAYER>/`. Also references `ucx_hermes/templates/` etc. Hermes-side modernization batch.
- **`plans/FRAMEWORK-TODO.md` `[legacy]` entry**: dedicated v3.2-residue scan pass across the whole codebase — grep for `SDD v3`, `v3.2`, `sdd_depth`, depth triples, 15-persona, ucx_hermes references.

## Verification

- [x] Conformance: 120/120 PASS (docs-only change; no logic touched)
- [x] Pre-commit hooks PASS

## Refs

- NECESSARY-UPSTREAM-001 — necessary-upstream contract (framework `0.16.0`)
- CHG-RT-001 (PR #137) — adaptive-loop reality-delta path; just merged
- Master plan FRAMEWORK-CLEANUP-001 (PR #128) — broader cleanup workstream