### PR TITLE
docs(plugin): pre-publish marketplace doc-polish (plugin v0.20.1, no VERSION bump)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "aidoc-flow",
       "source": "./platforms/claude-code-plugin",
-      "description": "Pre-1.0 preview. AI-Driven Specification-Driven Development (SDD) workflow — 50 active skills + 2 deprecated stubs (52 total), 11 agents, and 1 command for the 8-layer doc flow (BRD → IPLAN). Consumes the engine-agnostic aidoc-flow framework spec. APIs and surfaces may change before 1.0.",
+      "description": "Pre-1.0 preview. AI-Driven Specification-Driven Development (SDD) workflow — 50 active skills + 2 deprecated stubs (52 total), 11 agents, and 12 commands for the 8-layer doc flow (BRD → IPLAN). Consumes the engine-agnostic aidoc-flow framework spec. APIs and surfaces may change before 1.0.",
       "version": "0.20.1"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,29 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — plugin marketplace pre-publish doc-polish (plugin v0.20.1; no VERSION bump)
+
+Three doc-only corrections discovered during a marketplace-readiness
+review of `claude-code-plugin/v0.20.1`. Code, framework spec, skills,
+agents, commands, and the vendored bundle all unchanged; conformance
+suite 129/129 before and after.
+
+- `.claude-plugin/marketplace.json` — description undercounted
+  commands ("1 command" → "12 commands"). The plugin has shipped 12
+  user-facing commands since plugin `v0.19.0` (PLUGIN-USER-COMMANDS).
+- `platforms/claude-code-plugin/README.md` "What's inside" — added a
+  dedicated row enumerating the 2 deprecated-stub skills (`doc-review`,
+  `trace-check`). The 50/52 totals already reconciled; only the named
+  utility list omitted them.
+- `platforms/claude-code-plugin/README.md` "Framework spec conformance"
+  — reworded to remove the incorrect claim that the bundle ships its
+  own `framework/VERSION`. The bundle deliberately vendors only the
+  subtrees the plugin consumes (`layers/`, `governance/`, `registry/`,
+  `playbooks/`) plus `SPEC_DRIVEN_DEVELOPMENT_GUIDE.md` per D-0022;
+  canonical `../../framework/VERSION` remains the single source of
+  truth, and `tests/conformance/platforms/test_version_declaration.py`
+  enforces the `FRAMEWORK_SPEC_VERSION` match.
+
 ### Changed — `docs/SUPPORT.md` go-live sync (operations IPLAN-0009 PR 3)
 
 - `docs/SUPPORT.md` updated to reflect that the Contact-us channel is

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -1,5 +1,19 @@
 # Session Handoff
 
+> **🟢 PLUGIN MARKETPLACE PRE-PUBLISH DOC-POLISH — 2026-06-15.** Three
+> doc-only fixes prior to publishing `claude-code-plugin/v0.20.1` to the
+> marketplace, discovered during a marketplace-readiness review.
+> (1) `.claude-plugin/marketplace.json` description: "1 command" →
+> "12 commands"; (2) plugin README "What's inside" enumerates the
+> 2 deprecated-stub skills (`doc-review`, `trace-check`) in a dedicated
+> row; (3) README "Framework spec conformance" section reworded to
+> remove the incorrect claim that the bundle ships its own
+> `framework/VERSION` (the bundle deliberately omits it per D-0022).
+> No plugin VERSION bump; 129/129 conformance unchanged. Branch
+> `docs/plugin-marketplace-polish`.
+
+---
+
 > **🟢 ACCEPTANCE-FIXTURES-DRIFT IMPL READY FOR PR — 2026-06-14.** Closes
 > 12 long-standing deterministic-suite failures that were red on the
 > umbrella `PR Checks` workflow since 2026-06-02. Three coordinated

--- a/platforms/claude-code-plugin/README.md
+++ b/platforms/claude-code-plugin/README.md
@@ -52,6 +52,7 @@ right skill. The deeper authoring guidance is in
 | Skills (layer families) | 32 | The 8 SDD layers — `doc-brd`, `doc-prd`, `doc-ears`, `doc-bdd`, `doc-adr`, `doc-spec`, `doc-tdd`, `doc-iplan` — each in 4 variants: base, `-autopilot`, `-audit`, `-fixer`. |
 | Skills (change-management) | 4 | The CHG governance overlay — `doc-chg` + `-autopilot` + `-audit` + `-fixer` (governs edits to existing artifacts; not a layer). |
 | Skills (utilities) | 14 | `doc-flow`, `doc-naming`, `doc-ref`, `doc-validator`, `review-team`, `project-init`, `project-adopt`, `project-profile`, `knowledge-extractor`, `gate-check`, `charts-flow`, `adr-roadmap`, `quality-advisor`, `security-audit`. |
+| Skills (deprecated stubs) | 2 | `doc-review`, `trace-check` — redirect stubs for `doc-validator`; scheduled for removal in v0.7.0. |
 | Agents | 11 | AI Team specialist roster — `requirements-analyst`, `pm-orchestrator`, `solutions-architect`, `test-architect`, `software-engineer`, `devops-release-engineer`, `code-reviewer`, `security-engineer`, `traceability-auditor`, plus the two review-team lenses `chaos-engineer` and `synthesizer`. See `docs/AGENTS.md`. |
 | Commands | 12 | 11 user-facing commands (meta · workflow · lifecycle · config) + `/aidoc-flow:save-plan`. See the "User-facing commands" subsection below. |
 | Hooks | 1 | `hooks/sdd-doc-review.sh` — a `PostToolUse` advisory nudge (see below). |
@@ -126,10 +127,14 @@ $ cat FRAMEWORK_SPEC_VERSION
 0.21.1
 ```
 
-The plugin declares conformance to framework spec `0.21.1`; the bundled spec's
-own version is at `framework/VERSION` (byte-identical to `../../framework/VERSION`).
-A conformance test enforces that `FRAMEWORK_SPEC_VERSION` matches the framework's
-published version.
+The plugin declares conformance to framework spec `0.21.1`; the canonical
+spec ships its version at `../../framework/VERSION`. The bundle vendors
+only the subtrees the plugin consumes (`layers/`, `governance/`,
+`registry/`, `playbooks/`) plus `SPEC_DRIVEN_DEVELOPMENT_GUIDE.md` — not
+`VERSION` itself; see "Self-contained framework bundle" above. A
+conformance test (`tests/conformance/platforms/test_version_declaration.py`)
+enforces that `FRAMEWORK_SPEC_VERSION` matches the canonical
+`framework/VERSION`.
 
 ## Platform info
 


### PR DESCRIPTION
## Summary

Three doc-only corrections to `claude-code-plugin/v0.20.1` discovered during a marketplace-readiness review. Code, framework spec, skills, agents, commands, and the vendored bundle are all unchanged — this is publish-ready polish only. **No plugin VERSION bump; conformance suite 129/129 before and after.**

### Fixes

- **`.claude-plugin/marketplace.json`** — description undercounted commands (`"1 command"` → `"12 commands"`). The plugin has shipped 12 user-facing commands since `v0.19.0` (PLUGIN-USER-COMMANDS).
- **`platforms/claude-code-plugin/README.md` "What's inside"** — added a dedicated row enumerating the 2 deprecated-stub skills (`doc-review`, `trace-check`). The 50/52 totals already reconciled; only the named utility list omitted them.
- **`platforms/claude-code-plugin/README.md` "Framework spec conformance"** — reworded to remove the incorrect claim that the bundle ships its own `framework/VERSION`. The bundle deliberately vendors only the subtrees the plugin consumes (`layers/`, `governance/`, `registry/`, `playbooks/`) plus `SPEC_DRIVEN_DEVELOPMENT_GUIDE.md` per **D-0022**; canonical `../../framework/VERSION` remains the single source of truth, and `tests/conformance/platforms/test_version_declaration.py` enforces the `FRAMEWORK_SPEC_VERSION` match.

### Docs of record

- `CHANGELOG.md` — entry under `[Unreleased]` (Fixed).
- `plans/HANDOFF.md` — top-line live callout.

Per the per-PR doc-of-record rule (`framework/governance/DOC_GOVERNANCE_CORE.md` Principle 8).

## Test plan

- [x] `python -m unittest discover -s tests/conformance` — 129/129 pass
- [x] `pre-commit run` on the commit — all hooks pass (markdownlint, conformance, docs-of-record reminder)
- [x] `cat .claude-plugin/marketplace.json` — JSON valid; description matches actual plugin component counts (50+2 skills / 11 agents / 12 commands)
- [x] `ls platforms/claude-code-plugin/commands/ \| wc -l` → 12 — matches README claim
- [x] `diff -rq framework/ platforms/claude-code-plugin/framework/` — confirms bundle only ships the 4 subtrees + `SPEC_DRIVEN_DEVELOPMENT_GUIDE.md`, no `VERSION` (matches reworded prose)
- [ ] CI green on this PR (Conformance, GATE-SPEC, CodeQL)

## Out of scope (parked for follow-up if needed)

- `framework/CLAUDE.md:13` still says plugin is `0.17.0` — project-memory rot; not on the marketplace-consumer path. Single-line fix when convenient.
- After merge: tag `claude-code-plugin/v0.20.1` per `docs/TAGGING.md`.