### PR TITLE
fix(ai-review): bump caller pin @ci/v1.1.1 → @ci/v1.1.2 (full-clone fix)

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,8 +1,8 @@
-# Pinned at @ci/v1.1.1 — IPLAN-0022 PR-A sparse-checkout pattern hot-fix
+# Pinned at @ci/v1.1.2 — IPLAN-0022 PR-A sparse-checkout pattern hot-fix
 # (aidoc-flow-ci PR #29; CLASS-aware terminology cleanup PR #30 also
 # in-flight on aidoc-flow-ci). Prior @ci/v1.1.0 had a sparse-checkout
 # pattern bug that broke ai-review on GitHub-hosted runners (worked on
-# self-hosted only due to cached state). @ci/v1.1.1 fixes that.
+# self-hosted only due to cached state). @ci/v1.1.2 fixes that.
 #
 # Pinned at @ci/v1.1.0 was — IPLAN-0022 PR-C: reviewer rubric + schema
 # now fetched from aidoc-flow-ci/ai-review/ at this pin (no longer
@@ -45,7 +45,7 @@ permissions:
   issues: write          # labels
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/ai-review.yml@ci/v1.1.1
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/ai-review.yml@ci/v1.1.2
     with:
       reviewer: claude
       runner_labels_routine: '"ubuntu-latest"'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — bump caller pin @ci/v1.1.1 → @ci/v1.1.2 (full-clone sparse-checkout fix; 2026-06-26)
+
+- **`.github/workflows/ai-review.yml`** caller pin bumped per
+  aidoc-flow-ci PR #31 / `ci/v1.1.2`. v1.1.1's cone-mode sparse-checkout
+  STILL didn't populate `./reviewer-assets/ai-review/` on GitHub-hosted
+  runner fresh clones (broke framework PR #173 + operations PR #140
+  ai-review). v1.1.2 removes sparse-checkout entirely + does full
+  clone (reliable; a few seconds slower).
+- Chicken-and-egg: this PR's ai-review uses BASE main's v1.1.1
+  workflow (which has the bug) → ships via `skip-ai-review` label
+  - admin-merge.
+
 ### Fixed — close 2 repo-wide CI gaps + CHANGELOG terminology (2026-06-26)
 
 - **`.github/workflows/ai-review.yml`** caller pin bumped


### PR DESCRIPTION
Consumes aidoc-flow-ci PR #31 / `ci/v1.1.2`. Chicken-and-egg — ships via skip-ai-review + admin-merge.