### PR TITLE
docs+chore: support channels framework slice (IPLAN-0008 steps 3 + 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,28 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added — IPLAN-0008 framework slice (no plugin VERSION change)
+
+- **`docs/SUPPORT.md`** — new public-facing channel directory for
+  developers, evaluators, and contributors. Names the four channels
+  (in-product `/aidoc-flow:bug-report` and `/feedback`, GitHub Issues
+  direct, web-site `/support`), explains the AI Team intake architecture
+  for Phase 2 Contact-us, and documents what channels do NOT exist by
+  design (no public Slack, no public Telegram, no `mailto:`, no status
+  page). Cross-links to the operations and business sibling docs.
+- **`scripts/sync-version-refs.sh`** extended to propagate
+  `Pre-release v<X.Y.Z>` in `../web-site/src/pages/index.astro`
+  (cross-submodule write at the umbrella layer; no-op when the sibling
+  is not present). Closes the version-badge drift class for the web-site
+  home page — sibling fix to the plugin-README drift fixed in v0.20.1.
+  Per IPLAN-0008 step 6.
+- **`plans/FRAMEWORK-TODO.md`** carries the
+  `WEBSITE-VERSION-BADGE-DRIFT` entry documenting the cross-repo
+  coupling.
+
+Trace: this CHANGELOG entry covers the framework slice of
+`../operations/ops/iplans/IPLAN-0008_support-channels.md` (steps 3 + 6).
+
 ### Fixed — Claude Code plugin 0.20.0 → 0.20.1 (PATCH)
 
 - Long-standing drift in `platforms/claude-code-plugin/README.md` Platform

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -88,6 +88,14 @@ Strategic direction.
 Headline capabilities now in the framework (full detail in
 [`CHANGELOG.md`](CHANGELOG.md)):
 
+- **Support channels — framework slice (IPLAN-0008 steps 3 + 6, no
+  VERSION change).** New public-facing `docs/SUPPORT.md` channel
+  directory (four channels: in-product `/aidoc-flow:bug-report` and
+  `/feedback`, GitHub Issues direct, web-site `/support`);
+  `scripts/sync-version-refs.sh` extended for the web-site home-page
+  version badge (sibling fix to the plugin-README drift fixed in
+  v0.20.1). Tracked in `plans/FRAMEWORK-TODO.md` as
+  `WEBSITE-VERSION-BADGE-DRIFT`.
 - **Platform README Version cell drift fix (`0.20.0 → 0.20.1`, PATCH).**
   Fixed long-standing drift in `platforms/claude-code-plugin/README.md`
   Platform info table (`Version` cell stuck at `0.6.3` since plugin v0.7.0)

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -1,0 +1,142 @@
+---
+title: "Support — where to file what"
+description: Channel directory for developers, evaluators, and contributors. Names the four channels, what each is for, and what to expect after submission.
+tags:
+  - reference
+  - active
+custom_fields:
+  document_type: reference
+  priority: shared
+  development_status: active
+---
+
+# Support
+
+Four channels. Different intents, same triage destination, transparent
+trade-offs. Pick the one that matches what you're trying to do.
+
+> **One thing to know up front:** the plugin **never auto-submits**
+> anything. Every channel below ends at a form on `github.com` or in
+> your Gmail — *you* click Submit. The AI Team handles filtering and
+> drafting; humans handle authorship.
+
+## The four channels
+
+| When | Use this | Where it lands |
+|---|---|---|
+| Plugin is installed; the problem is right in front of you | `/aidoc-flow:bug-report <one-line description>` | LLM drafts a complete GitHub issue from your prompt + recent conversation context; you click the printed URL and Submit on github.com |
+| Plugin is installed; you have an idea or comment | `/aidoc-flow:feedback <one-line summary>` | Same shape as `bug-report`, lands on the `feedback.md` template |
+| You're on GitHub already; you know what's broken | [GitHub Issues](https://github.com/vladm3105/aidoc-flow-framework/issues/new/choose) — pick the **Bug Report** or **Feedback** template directly | Issue lands in the repo's triage queue |
+| You're on the website; no GitHub account or you want to ask something open-ended | [`aidoc-flow.io/support`](https://aidoc-flow.io/support) — Bug-report and Feedback sections link out to GitHub; Contact-us is for everything else | Bug-report / Feedback → GitHub; Contact-us → AI Team intake (Phase 2) |
+
+## Channel details
+
+### 1. In-product `/aidoc-flow:bug-report`
+
+You type one sentence about what broke; the plugin's LLM uses that
+plus the recent conversation context (last command, the error message,
+files referenced) and the environment stamp (plugin version, framework
+spec, OS, Claude Code version) to **draft** a complete GitHub issue —
+concise title + sectioned body matching
+[`.github/ISSUE_TEMPLATE/bug_report.md`](../.github/ISSUE_TEMPLATE/bug_report.md).
+
+The draft is URL-encoded into a `?title=&body=` GitHub `issues/new` URL.
+The plugin prints a preview of the title + body in chat so you can
+sanity-check before clicking through. Then it prints the link. You open
+it, the GitHub form opens prefilled, you add anything that's missing,
+and click Submit.
+
+**Honest framing:** the plugin never submits the issue itself; it never
+includes secrets it sees in the conversation (fragments matching
+`token|secret|key|password|api[_-]?key` are replaced with `(redacted)`).
+The drafted title and body are an LLM proposal you can edit on github.com.
+
+### 2. In-product `/aidoc-flow:feedback`
+
+Same shape as `bug-report` but lands on
+[`.github/ISSUE_TEMPLATE/feedback.md`](../.github/ISSUE_TEMPLATE/feedback.md).
+Use this for feature ideas, what worked / didn't work, and questions
+that aren't bugs. The classifier on the GitHub side may further route
+your feedback during triage.
+
+### 3. Direct on GitHub
+
+If you already know what's broken and you're comfortable with GitHub,
+the fastest path is the Issues page. Click "New issue" and pick the
+template that matches your intent:
+
+- [Bug Report](https://github.com/vladm3105/aidoc-flow-framework/issues/new?template=bug_report.md) — something is broken
+- [Feedback](https://github.com/vladm3105/aidoc-flow-framework/issues/new?template=feedback.md) — idea, comment, question
+
+The templates carry the same section structure the in-product commands
+draft into, so the issue reads the same whether you arrive via the
+plugin or directly.
+
+### 4. Web-site `/support` (`aidoc-flow.io/support`)
+
+Three sections on one page:
+
+- **Report a bug** — clicks through to GitHub Issues (zero-spam-exposure
+  on the website; GitHub auth handles abuse).
+- **Share feedback** — clicks through to GitHub Issues, feedback template.
+- **Contact us** — for visitors who don't have a GitHub account or have
+  a question that doesn't fit a template. The Contact-us form is
+  active in Phase 2 (see "Where this is going" below); until then the
+  section explains the architecture and points back to the GitHub
+  channels.
+
+The Contact-us channel, when active, routes through the AI Team's
+intake workflow — see
+[`../../operations/docs/SUPPORT_INTAKE.md`](../../operations/docs/SUPPORT_INTAKE.md)
+for the full design. Short version: the AI Team filters, classifies,
+auto-acknowledges, drafts a substantive reply for the maintainer to
+review, and notifies the maintainer via email + internal Slack +
+internal Telegram bot. No spam reaches the maintainer's IM. No reply
+goes out without human review (except a narrowly-scoped template ack).
+
+## Where this is going (Phase 2)
+
+The Contact-us channel on `aidoc-flow.io/support` is **stubbed** today
+("AI Team intake coming in v2 — for now please use the GitHub channels
+above"). It is intentional, not a placeholder forgotten in production.
+Phase 2 activates the form once the AI Team intake workflow is built.
+
+Phase 2 is tracked at:
+
+- [`../../operations/ops/iplans/IPLAN-0008_support-channels.md`](../../operations/ops/iplans/IPLAN-0008_support-channels.md)
+  — the cross-repo coordination IPLAN.
+- [`../../operations/docs/SUPPORT_INTAKE.md`](../../operations/docs/SUPPORT_INTAKE.md)
+  — operations-side intake design.
+- [`../../business/docs/SUPPORT_STRATEGY.md`](../../business/docs/SUPPORT_STRATEGY.md)
+  — channel × audience × SLA × pricing-tier policy.
+
+There is no SLA promised on Phase 2 timing. If you need a contact
+channel and don't have GitHub, open an issue on a sibling project and
+mention this one — that's the fallback while Phase 2 is in flight.
+
+## What to expect after you submit
+
+| Channel | When you'll hear back |
+|---|---|
+| GitHub Issues (any of channels 1–3) | Triage queue; aiming for a substantive reply per the windows in [`../../business/docs/SUPPORT_STRATEGY.md`](../../business/docs/SUPPORT_STRATEGY.md) §3 (bug: 2 business days; feature: 5 business days; chat: 3 business days) |
+| Web-site Contact-us (Phase 2, when active) | Auto-acknowledgment within minutes (template); substantive reply per the same windows; commercial inquiries (`sales` class) targeted at 1 business day |
+
+These are intent windows, not contractual SLAs. The OSS project runs
+on best-effort; paid-tier SLAs are documented separately when paid
+tiers ship.
+
+## Out of scope (channels that don't exist today)
+
+The following are explicitly NOT support channels — by design:
+
+- **No public Slack workspace.** Internal Slack is a notification sink
+  for the maintainer; it's not a place for external users to drop in.
+- **No public Telegram bot.** Internal Telegram bot serves the same
+  notification role; it's not public.
+- **No `mailto:` link** anywhere on the public surface. Email crawlers
+  harvest these and turn maintainer inboxes into spam.
+- **No status page** (`status.aidoc-flow.io`) yet. Useful when uptime
+  is meaningful; not now (no hosted service to monitor).
+
+When any of these become useful enough to set up, the change ships
+through a normal IPLAN — not unilaterally added to a doc.

--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -24,6 +24,28 @@
 
 ## Open
 
+### `[sync]` `WEBSITE-VERSION-BADGE-DRIFT` — `web-site/src/pages/index.astro` `Pre-release v<X.Y.Z>` badge
+
+- *Context:* IPLAN-0008 step 6 closed the bug class for the web-site
+  home-page badge by extending `scripts/sync-version-refs.sh` to
+  propagate `Pre-release v<X.Y.Z>` into the sibling
+  `../web-site/src/pages/index.astro` (cross-submodule write at the
+  umbrella layer). The script change ships in the framework PR;
+  the actual badge value is set in the web-site PR (also part of
+  IPLAN-0008, step 4-5-7). This entry exists so the cross-repo
+  coupling is discoverable from the framework side.
+- *Fix shape:* Same `replace_in_file "Pre-release v<old>" "Pre-release v<new>"` shape
+  as the v0.20.1 plugin-README fix used. The replace_in_file helper is
+  no-op if `../web-site/src/pages/index.astro` does not exist
+  (framework cloned standalone without the umbrella siblings). When
+  framework's plugin VERSION bumps next, the hook propagates to the
+  web-site working tree; the developer commits the change in
+  web-site's own PR.
+- *Status:* Closed by the framework PR for IPLAN-0008 step 3+6 — the
+  sync-script extension lands here; the cross-repo verification (bump
+  VERSION → run sync → observe web-site badge change) is the
+  Confirmation gate in IPLAN-0008.
+
 ### `[sync]` `HERMES-README-VERSION-DRIFT` — `platforms/hermes/README.md` Version + framework-spec cells stale
 
 - *Context:* Plugin `0.20.1` PATCH (2026-06-14) found and fixed the same

--- a/scripts/sync-version-refs.sh
+++ b/scripts/sync-version-refs.sh
@@ -27,6 +27,13 @@
 #       (added 2026-06-14 to close the v0.6.3 → v0.20.0 drift bug — the
 #       prior awk pass only handled bare X.Y.Z lines in the `$ cat VERSION`
 #       example block, missing the table cell)
+#   - ../web-site/src/pages/index.astro
+#       `Pre-release v<X.Y.Z>` badge in the home page (cross-submodule write
+#       at the umbrella layer; added 2026-06-14 per IPLAN-0008 step 6 to
+#       close the v0.18.0 stale-badge drift bug). The sibling web-site/ is
+#       a separate git repo, so writes here land as unstaged changes in
+#       web-site's working tree — the developer commits them in web-site's
+#       own PR. Skipped silently if web-site/ is not present alongside.
 #   - docs/PARITY.md
 #       claude-code-plugin/v<X.Y.Z> current-state row
 #
@@ -136,6 +143,13 @@ if [[ -n "$plugin_ver" ]]; then
       "claude-code-plugin/v$plugin_prev" "claude-code-plugin/v$plugin_ver"
     replace_in_file platforms/claude-code-plugin/README.md \
       "claude-code-plugin/v$plugin_prev" "claude-code-plugin/v$plugin_ver"
+    # Cross-submodule write: ../web-site/ is a sibling repo under the umbrella.
+    # The sync hook lands changes in its working tree; the developer commits
+    # them in the web-site PR. The replace_in_file helper is no-op if the file
+    # does not exist (e.g., the framework repo is cloned standalone without
+    # the umbrella siblings).
+    replace_in_file ../web-site/src/pages/index.astro \
+      "Pre-release v$plugin_prev" "Pre-release v$plugin_ver"
     replace_in_file platforms/claude-code-plugin/docs/SKILL_AUTHORING.md \
       "version: \"$plugin_prev\"" "version: \"$plugin_ver\""
     replace_in_file platforms/claude-code-plugin/docs/SKILL_AUTHORING.md \


### PR DESCRIPTION
## Summary

Implements **steps 3 and 6 of IPLAN-0008** (the cross-repo support-channels coordination IPLAN merged via [aidoc-flow-operations PR #19](https://github.com/vladm3105/aidoc-flow-operations/pull/19)). The framework slice: a new public-facing channel directory + an extension to the version-sync script that closes the version-badge drift class for the web-site home page.

This is one of **4 parallel impl PRs** following PR #19. PRs #20 (operations doc) and #23 (business doc) are already open. PR 4 (web-site) opens next.

**No plugin VERSION change** — the framework slice is purely docs + sync-script extension.

## Changes

### `docs/SUPPORT.md` — new public-facing channel directory

The four channels named and explained:

- In-product `/aidoc-flow:bug-report` and `/aidoc-flow:feedback` (LLM-drafted, never auto-submitted)
- GitHub Issues direct (template URLs prefilled)
- Web-site `/support` (Bug-report + Feedback → GitHub; Contact-us → AI Team intake in Phase 2)

Honest framing for each: what the channel does, what to expect after submission, the AI Team intake architecture for Phase-2 Contact-us, and **what channels do NOT exist by design** — no public Slack, no public Telegram, no `mailto:`, no status page. Future "should we add X?" questions now have a written answer pointing at this doc.

Cross-links to sibling design docs (`operations/docs/SUPPORT_INTAKE.md`, `business/docs/SUPPORT_STRATEGY.md`).

### `scripts/sync-version-refs.sh` extension — cross-submodule write

Propagates `Pre-release v<X.Y.Z>` in `../web-site/src/pages/index.astro` whenever the plugin VERSION changes. The sibling web-site is a separate git repo, so writes land as **unstaged changes in web-site's working tree** — the developer commits them in web-site's own PR. The `replace_in_file` helper is no-op if the sibling is absent (e.g. framework cloned standalone without the umbrella).

Same shape as the v0.20.1 plugin-README fix; sibling closure of the same drift class.

### `plans/FRAMEWORK-TODO.md` — `WEBSITE-VERSION-BADGE-DRIFT` entry

Records the cross-repo coupling so it's discoverable from the framework side.

## Why no plugin VERSION bump

The framework slice ships no plugin behavior change (no skill, no agent, no command, no plugin-internal config). Adding `docs/SUPPORT.md` is a framework-doc addition; extending the sync script affects build-time mechanics, not plugin runtime. The CHANGELOG entry sits under `[Unreleased]` without a SemVer band.

The next plugin VERSION bump (whenever it happens) will trigger the extended sync hook, which will then propagate to the web-site working tree. The web-site PR landing alongside this one sets the badge to the current value (`v0.20.1`) by hand-edit; subsequent bumps are automatic.

## SDD Traceability

| Tag | Reference |
|-----|-----------|
| `@iplan` | `../operations/ops/iplans/IPLAN-0008_support-channels.md` steps 3 + 6 |
| `@sibling-pr` | aidoc-flow-operations [PR #20](https://github.com/vladm3105/aidoc-flow-operations/pull/20) (operations doc) |
| `@sibling-pr` | aidoc-flow-business [PR #23](https://github.com/vladm3105/aidoc-flow-business/pull/23) (business doc) |
| `@predecessor` | PR #145 (v0.20.1 plugin-README drift fix; sibling to this PR's sync-script extension) |

## Testing

- [x] **V3** Full conformance suite — **129/129 pass**
- [x] `docs/SUPPORT.md` exists and renders
- [x] `grep -n "Pre-release v" scripts/sync-version-refs.sh` = 2 hits (script header + replace_in_file line)
- [x] Pre-commit: trim, markdownlint, ruff, conformance, version-sync, docs-of-record reminder — all pass
- [ ] **V9-equivalent** cross-repo: after this lands, when the next plugin VERSION bumps, the sync hook should propagate to `../web-site/src/pages/index.astro` — verifiable empirically by bumping a test VERSION and observing the change.

## Docs of record updated inline (per Durable convention)

- [x] `CHANGELOG.md` — new `### Added — IPLAN-0008 framework slice` under `[Unreleased]`
- [x] `ROADMAP.md` — "Recently shipped" bullet
- [x] `plans/FRAMEWORK-TODO.md` — `WEBSITE-VERSION-BADGE-DRIFT` entry

## Checklist

- [x] Code follows project conventions
- [x] Traces back to IPLAN-0008
- [x] No speculative scope: 1 doc + 1 script extension + 1 TODO entry = direct mapping to IPLAN-0008 steps 3 + 6
- [x] Honest framing preserved: cross-submodule write is documented (not hidden)
- [x] No plugin VERSION bump (no plugin behavior change)