### PR TITLE
chore(ci): bump aidoc-flow-ci pin to @ci/v1.0.5

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -34,7 +34,7 @@ permissions:
   issues: write          # labels
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/ai-review.yml@ci/v1.0.2
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/ai-review.yml@ci/v1.0.5
     with:
       reviewer: claude
       runner_labels_routine: '"ubuntu-latest"'

--- a/.github/workflows/composition.yml
+++ b/.github/workflows/composition.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/composition.yml@ci/v1.0.2
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/composition.yml@ci/v1.0.5
     with:
       runner_labels: '"ubuntu-latest"'
     secrets: inherit  # pragma: allowlist secret


### PR DESCRIPTION
Bumps both ai-review.yml + composition.yml pins from @ci/v1.0.2 to @ci/v1.0.5.

v1.0.5 fixes the auth-env-export bug surfaced by PR #169. After merge, PR #169's ai-review retriggers + should succeed.

Applied under explicit founder chat authorization 2026-06-24.