### PR TITLE
docs(ci): note this public repo stays on GitHub-hosted runners

### DIFF
--- a/.github/workflows/chg-gate.yml
+++ b/.github/workflows/chg-gate.yml
@@ -1,3 +1,6 @@
+# CI runs on GitHub-hosted runners — this is a PUBLIC repo. Do NOT switch to self-hosted:
+# no cost benefit (public-repo Actions minutes are free) + a fork PR could run code on the
+# host. The ephemeral self-hosted runner is for PRIVATE repos only. Ref: aidoc-flow-operations IPLAN-0012.
 # GATE-SPEC enforcement (CHG-D1) — the CI half of the framework-spec change gate.
 #
 # Runs on pull_request so the whole PR diff (base...HEAD) is the unit of

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,3 +1,6 @@
+# CI runs on GitHub-hosted runners — this is a PUBLIC repo. Do NOT switch to self-hosted:
+# no cost benefit (public-repo Actions minutes are free) + a fork PR could run code on the
+# host. The ephemeral self-hosted runner is for PRIVATE repos only. Ref: aidoc-flow-operations IPLAN-0012.
 name: CodeQL
 
 on:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,3 +1,6 @@
+# CI runs on GitHub-hosted runners — this is a PUBLIC repo. Do NOT switch to self-hosted:
+# no cost benefit (public-repo Actions minutes are free) + a fork PR could run code on the
+# host. The ephemeral self-hosted runner is for PRIVATE repos only. Ref: aidoc-flow-operations IPLAN-0012.
 name: Conformance
 
 on:

--- a/.github/workflows/doc-review.yml
+++ b/.github/workflows/doc-review.yml
@@ -1,3 +1,6 @@
+# CI runs on GitHub-hosted runners — this is a PUBLIC repo. Do NOT switch to self-hosted:
+# no cost benefit (public-repo Actions minutes are free) + a fork PR could run code on the
+# host. The ephemeral self-hosted runner is for PRIVATE repos only. Ref: aidoc-flow-operations IPLAN-0012.
 name: Document review gate
 
 # pre_merge trigger point (framework/governance/REVIEW_REMEDIATION_FLOW.md):

--- a/.github/workflows/hermes.yml
+++ b/.github/workflows/hermes.yml
@@ -1,3 +1,6 @@
+# CI runs on GitHub-hosted runners — this is a PUBLIC repo. Do NOT switch to self-hosted:
+# no cost benefit (public-repo Actions minutes are free) + a fork PR could run code on the
+# host. The ephemeral self-hosted runner is for PRIVATE repos only. Ref: aidoc-flow-operations IPLAN-0012.
 name: Hermes platform
 
 on:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,3 +1,6 @@
+# CI runs on GitHub-hosted runners — this is a PUBLIC repo. Do NOT switch to self-hosted:
+# no cost benefit (public-repo Actions minutes are free) + a fork PR could run code on the
+# host. The ephemeral self-hosted runner is for PRIVATE repos only. Ref: aidoc-flow-operations IPLAN-0012.
 name: Labeler
 
 on:

--- a/.github/workflows/plugin.yml
+++ b/.github/workflows/plugin.yml
@@ -1,3 +1,6 @@
+# CI runs on GitHub-hosted runners — this is a PUBLIC repo. Do NOT switch to self-hosted:
+# no cost benefit (public-repo Actions minutes are free) + a fork PR could run code on the
+# host. The ephemeral self-hosted runner is for PRIVATE repos only. Ref: aidoc-flow-operations IPLAN-0012.
 name: Claude Code plugin
 
 on:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,3 +1,6 @@
+# CI runs on GitHub-hosted runners — this is a PUBLIC repo. Do NOT switch to self-hosted:
+# no cost benefit (public-repo Actions minutes are free) + a fork PR could run code on the
+# host. The ephemeral self-hosted runner is for PRIVATE repos only. Ref: aidoc-flow-operations IPLAN-0012.
 name: pre-commit
 
 on:


### PR DESCRIPTION
Self-documenting comment atop each workflow: this PUBLIC repo keeps CI on GitHub-hosted runners and must **not** be switched to the ephemeral self-hosted runner — (1) no cost benefit (public Actions minutes are free), (2) a fork PR could run code on the host. Self-hosted runner = PRIVATE repos only (ref: aidoc-flow-operations IPLAN-0012).

Comment-only; no behavior change. **Founder to review/merge** (cross-repo change prepared by the AI team, not auto-merged; framework is spec/governance tier → human-always).

🤖 Generated with [Claude Code](https://claude.com/claude-code)