### PR TITLE
fix(changelog): IPLAN-0022 §3.7 → §4 cross-ref correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed — IPLAN-0022 PR-C: ai-review caller bumped @ci/v1.0.5 → @ci/v1.1.0 (2026-06-25)
 
 - **`.github/workflows/ai-review.yml`** caller pin bumped per
-  IPLAN-0022 §3.7 P2 (second consumer after operations PR-B; both
+  IPLAN-0022 §4 P2 (second consumer after operations PR-B; both
   consume the new asset source on aidoc-flow-ci).
 - **What this changes for framework:** the reusable workflow now
   fetches `review-prompt.md` + `verdict.schema.json` from


### PR DESCRIPTION
PR #172 CHANGELOG cited `IPLAN-0022 §3.7 P2` but the rollout phases moved to §4 when IPLAN-0022 Pass 2 collapsed 7→3 phases. Broken internal cross-ref.

Same bug fix shipped on aidoc-flow-ci [PR #28](https://github.com/vladm3105/aidoc-flow-ci/pull/28).

Originally caught by operations [PR #138](https://github.com/vladm3105/aidoc-flow-operations/pull/138)'s second ai-review re-fire.

## Compliance

- Rule 1: 1 surface (CHANGELOG)