### PR TITLE
fix(ci): close 2 repo-wide CI gaps — bump pin @ci/v1.1.0→v1.1.1 + composition opened trigger

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,4 +1,10 @@
-# Pinned at @ci/v1.1.0 — IPLAN-0022 PR-C: reviewer rubric + schema
+# Pinned at @ci/v1.1.1 — IPLAN-0022 PR-A sparse-checkout pattern hot-fix
+# (aidoc-flow-ci PR #29; CLASS-aware terminology cleanup PR #30 also
+# in-flight on aidoc-flow-ci). Prior @ci/v1.1.0 had a sparse-checkout
+# pattern bug that broke ai-review on GitHub-hosted runners (worked on
+# self-hosted only due to cached state). @ci/v1.1.1 fixes that.
+#
+# Pinned at @ci/v1.1.0 was — IPLAN-0022 PR-C: reviewer rubric + schema
 # now fetched from aidoc-flow-ci/ai-review/ at this pin (no longer
 # from operations@main; see IPLAN-0022 §3.7 P2). Per-consumer
 # config.json preservation via transitional sparse-checkout in the
@@ -39,7 +45,7 @@ permissions:
   issues: write          # labels
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/ai-review.yml@ci/v1.1.0
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/ai-review.yml@ci/v1.1.1
     with:
       reviewer: claude
       runner_labels_routine: '"ubuntu-latest"'

--- a/.github/workflows/composition.yml
+++ b/.github/workflows/composition.yml
@@ -2,8 +2,13 @@
 # composition-private.yml for the trigger-shape rationale.
 name: composition
 on:
+  # `opened` + `reopened` added 2026-06-26: without them, freshly-opened PRs
+  # left composition pending (only ai-review fired) → merge blocked until
+  # label-cycle / push woke composition. Asymmetric trigger sets between
+  # ai-review (includes opened) + composition (didn't) was the repo-wide gap
+  # — root-cause fix per docs/troubleshooting §15 label-cycle pattern.
   pull_request_target:
-    types: [synchronize, labeled, unlabeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   pull_request_review:
     types: [submitted, dismissed, edited]
 # Caller-level permissions — see ai-review.yml header for rationale.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,33 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — close 2 repo-wide CI gaps + CHANGELOG terminology (2026-06-26)
+
+- **`.github/workflows/ai-review.yml`** caller pin bumped
+  `@ci/v1.1.0` → `@ci/v1.1.1`. The prior pin had a sparse-checkout
+  pattern bug (aidoc-flow-ci PR #29 / `ci/v1.1.1`) that broke
+  ai-review on GitHub-hosted runners (worked on self-hosted only
+  due to cached state from prior `actions/checkout` invocations
+  masking the issue). Framework PR #173 ai-review failed with
+  `Append system prompt file not found` — exposed the bug.
+- **`CHANGELOG.md` line 27** terminology fix: "(ubuntu-latest
+  runner)" → "(GitHub-hosted runner)" per
+  [GitHub Actions docs](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners)
+  - the canonical reference at `aidoc-flow-ci/docs/runners.md §0`
+  (shipped in aidoc-flow-ci PR #30). Runners have two CLASSES
+  (GitHub-hosted vs self-hosted); `ubuntu-latest` is a LABEL
+  identifying a specific runner image within the GitHub-hosted
+  class. Class-first framing prevents conflation bugs.
+- **`.github/workflows/composition.yml`** triggers extended:
+  `[synchronize, labeled, unlabeled]` →
+  `[opened, synchronize, reopened, labeled, unlabeled]`.
+  **Gap 2 closed:** without `opened`, freshly-opened PRs left
+  composition pending (only ai-review fired on `opened`) → merge
+  blocked until label-cycle / push woke composition. Root-cause fix
+  per `aidoc-flow-ci/docs/troubleshooting §15` label-cycle pattern
+  (label-cycle was the workaround; this is the fix). Mirrors
+  operations PR #140 same-pattern fix.
+
 ### Changed — IPLAN-0022 PR-C: ai-review caller bumped @ci/v1.0.5 → @ci/v1.1.0 (2026-06-25)
 
 - **`.github/workflows/ai-review.yml`** caller pin bumped per
@@ -24,7 +51,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   operations@main via a transitional sparse-checkout step.
 - **Validation:** next framework PR after this merges will fire
   the new asset-fetch path end-to-end on a PUBLIC consumer
-  (ubuntu-latest runner). Pairs with operations PR #138 (PRIVATE
+  (GitHub-hosted runner). Pairs with operations PR #138 (PRIVATE
   consumer; self-hosted) for cross-visibility coverage.
 - **What stays on operations** (until IPLAN-0022 PR-D): the legacy
   `.github/ai-review/review-prompt.md` + `verdict.schema.json` files


### PR DESCRIPTION
Bundles fixes for the 2 repo-wide CI gaps surfaced by founder audit 2026-06-26.

## Gap 1: `reviewer-assets/ai-review/review-prompt.md` missing → ai-review fail-closes

**Cause:** @ci/v1.1.0 had a sparse-checkout pattern bug. **Fix:** bump caller pin → @ci/v1.1.1 (aidoc-flow-ci [PR #29](https://github.com/vladm3105/aidoc-flow-ci/pull/29) hot-fix).

Framework PR [#173](https://github.com/vladm3105/aidoc-flow-framework/pull/173) ai-review failure on GitHub-hosted runner exposed this bug.

## Gap 2: composition.yml missing `opened` trigger

**Cause:** ai-review triggers include `opened`; composition didn't → fresh PRs left composition pending → merge blocked until label-cycle / push.

**Fix:** extend composition triggers to `[opened, synchronize, reopened, labeled, unlabeled]` matching ai-review's set.

## Plus: terminology fix

CHANGELOG line 27: 'ubuntu-latest runner' → 'GitHub-hosted runner' per aidoc-flow-ci/docs/runners.md §0 (shipped in aidoc-flow-ci [PR #30](https://github.com/vladm3105/aidoc-flow-ci/pull/30)).

## Changes (3 surfaces; Rule 1 compliant)

1. `.github/workflows/ai-review.yml` — pin bump
2. `.github/workflows/composition.yml` — extended triggers
3. `CHANGELOG.md` — documents both gaps + terminology

## Coordination

Operations gets same fixes via [PR #140](https://github.com/vladm3105/aidoc-flow-operations/pull/140) (same shape; different repo).