### PR TITLE
feat(ci): adopt aidoc-flow-ci@ci/v1.0.2 (Phase A — first PUBLIC consumer test)

### DIFF
--- a/.github/ai-review/config.json
+++ b/.github/ai-review/config.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://aidoc-flow.io/schemas/ai-review-config-v1.json",
+  "version": 1,
+  "trust": {
+    "ai_review": ["vladm3105"],
+    "auto_fix":  []
+  },
+  "governance": {
+    "locked_paths": [".github/", "governance/", "templates/ai-review/"],
+    "code_owners": ["@vladm3105"],
+    "require_human_review": false
+  },
+  "composition": {
+    "required": true,
+    "carry_forward_on_skip_label": true
+  },
+  "auto_merge": {
+    "enabled": true,
+    "spec_paths_blocked": ["framework/", "spec/"]
+  },
+  "autofix": {
+    "enabled": false
+  }
+}

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -29,5 +29,5 @@ jobs:
     with:
       reviewer: codex
       runner_labels_routine: '"ubuntu-latest"'
-      runner_labels_review:  '"ubuntu-latest"'
-    secrets: inherit
+      runner_labels_review: '"ubuntu-latest"'
+    secrets: inherit  # pragma: allowlist secret

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -8,8 +8,8 @@
 #
 # Secrets required (consumer adds to repo secrets):
 #   APP_REVIEWER_1_ID + APP_REVIEWER_1_KEY  reviewer App credentials
+#   ANTHROPIC_API_KEY                        if reviewer: claude (active)
 #   OPENAI_API_KEY                           if reviewer: codex
-#   ANTHROPIC_API_KEY                        if reviewer: claude
 #
 # `pull_request_target` (not `pull_request`) is required because the
 # trust gate needs write-capable credentials to apply labels/comments
@@ -27,7 +27,7 @@ jobs:
   call:
     uses: vladm3105/aidoc-flow-ci/.github/workflows/ai-review.yml@ci/v1.0.2
     with:
-      reviewer: codex
+      reviewer: claude
       runner_labels_routine: '"ubuntu-latest"'
       runner_labels_review: '"ubuntu-latest"'
     secrets: inherit  # pragma: allowlist secret

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,0 +1,33 @@
+# v1.0.2: public consumers can use ubuntu-latest. The reusable
+# ai-review.yml installs codex + claude CLI at workflow start when
+# runner_labels_review contains "ubuntu-latest" (no-op on self-hosted
+# runners that have the CLI pre-baked). See ci/v1.0.2 CHANGELOG and
+# docs/troubleshooting.md §10 for context. Install commands are
+# **unverified-in-CI** as of v1.0.2 ship; first PUBLIC consumer
+# adoption will validate. Report issues at vladm3105/aidoc-flow-ci.
+#
+# Secrets required (consumer adds to repo secrets):
+#   APP_REVIEWER_1_ID + APP_REVIEWER_1_KEY  reviewer App credentials
+#   OPENAI_API_KEY                           if reviewer: codex
+#   ANTHROPIC_API_KEY                        if reviewer: claude
+#
+# `pull_request_target` (not `pull_request`) is required because the
+# trust gate needs write-capable credentials to apply labels/comments
+# on fork PRs and the heavy review job needs secrets — both unavailable
+# under `pull_request` on fork PRs. The trust gate decides whether to
+# proceed; the heavy job runs only for trusted authors per the
+# allowlist in `.github/ai-review/config.json`.
+name: ai-review
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  pull_request_review:
+    types: [submitted]
+jobs:
+  call:
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/ai-review.yml@ci/v1.0.2
+    with:
+      reviewer: codex
+      runner_labels_routine: '"ubuntu-latest"'
+      runner_labels_review:  '"ubuntu-latest"'
+    secrets: inherit

--- a/.github/workflows/composition.yml
+++ b/.github/workflows/composition.yml
@@ -11,4 +11,4 @@ jobs:
     uses: vladm3105/aidoc-flow-ci/.github/workflows/composition.yml@ci/v1.0.2
     with:
       runner_labels: '"ubuntu-latest"'
-    secrets: inherit
+    secrets: inherit  # pragma: allowlist secret

--- a/.github/workflows/composition.yml
+++ b/.github/workflows/composition.yml
@@ -1,0 +1,14 @@
+# v1.0.0 trigger shape per aidoc-flow-operations PR #111. See
+# composition-private.yml for the trigger-shape rationale.
+name: composition
+on:
+  pull_request_target:
+    types: [synchronize, labeled, unlabeled]
+  pull_request_review:
+    types: [submitted, dismissed, edited]
+jobs:
+  call:
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/composition.yml@ci/v1.0.2
+    with:
+      runner_labels: '"ubuntu-latest"'
+    secrets: inherit


### PR DESCRIPTION
Phase A of IPLAN-0017 unified-CI rollout on framework. **First PUBLIC consumer adoption of `ci/v1.0.2`** — tests the new ubuntu-latest reviewer-CLI install step end-to-end.

Source runbook: [`aidoc-flow-operations/ops/inbox/2026-06-24_cto-platform_framework-phase-a-migration.md`](https://github.com/vladm3105/aidoc-flow-operations/blob/main/ops/inbox/2026-06-24_cto-platform_framework-phase-a-migration.md).

## What this PR drops

- `.github/workflows/ai-review.yml` — thin caller; uses `vladm3105/aidoc-flow-ci/.github/workflows/ai-review.yml@ci/v1.0.2`
- `.github/workflows/composition.yml` — thin caller; uses `...@ci/v1.0.2`
- `.github/ai-review/config.json` — trust allowlist (vladm3105 only initially)

Plus 9 canonical labels were bootstrapped on the repo via `gh label create` (8 on the initial `v1.0.2` install.sh run + 1 (`area: governance`) after `ci/v1.0.3` patched its description from 109c to 98c to fit GitHub's 100c labels-API cap).

## Coexists with existing 8 workflows

Framework's existing `chg-gate` / `codeql` / `conformance` / `doc-review` / `hermes` / `labeler` / `plugin` / `pre-commit` workflows are untouched. `install.sh` preserves any existing files per the local-overrides-shared rule.

## What's needed BEFORE the heavy ai-review job will succeed

🔴 **Founder prerequisites:**

1. Install the reviewer GitHub App on `vladm3105/aidoc-flow-framework` (per F5 blast-radius rule)
2. Set the following secrets on this repo:
   - `APP_REVIEWER_1_ID` (App's numeric App ID)
   - `APP_REVIEWER_1_KEY` (App's private key PEM)
   - `OPENAI_API_KEY` (default reviewer auth)

Until those land, the heavy `ai-review` job will skip / fail loudly (intentional — fail-fast on missing creds).

## After this PR's first workflow run

If the **install codex + claude CLI** step (the v1.0.2 load-bearing feature) fails on ubuntu-latest, **STOP** + report → operations ships `ci/v1.0.4` patch with verified install commands → framework re-tries against the stable version.

## Compliance

- Standard commit-message rules followed (no reviewer-tool identifiers in commit msg)
- Branch protection on `main` left untouched in this PR (founder Step 7)

Applied under explicit founder chat authorization 2026-06-24.