### PR TITLE
fix: clear umbrella PR Checks release gate (cut 0.21.1 + fix plugin manifest)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+Nothing yet.
+
+## [0.21.1] — Framework Spec — 2026-06-14
+
+### Fixed — release gate (umbrella `PR Checks`)
+
+- Cut this `## [0.21.1]` section from `[Unreleased]` so `tests/release`
+  (`test_changelog_has_entry_for_current_version`) matches `framework/VERSION`.
+- `platforms/claude-code-plugin/commands/status.md` — quoted the `description`
+  frontmatter value (an unquoted `:` made the YAML parse as a nested mapping),
+  so `claude plugin validate --strict` (`tests/packaging`) passes. At runtime
+  the unparsed frontmatter had been silently dropped.
+
 ### Fixed — ACCEPTANCE-FIXTURES-DRIFT (no plugin VERSION change)
 
 Closes 12 long-standing failures in

--- a/platforms/claude-code-plugin/commands/status.md
+++ b/platforms/claude-code-plugin/commands/status.md
@@ -1,6 +1,6 @@
 ---
 title: "Status — where is this project in the SDD flow"
-description: Scan the project's `docs/` tree and report per-layer state: exists, last edited, audited.
+description: "Scan the project's `docs/` tree and report per-layer state: exists, last edited, audited."
 tags:
   - workflow
   - active


### PR DESCRIPTION
## Summary

Fixes the two pre-existing framework-`main` failures that the umbrella `aidoc-flow` **PR Checks / deterministic** job has been red on (baseline since 2026-06-02). This is "option B" follow-up to the OSS-hardening work (#150). The umbrella job runs framework's full test suite; these two tiers were failing independent of any submodule pin.

## Changes

- **`tests/release`** — cut `## [0.21.1] — Framework Spec — 2026-06-14` from `[Unreleased]` in `CHANGELOG.md` so a section matches `framework/VERSION` (`0.21.1`). `test_changelog_has_entry_for_current_version` now passes. A fresh empty `[Unreleased]` is kept.
- **`tests/packaging`** — `platforms/claude-code-plugin/commands/status.md`: quoted the `description:` frontmatter value. An unquoted `:` (`per-layer state: exists, …`) made YAML parse it as a nested mapping, so `claude plugin validate --strict` failed — and the command's frontmatter was being **silently dropped at runtime**. Scanned all plugin `*.md` frontmatter; this was the only offender.

## Testing

All tiers the umbrella `deterministic` job runs, verified locally:

```
tests/conformance              -> OK
tests/unit                     -> OK
tests/acceptance/deterministic -> OK   (already fixed by #148)
tests/packaging                -> OK   (was failing: validate --strict)
tests/release                  -> OK   (was failing: missing 0.21.1 entry)
```

`claude plugin validate --strict` → `✔ Validation passed`.

## Checklist

- [x] Root cause verified (reproduced `validate --strict` error locally with `claude` 2.1.x)
- [x] No spec/contract change; no `framework/VERSION` change (already 0.21.1)
- [x] CHANGELOG updated (this is the changelog fix)

> Note: committed with `SKIP=markdownlint` — its Node pre-commit env can't install here (`GLIBCXX_3.4.30`); all other hooks (detect-secrets, gitleaks, conformance, docs-gate) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)