### PR TITLE
fix(ci): add caller-level permissions blocks (ai-review + composition startup_failure)

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -23,6 +23,15 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
   pull_request_review:
     types: [submitted]
+# Caller-level permissions required because framework's repo-default workflow
+# permissions is `read` — the reusable workflow declares write-level
+# permissions but a callee cannot elevate above the caller. Mirror what
+# operations' standalone ai-review.yml declares (operations works today
+# because its standalone workflow declares these directly).
+permissions:
+  contents: write        # auto-merge
+  pull-requests: write   # review comment, labels, merge
+  issues: write          # labels
 jobs:
   call:
     uses: vladm3105/aidoc-flow-ci/.github/workflows/ai-review.yml@ci/v1.0.2

--- a/.github/workflows/composition.yml
+++ b/.github/workflows/composition.yml
@@ -6,6 +6,11 @@ on:
     types: [synchronize, labeled, unlabeled]
   pull_request_review:
     types: [submitted, dismissed, edited]
+# Caller-level permissions — see ai-review.yml header for rationale.
+# composition only needs read scopes.
+permissions:
+  pull-requests: read
+  contents: read
 jobs:
   call:
     uses: vladm3105/aidoc-flow-ci/.github/workflows/composition.yml@ci/v1.0.2


### PR DESCRIPTION
**Root cause of PR #169's ai-review + composition startup_failure.**

Framework's repo-default workflow_permissions is `read`. The reusable workflows on aidoc-flow-ci declare write-level permissions in their bodies, but a callee CANNOT elevate above its caller's permissions.

## Fix

Add explicit `permissions:` blocks to both caller workflows, mirroring operations' standalone equivalents:
- `ai-review.yml`: contents:write, pull-requests:write, issues:write
- `composition.yml`: contents:read, pull-requests:read

## After merge

PR #169 retriggered → ai-review + composition should fire successfully → first real test of v1.0.2 CLI install + claude OAuth auth.

ai-review will fail with startup_failure on THIS PR (broken workflow on main); merge anyway since composition isn't yet a required check (Step 7 = founder action).

Applied under explicit founder chat authorization 2026-06-24.