### PR TITLE
docs(plans): close out MODEL-PRECHECK-ROLLOUT + refresh HANDOFF

### DIFF
--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -24,20 +24,6 @@
 
 ## Open
 
-### `[skill]` `MODEL-PRECHECK-ROLLOUT` — IMPLEMENTED on branch (pending merge)
-
-- *Context:* Closes the documented-but-unimplemented `model.precheck` behavior
-  (`commands/model.md`): the 8 layer autopilots now PRINT the per-layer model
-  recommendation at the entry point (no compare — a skill can't read its own
-  session model). Design converged Pass 1-7; scope locked **autopilots-only**
-  (D-0035); base/audit/fixer deferred (headless under the driver).
-- *Status:* **IMPLEMENTED on branch `feat/model-precheck-rollout`.** `## Model
-  precheck` added to all 8 autopilots + Step-1 directive reworded to "first
-  orchestration action"; new `test_model_precheck.py` (8×2 subtests); plugin
-  `0.21.0 → 0.22.0`. Local CI green (conformance 135, plm_lint, markdownlint).
-  Move to **Closed** with the merge SHA once the PR lands. See
-  `plans/MODEL-PRECHECK-ROLLOUT-PLAN.md`.
-
 ### `[harness]` `TRACE-RES-001-PER-LAYER-TEST-MODE` — per-layer acceptance tests duplicate the upstream chain
 
 - *Context:* ACCEPTANCE-FIXTURES-DRIFT (2026-06-14) closed 12
@@ -138,6 +124,25 @@
   decision gate.
 
 ## Closed
+
+### `[skill]` `MODEL-PRECHECK-ROLLOUT` — autopilots print the per-layer model recommendation (2026-06-23)
+
+- *Context:* `commands/model.md` documented a `model.precheck` mode the
+  `doc-*` skills "consult," but no skill did — a documented-but-unimplemented
+  behavior introduced by PLUGIN-USER-COMMANDS.
+- *Resolution:* MODEL-PRECHECK-ROLLOUT (PR #164, merge `6700301f`). The 8 layer
+  autopilots gained a `## Model precheck` section (before `## Workflow`) that
+  reads `model.per_layer`/`model.default`/`model.precheck` from
+  `.claude/aidoc-flow.config.yaml` and **prints** the recommendation + the
+  `/model <rec>` command (no compare — a skill can't read its own session
+  model). `warn`/`silent`/`block` modes; Step-1 saga directive reworded to
+  "first orchestration action" so the notice runs before the driver. New
+  `tests/conformance/platforms/test_model_precheck.py`; `commands/model.md` +
+  `docs/CONFIG.md` mode descriptions corrected to print-not-compare. Plugin
+  `0.21.0 → 0.22.0`; no framework-spec change. Scope locked autopilots-only
+  (D-0035); base/audit/fixer deferred (headless under the driver). Converged
+  Pass 1-7 + independent diff review (caught the stale `commands/model.md`
+  wording). See `plans/MODEL-PRECHECK-ROLLOUT-PLAN.md`.
 
 ### `[skill]` `SAGA-PARITY-001-PHASE-4` — 6 layer autopilots now saga-driven (2026-06-22)
 

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -25,19 +25,20 @@
 >
 > **NEXT (priority order):**
 >
-> 1. ~~**MODEL-PRECHECK-ROLLOUT**~~ — **IMPLEMENTED** on branch
->    `feat/model-precheck-rollout` (plugin `0.22.0`). Scope locked
->    autopilots-only (D-0035); all 8 autopilots print the per-layer model
->    recommendation; new `test_model_precheck.py`. Pending PR/merge.
+> 1. ✅ **MODEL-PRECHECK-ROLLOUT** — **SHIPPED** (PR #164, merge `6700301f`,
+>    plugin `0.22.0`). All 8 autopilots print the per-layer model recommendation
+>    (D-0035, autopilots-only). Closed in `FRAMEWORK-TODO.md`.
 > 2. **P2 plugin deploy-verification** — `plans/PLUGIN-P2-DEPLOY-RUNBOOK.md`;
 >    needs the user's local Claude Code CLI (live skill run proving
 >    `${CLAUDE_PLUGIN_ROOT}` resolves in SKILL prose). Flips the plugin from
 >    "release-ready" to "deploy-verified".
 > 3. **Hermes parity** — ROADMAP "Now" item; Hermes lags the plugin.
 >
-> **Plugin state:** `0.21.0`, release-ready (conformance green, `plm_lint`
-> clean, BYO-marketplace installable, tag `claude-code-plugin/v0.20.1` pushed —
-> bump the tag to `v0.21.0` next release). Not yet deploy-verified (item 2).
+> **Plugin state:** `0.22.0`, release-ready (conformance green, `plm_lint`
+> clean, BYO-marketplace installable). **Release tag lags:**
+> `claude-code-plugin/v0.20.1` is the latest pushed tag — push `v0.21.0` and
+> `v0.22.0` from a local clone (tag pushes are a local-clone action). Not yet
+> deploy-verified (item 2).
 >
 > **Phase 4 plan (historical detail): `plans/SAGA-PARITY-001-PHASE-4-PLAN.md` — CONVERGED (Pass 1-3), IMPLEMENTED.**
 > Scope: rewrite the 6 legacy `## Workflow` sections to the proven


### PR DESCRIPTION
Doc-only housekeeping after MODEL-PRECHECK-ROLLOUT shipped (PR #164, merge `6700301f`).

- **FRAMEWORK-TODO.md** — move the entry Open → **Closed** with the merge SHA.
- **HANDOFF.md** — mark it shipped; plugin state `0.21.0 → 0.22.0`; flag that the release tag lags (`v0.20.1` is latest pushed — push `v0.21.0` + `v0.22.0` from a local clone).

Plan-only; no code/spec change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)