### PR TITLE
docs(support): go-live sync — Contact-us live via Google Forms (PR 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,24 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-Nothing yet.
+### Changed — `docs/SUPPORT.md` go-live sync (operations IPLAN-0009 PR 3)
+
+- `docs/SUPPORT.md` updated to reflect that the Contact-us channel is
+  **live** (not "stubbed / coming in v2") with a Google Form ↔ Sheet ↔
+  Drive MCP architecture.
+- §"Where this is going (Phase 2)" renamed to §"Architecture (live since
+  2026-06)" and rewritten to describe the simplified design: form →
+  Sheet → AI Team polls via `mcp__claude_ai_Google_Drive__*`; two-stage
+  classifier (Python prefilter + Haiku 4.5 LLM); no auto-acknowledgment
+  email (the Google Forms confirmation page is the visitor's only ack);
+  notification fan-out to internal Slack + Telegram + optional Gmail draft.
+- The four-channel directory table (channel #4 row) and the "What to
+  expect" table updated to drop "Phase 2 / when active" qualifiers.
+- Cross-link table now references `operations/ops/iplans/IPLAN-0009`
+  (Phase 2 implementation) alongside IPLAN-0008 (Phase 1 historical
+  context) and the operations + business design docs.
+- Trace: operations OPS-0039 + `aidoc-flow-operations#23` (plan) +
+  `aidoc-flow-operations#24` (impl).
 
 ## [0.21.1] — Framework Spec — 2026-06-14
 

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -27,7 +27,7 @@ trade-offs. Pick the one that matches what you're trying to do.
 | Plugin is installed; the problem is right in front of you | `/aidoc-flow:bug-report <one-line description>` | LLM drafts a complete GitHub issue from your prompt + recent conversation context; you click the printed URL and Submit on github.com |
 | Plugin is installed; you have an idea or comment | `/aidoc-flow:feedback <one-line summary>` | Same shape as `bug-report`, lands on the `feedback.md` template |
 | You're on GitHub already; you know what's broken | [GitHub Issues](https://github.com/vladm3105/aidoc-flow-framework/issues/new/choose) — pick the **Bug Report** or **Feedback** template directly | Issue lands in the repo's triage queue |
-| You're on the website; no GitHub account or you want to ask something open-ended | [`aidoc-flow.io/support`](https://aidoc-flow.io/support) — Bug-report and Feedback sections link out to GitHub; Contact-us is for everything else | Bug-report / Feedback → GitHub; Contact-us → AI Team intake (Phase 2) |
+| You're on the website; no GitHub account or you want to ask something open-ended | [`aidoc-flow.io/support`](https://aidoc-flow.io/support) — Bug-report and Feedback sections link out to GitHub; Contact-us is for everything else | Bug-report / Feedback → GitHub; Contact-us → AI Team intake (live; Google Forms → Sheet → Drive MCP poll) |
 
 ## Channel details
 
@@ -80,46 +80,57 @@ Three sections on one page:
   on the website; GitHub auth handles abuse).
 - **Share feedback** — clicks through to GitHub Issues, feedback template.
 - **Contact us** — for visitors who don't have a GitHub account or have
-  a question that doesn't fit a template. The Contact-us form is
-  active in Phase 2 (see "Where this is going" below); until then the
-  section explains the architecture and points back to the GitHub
-  channels.
+  a question that doesn't fit a template. The Contact-us form is a
+  Google Form; submissions land in a Google Sheet that the AI Team
+  polls via Google Drive MCP every ~15 minutes.
 
-The Contact-us channel, when active, routes through the AI Team's
-intake workflow — see
+The Contact-us channel routes through the AI Team's intake workflow —
+see
 [`../../operations/docs/SUPPORT_INTAKE.md`](../../operations/docs/SUPPORT_INTAKE.md)
-for the full design. Short version: the AI Team filters, classifies,
-auto-acknowledges, drafts a substantive reply for the maintainer to
-review, and notifies the maintainer via email + internal Slack +
-internal Telegram bot. No spam reaches the maintainer's IM. No reply
-goes out without human review (except a narrowly-scoped template ack).
+for the full design. Short version: a two-stage classifier (Python
+prefilter then Claude Haiku 4.5 LLM) drops spam, then the AI Team
+drafts a substantive reply for the maintainer to review and notifies
+the maintainer via internal Slack + internal Telegram bot + an
+optional Gmail draft. No spam reaches the maintainer's IM. No reply
+goes out without human review (the Google Forms confirmation page is
+the visitor's only auto-acknowledgment; founder composes a fresh
+Gmail per reply).
 
-## Where this is going (Phase 2)
+## Architecture (live since 2026-06)
 
-The Contact-us channel on `aidoc-flow.io/support` is **stubbed** today
-("AI Team intake coming in v2 — for now please use the GitHub channels
-above"). It is intentional, not a placeholder forgotten in production.
-Phase 2 activates the form once the AI Team intake workflow is built.
+The Contact-us channel on `aidoc-flow.io/support` is a Google Form;
+submissions auto-land in a linked Google Sheet that the AI Team's
+`customer-success-manager` seat polls via Google Drive MCP every ~15
+minutes. A two-stage classifier (Python prefilter → Claude Haiku 4.5
+LLM) drops spam without notifying the maintainer; non-spam classes
+produce a substantive-reply draft in `ops/inbox/` plus a notification
+fan-out to internal Slack, internal Telegram bot, and an optional
+Gmail draft for the maintainer to review.
 
-Phase 2 is tracked at:
+Design and implementation are documented at:
 
-- [`../../operations/ops/iplans/IPLAN-0008_support-channels.md`](../../operations/ops/iplans/IPLAN-0008_support-channels.md)
-  — the cross-repo coordination IPLAN.
 - [`../../operations/docs/SUPPORT_INTAKE.md`](../../operations/docs/SUPPORT_INTAKE.md)
-  — operations-side intake design.
+  — operations-side intake design (Forms→Sheet schema, classifier
+  cascade, per-class routing, escalation rules, notification fan-out).
+- [`../../operations/ops/iplans/IPLAN-0009_support-intake-implementation.md`](../../operations/ops/iplans/IPLAN-0009_support-intake-implementation.md)
+  — the implementation plan (steps A4–C3, claim ledger, review log).
+- [`../../operations/ops/iplans/IPLAN-0008_support-channels.md`](../../operations/ops/iplans/IPLAN-0008_support-channels.md)
+  — the original cross-repo coordination IPLAN (Phase 1 design;
+  superseded by IPLAN-0009 for Phase 2).
 - [`../../business/docs/SUPPORT_STRATEGY.md`](../../business/docs/SUPPORT_STRATEGY.md)
   — channel × audience × SLA × pricing-tier policy.
 
-There is no SLA promised on Phase 2 timing. If you need a contact
-channel and don't have GitHub, open an issue on a sibling project and
-mention this one — that's the fallback while Phase 2 is in flight.
+There are no contractual SLAs — the intent windows in
+[`../../business/docs/SUPPORT_STRATEGY.md`](../../business/docs/SUPPORT_STRATEGY.md)
+§3 are best-effort. If you need a contact channel and don't have
+GitHub, the form is the canonical path.
 
 ## What to expect after you submit
 
 | Channel | When you'll hear back |
 |---|---|
 | GitHub Issues (any of channels 1–3) | Triage queue; aiming for a substantive reply per the windows in [`../../business/docs/SUPPORT_STRATEGY.md`](../../business/docs/SUPPORT_STRATEGY.md) §3 (bug: 2 business days; feature: 5 business days; chat: 3 business days) |
-| Web-site Contact-us (Phase 2, when active) | Auto-acknowledgment within minutes (template); substantive reply per the same windows; commercial inquiries (`sales` class) targeted at 1 business day |
+| Web-site Contact-us (Google Form) | Google Forms confirmation page is the visitor's only ack; substantive reply per the same windows (commercial inquiries `sales` class targeted at 1 business day) |
 
 These are intent windows, not contractual SLAs. The OSS project runs
 on best-effort; paid-tier SLAs are documented separately when paid

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -1513,3 +1513,15 @@ MINOR 0.20.1 → 0.21.0; plugin MINOR 0.17.1 → 0.18.0. Static work landed
 (crew + 6 playbooks + 3 SKILL rewrites + saga driver + conformance
 extensions); 120/120 conformance + 47/47 unit. Live CHG cascade
 verification next.
+
+### 2026-06-14 — SUPPORT.md go-live sync (operations IPLAN-0009 PR 3)
+
+`docs/SUPPORT.md` updated to reflect that the Contact-us channel is **live**
+with a Google Form ↔ Sheet ↔ Drive MCP architecture (replacing the prior
+"stubbed / coming in v2" language). The simplified design — Forms + Sheet +
+Drive MCP poll + Python prefilter + Haiku 4.5 LLM classifier; no
+auto-acknowledgment; one-way form — is owned by the operations repo (PR
+[#23](https://github.com/vladm3105/aidoc-flow-operations/pull/23) plan +
+PR [#24](https://github.com/vladm3105/aidoc-flow-operations/pull/24) impl;
+OPS-0039). This framework PR is the docs-only sync. No VERSION change
+(documentation update only). No conformance impact.


### PR DESCRIPTION
## Summary

**Framework impl PR 3** for operations IPLAN-0009. Surgical edits to `docs/SUPPORT.md` to drop the "stubbed / coming in v2" language and reflect that the Contact-us channel is live with a Google Form ↔ Sheet ↔ Drive MCP architecture.

Trace: operations OPS-0039 ([operations PR #23 merged](https://github.com/vladm3105/aidoc-flow-operations/pull/23), [operations PR #24 merged](https://github.com/vladm3105/aidoc-flow-operations/pull/24)).

## What changed

### `docs/SUPPORT.md`

- **Four-channel directory table (row #4)** — "AI Team intake (Phase 2)" → "AI Team intake (live; Google Forms → Sheet → Drive MCP poll)".
- **§"### 4. Web-site `/support`"** — Contact-us bullet rewritten to describe the live Google-Form-backed architecture; the next paragraph drops "auto-acknowledges" + "narrowly-scoped template ack" language (no auto-ack ships) and names the two-stage classifier explicitly.
- **§"Where this is going (Phase 2)"** — **renamed** to **§"Architecture (live since 2026-06)"** and rewritten. Cross-link table now points to IPLAN-0009 (Phase 2 implementation) alongside IPLAN-0008 (Phase 1 historical context) and the operations + business design docs.
- **§"What to expect" table** — "(Phase 2, when active)" qualifier dropped from the Contact-us row; "Auto-acknowledgment within minutes (template)" promise removed.

### `CHANGELOG.md`

New `### Changed` entry in `[Unreleased]` summarizing the doc sync.

### `plans/HANDOFF.md`

New log entry "2026-06-14 — SUPPORT.md go-live sync" cross-referencing operations PR #23 + #24 + OPS-0039.

## What did NOT change

- **No VERSION change.** Neither `framework/VERSION` nor `platforms/claude-code-plugin/VERSION` is affected. This is a documentation update, not a framework-spec or plugin behavior change.
- **No conformance impact.** Nothing in `tests/conformance/` references the SUPPORT.md content.
- **No ROADMAP update.** Support is not on the framework's roadmap (it's owned by operations).

## Verification

- **Pre-commit:** all hooks pass EXCEPT markdownlint, which is skipped via `SKIP=markdownlint` due to a system-nodejs / anaconda `libstdc++` mismatch (`GLIBCXX_3.4.30` missing). User-authorized.
- **doc-of-record reminder hook:** PASSED — both `CHANGELOG.md` and `plans/HANDOFF.md` touched in same commit.

## Test plan

- [ ] Reviewer reads the diff to `docs/SUPPORT.md` and confirms the architecture description matches what `operations/docs/SUPPORT_INTAKE.md` describes (Forms → Sheet → Drive MCP poll; two-stage classifier; no auto-ack)
- [ ] Reviewer confirms cross-references to IPLAN-0009 + IPLAN-0008 + operations + business docs resolve correctly
- [ ] Reviewer confirms `CHANGELOG.md` `[Unreleased]` entry is the right shape
- [ ] Reviewer confirms `plans/HANDOFF.md` log entry is in chronological position
- [ ] No merge until reviewer is satisfied

## What's still in flight

- PR 4 — web-site Google Forms cutover (blocked on founder A8: form URL)
- PR 5 — umbrella submodule bumps (follows PR 2 + PR 3 merge)
- Founder-side A5/A7/A8 — pending

Per global rule, I won't merge.