### PR TITLE
docs: add root GOVERNANCE.md as the aidoc-flow governance source of truth

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,37 @@
+# Governance
+
+This repository is the **source of truth** for aidoc-flow project governance.
+The engine-agnostic standards live in
+[`framework/governance/`](framework/governance/README.md) and apply across every
+aidoc-flow repository. Consuming repositories reference this governance; they do
+not copy it.
+
+## Standards
+
+See [`framework/governance/README.md`](framework/governance/README.md) for the
+full index. Key documents:
+
+- `DOC_GOVERNANCE_CORE.md` — core principles (single source of truth, YAML-first
+  templates, immutability, validation baseline).
+- `ID_NAMING_STANDARDS.md` — document IDs, element IDs, traceability tags, file
+  naming.
+- `TRACEABILITY.md` — the traceability chain and readiness gates.
+- `REVIEW_TEAM.md` + `REVIEW_CREWS.yaml` — the multi-persona review model.
+- `REVIEW_REMEDIATION_FLOW.md` — the review to remediation to gate quality loop.
+- `SECURITY_REVIEW.md` — safety checks for agent-authored artifacts.
+- `AUTHORING_STYLE.md` — token-efficient authoring rules.
+- `DIAGRAM_STANDARDS.md` + `THRESHOLD_NAMING_RULES.md` — diagram and threshold
+  conventions.
+- `ADAPTATION.md` + `ADAPTATION_SURFACE.yaml` — how a consuming repo adapts the
+  flow without forking.
+- `DECISIONS.md` — durable register of governance and spec decisions.
+- `chg/` — the change-management overlay and GATE-SPEC (CHG-D1), the meta gate
+  governing changes to the `framework/` spec itself.
+
+## Changing governance
+
+Governance changes are proposed and ratified here through the CHG / GATE-SPEC
+process (`framework/governance/chg/`). The spec defines the gates; each
+consuming platform implements enforcement against this shared contract (record
+validator, CI, protected-branch review). This model is recorded as GD-01 in
+`framework/governance/DECISIONS.md`.


### PR DESCRIPTION
## Summary

Adds a root `GOVERNANCE.md` that designates this repo's `framework/governance/` as the **single source of truth** for aidoc-flow project governance, referenced (never copied) by every aidoc-flow repository.

This is the canonical entry point; companion PRs add a thin pointer `GOVERNANCE.md` to the sibling repos (iplan-runner, business, operations, iplanic, knowledge-rag) and the umbrella, each linking back here.

## Changes

- New `GOVERNANCE.md` (root) → indexes `framework/governance/` + the CHG / GATE-SPEC change process. Pure documentation; no spec/behavior change, no VERSION bump.

Validated against `markdownlint-cli@0.43.0` (`--fix` is a no-op).

> Committed with `SKIP=markdownlint` (Node hook can't install in this env); all other hooks + conformance passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)