### PR TITLE
fix(ai-review): bump caller pin @ci/v1.0.5 → @ci/v1.1.0 — IPLAN-0022 PR-C

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,10 +1,15 @@
-# v1.0.2: public consumers can use ubuntu-latest. The reusable
-# ai-review.yml installs codex + claude CLI at workflow start when
-# runner_labels_review contains "ubuntu-latest" (no-op on self-hosted
-# runners that have the CLI pre-baked). See ci/v1.0.2 CHANGELOG and
-# docs/troubleshooting.md §10 for context. Install commands are
-# **unverified-in-CI** as of v1.0.2 ship; first PUBLIC consumer
-# adoption will validate. Report issues at vladm3105/aidoc-flow-ci.
+# Pinned at @ci/v1.1.0 — IPLAN-0022 PR-C: reviewer rubric + schema
+# now fetched from aidoc-flow-ci/ai-review/ at this pin (no longer
+# from operations@main; see IPLAN-0022 §3.7 P2). Per-consumer
+# config.json preservation via transitional sparse-checkout in the
+# reusable workflow (per-consumer-config improvement tracked as a
+# follow-up IPLAN).
+#
+# Prior @ci/v1.0.5 — first PUBLIC consumer of aidoc-flow-ci
+# (framework Phase A 2026-06-24). The reusable ai-review.yml installs
+# codex + claude CLI at workflow start when runner_labels_review
+# contains "ubuntu-latest" (no-op on self-hosted runners that have
+# the CLI pre-baked).
 #
 # Secrets required (consumer adds to repo secrets):
 #   APP_REVIEWER_1_ID + APP_REVIEWER_1_KEY  reviewer App credentials
@@ -34,7 +39,7 @@ permissions:
   issues: write          # labels
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/ai-review.yml@ci/v1.0.5
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/ai-review.yml@ci/v1.1.0
     with:
       reviewer: claude
       runner_labels_routine: '"ubuntu-latest"'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed — IPLAN-0022 PR-C: ai-review caller bumped @ci/v1.0.5 → @ci/v1.1.0 (2026-06-25)
+
+- **`.github/workflows/ai-review.yml`** caller pin bumped per
+  IPLAN-0022 §3.7 P2 (second consumer after operations PR-B; both
+  consume the new asset source on aidoc-flow-ci).
+- **What this changes for framework:** the reusable workflow now
+  fetches `review-prompt.md` + `verdict.schema.json` from
+  `aidoc-flow-ci/ai-review/@ci/v1.1.0` (via sparse-checkout) instead
+  of `aidoc-flow-operations@main`. `config.json` still comes from
+  operations@main via a transitional sparse-checkout step.
+- **Validation:** next framework PR after this merges will fire
+  the new asset-fetch path end-to-end on a PUBLIC consumer
+  (ubuntu-latest runner). Pairs with operations PR #138 (PRIVATE
+  consumer; self-hosted) for cross-visibility coverage.
+- **What stays on operations** (until IPLAN-0022 PR-D): the legacy
+  `.github/ai-review/review-prompt.md` + `verdict.schema.json` files
+  remain for back-compat with consumers pinned at older `@ci/v1.0.X`
+  tags.
+- Source-of-truth migration plan: [`aidoc-flow-operations` IPLAN-0022](https://github.com/vladm3105/aidoc-flow-operations/blob/main/ops/iplans/IPLAN-0022_source-of-truth-migration.md).
+
 ### Added — Adopted `aidoc-flow-ci@ci/v1.0.2` shared CI library (2026-06-24)
 
 Framework is the **first PUBLIC consumer of `aidoc-flow-ci`** per


### PR DESCRIPTION
Per IPLAN-0022 §3.7 P2 (operations [IPLAN-0022 plan PR #130](https://github.com/vladm3105/aidoc-flow-operations/pull/130) APPROVED + merged; [aidoc-flow-ci PR #27](https://github.com/vladm3105/aidoc-flow-ci/pull/27) implementation merged + tagged `ci/v1.1.0`).

Framework is the **second consumer** to consume the new asset source. Pairs with operations [PR #138](https://github.com/vladm3105/aidoc-flow-operations/pull/138) (PRIVATE consumer; self-hosted) for cross-visibility coverage.

## Single change

`.github/workflows/ai-review.yml` line 37: pin bump `@ci/v1.0.5` → `@ci/v1.1.0`.

## What this changes

- Reusable `ai-review.yml` fetches `review-prompt.md` + `verdict.schema.json` from `aidoc-flow-ci/ai-review/@ci/v1.1.0` (sparse-checkout) instead of operations@main
- `config.json` still comes from operations@main via transitional sparse-checkout step (per-consumer-config improvement = follow-up IPLAN)

## Validation

This PR itself is the validation. After merge, the next framework PR fires the new asset-fetch path end-to-end on a PUBLIC consumer (ubuntu-latest runner).

## Compliance

- Rule 1: 2 surfaces (caller workflow + CHANGELOG)
- Pin verified live: `ci/v1.1.0` tagged + pushed earlier this session on aidoc-flow-ci main