### PR TITLE
docs: default to GitHub CLI (gh) for GitHub operations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,3 +260,10 @@ The pristine pre-migration project is preserved on the protected, read-only
 branch **`legacy-ucx-v3.2-read-only`**. Change management (the gated CHG
 process) returns post-cutover to govern `framework/` spec changes — see
 `docs/PROJECT.md` §6.
+
+## GitHub operations
+
+Use the **GitHub CLI (`gh`)** as the default for all GitHub operations — PRs,
+issues, reviews, releases, repo queries — not the GitHub MCP servers
+(`github-tt`, `github-vl`) or raw API calls. If `gh` is unauthenticated, run
+`gh auth login` rather than falling back to MCP/API.


### PR DESCRIPTION
Adds a **GitHub operations** section to CLAUDE.md: default to the GitHub CLI (`gh`) for all GitHub operations (PRs, issues, reviews, releases, repo queries) rather than the GitHub MCP servers or raw API. If `gh` is unauthenticated, run `gh auth login` instead of falling back to MCP/API.

Per founder direction 2026-06-15.