### PR TITLE
docs(governance): PR-1a — correct trace contract docs to necessary-upstream

### DIFF
--- a/framework/governance/README.md
+++ b/framework/governance/README.md
@@ -10,7 +10,7 @@ of which engine executes the workflow.
 |------|--------|
 | `DOC_GOVERNANCE_CORE.md` | Core governance principles — single source of truth, YAML-first templates, immutability, validation baseline. |
 | `ID_NAMING_STANDARDS.md` | Document IDs, element IDs, traceability tags, and file-naming formats. |
-| `TRACEABILITY.md` | The 8-layer traceability chain, cumulative tagging, and readiness gates. |
+| `TRACEABILITY.md` | The 8-layer traceability chain, necessary-upstream tagging, and readiness gates. |
 | `DIAGRAM_STANDARDS.md` | Mermaid-only diagram requirement and the C4 + DFD + sequence ownership model. |
 | `THRESHOLD_NAMING_RULES.md` | Naming, boundary, and usage rules for thresholds, limits, and timing parameters. |
 | `SECURITY_REVIEW.md` | Safety checks for agent-authored artifacts — secret leakage, prompt-injection, provenance, active-content sanitization. |

--- a/framework/governance/TRACEABILITY.md
+++ b/framework/governance/TRACEABILITY.md
@@ -6,22 +6,34 @@
 BRD (L1) → PRD (L2) → EARS (L3) → BDD (L4) → ADR (L5) → SPEC (L6) → TDD (L7) → IPLAN (L8) → Code
 ```
 
-## Cumulative Tagging
+## Necessary-upstream tagging
 
-Each layer inherits and adds one tag:
+Each layer cites only its **necessary upstream** (`required_tags` in
+`LAYER_REGISTRY.yaml`) — **not** the cumulative closure of every preceding
+layer. Deeper lineage is discoverable transitively (one hop per layer, or
+`tools/trace_walk.py` for a one-shot query).
 
 ```
-Layer 1 (BRD):   @brd
-Layer 2 (PRD):   @brd @prd
-Layer 3 (EARS):  @brd @prd @ears
-Layer 4 (BDD):   @brd @prd @ears @bdd
-Layer 5 (ADR):   @brd @prd @ears @bdd @adr
-Layer 6 (SPEC):  @brd @prd @ears @bdd @adr @spec
-Layer 7 (TDD):   @brd @prd @ears @bdd @adr @spec @tdd
-Layer 8 (IPLAN): @brd @prd @ears @bdd @adr @spec @tdd @iplan
+Layer 1 (BRD):   —
+Layer 2 (PRD):   @brd
+Layer 3 (EARS):  @prd
+Layer 4 (BDD):   @ears
+Layer 5 (ADR):   @ears @bdd
+Layer 6 (SPEC):  @ears @bdd @adr
+Layer 7 (TDD):   @ears @bdd @adr @spec
+Layer 8 (IPLAN): @spec @tdd
 ```
 
-Maximum 8 cumulative tags at IPLAN layer.
+`required_tags` is the **minimum trace-resolution set**: a layer MAY
+additionally carry provenance tags (e.g. a platform ADR recording `@brd`/`@prd`
+in its `context`) but is not required to. Reverse lookup ("which BRD does
+SPEC-07 trace to?") walks the chain transitively, not a local tag.
+
+> *Origin:* NECESSARY-UPSTREAM-001 (spec `0.15.2` → `0.16.0`) replaced the
+> former cumulative-trace contract — every downstream layer redeclaring every
+> upstream layer — after it caused trace fabrication when an upstream layer was
+> genuinely absent from a project. See `governance/REVIEW_TEAM.md`
+> §"Necessary upstream + transitive trace".
 
 > **Cross-layer cardinality (CLEANUP-PR-F item 18):** doc numbers are
 > per-layer sequential and INDEPENDENT across layers. One BRD MAY drive
@@ -35,12 +47,12 @@ Maximum 8 cumulative tags at IPLAN layer.
 |-------|----------------------|---------------------|
 | BRD | — | PRD |
 | PRD | @brd | EARS |
-| EARS | @brd, @prd | BDD |
-| BDD | @brd, @prd, @ears | ADR |
-| ADR | @brd, @prd, @ears, @bdd | SPEC |
-| SPEC | @brd, @prd, @ears, @bdd, @adr | TDD |
-| TDD | @brd, @prd, @ears, @bdd, @adr, @spec | IPLAN |
-| IPLAN | @brd, @prd, @ears, @bdd, @adr, @spec, @tdd | Code |
+| EARS | @prd | BDD |
+| BDD | @ears | ADR |
+| ADR | @ears, @bdd | SPEC |
+| SPEC | @ears, @bdd, @adr | TDD |
+| TDD | @ears, @bdd, @adr, @spec | IPLAN |
+| IPLAN | @spec, @tdd | Code |
 
 ## Layer Readiness Gates
 

--- a/framework/governance/chg/gates/GATE-08_IPLAN.md
+++ b/framework/governance/chg/gates/GATE-08_IPLAN.md
@@ -220,15 +220,12 @@ Ensure test-first ordering:
 3. Implementation files fill in the stubs
 
 ## GATE-08-E003 Resolution
-Add upstream traceability tags:
+Add the necessary upstream traceability tags. IPLAN requires only @spec + @tdd
+(per LAYER_REGISTRY.yaml required_tags); BRD/PRD/EARS/BDD/ADR are reached
+transitively through the chain, not cited locally:
 
 @spec: SPEC-XX (Component Definition)
 @tdd: TDD-XX (Test Cases)
-@brd: BRD-XX
-@prd: PRD-XX
-@ears: EARS-XX
-@bdd: BDD-XX
-@adr: ADR-XX
 ```
 
 ---

--- a/plans/CFB-PR-1-TAG-CHAIN-GATE-SYNC-PLAN.md
+++ b/plans/CFB-PR-1-TAG-CHAIN-GATE-SYNC-PLAN.md
@@ -1,0 +1,161 @@
+# CFB-PR-1 — `BL-TAG-CHAIN-GATE-SYNC` → cumulative→necessary-upstream doc migration
+
+> First child of `CONSUMER-FEEDBACK-001`. Started as a 2-file fix
+> (`TRACEABILITY.md` + `GATE-08`); the mandatory Pass-2 independent review
+> found the obsolete **cumulative-tag model** survives in ~10 framework-core
+> teaching surfaces that `NECESSARY-UPSTREAM-001` (spec 0.16.0) never scrubbed
+> from prose — fixing only 2 would leave the framework self-contradictory and
+> self-create a dangling pointer. Per founder decision (2026-06-27), expanded
+> to the **full doc migration**, split into ≤3-surface sub-PRs. Documentation
+> only; the contract itself is unchanged.
+
+| Field          | Value                                                |
+| -------------- | ---------------------------------------------------- |
+| Task           | CFB-PR-1 (`BL-TAG-CHAIN-GATE-SYNC`, expanded)        |
+| Type           | documentation                                        |
+| Status         | DRAFT — 2026-06-27T00:00:00Z                         |
+| Parent         | `plans/CONSUMER-FEEDBACK-001-PLAN.md` (PR-1)         |
+| Depends on     | none (Wave-1 foundation)                             |
+| Feeds          | PR-2 (coverage engine reads the corrected chain); PR-3 |
+| Version impact | framework **PATCH** — human-readable governance/teaching-doc correction; the machine-read contract (`LAYER_REGISTRY.yaml` + templates' tag fields) is already correct and unchanged |
+
+## Objective
+
+Migrate every framework-core doc that still teaches the pre-0.16.0
+**cumulative-tag model** ("each layer inherits all upstream tags") to the live
+**necessary-upstream** model (each layer cites only its `required_tags`; deeper
+lineage is transitive). The contract does not change — only the prose/tables
+that misdescribe it. `framework/governance/REVIEW_TEAM.md:262-318` already
+carries the correct language and is the wording reference.
+
+## Scope
+
+**In — the 10 stale surfaces, grouped into 4 sub-PRs (≤3 each, Rule-1 cap):**
+
+- **PR-1a — trace contract source-of-truth:** `framework/governance/TRACEABILITY.md`,
+  `framework/governance/chg/gates/GATE-08_IPLAN.md`,
+  `framework/governance/README.md` (its 1-line description of TRACEABILITY).
+- **PR-1b — principles + author rules + template guidance:**
+  `framework/governance/DOC_GOVERNANCE_CORE.md` (Principle 3),
+  `framework/AI_ASSISTANT_RULES.md` (the live author-facing bug),
+  `framework/layers/05_ADR/ADR-TEMPLATE.yaml` (`_guidance` only — NOT tag fields).
+- **PR-1c — guides:** `framework/SPEC_DRIVEN_DEVELOPMENT_GUIDE.md`,
+  `framework/QUICK_REFERENCE.md`, `framework/README.md`.
+- **PR-1d — review-flow pointer:** `framework/governance/REVIEW_REMEDIATION_FLOW.md`
+  (1-line cross-ref). Small; rides last or folds into the lightest sibling.
+
+**Out of scope (deferred — owner named):**
+
+- Do NOT re-add cumulative tags anywhere (BL-Q1); do NOT touch template tag
+  fields — only `_guidance` prose. Templates' actual tags already match the
+  contract.
+- Hermes `sdd-orchestrator/references/*` + plugin mirrors carry the same stale
+  copies → owned by **PR-10 `ENG-STALE-DEPTH-DOCS`** (already flagged
+  >3-surface; the cumulative copies join that Hermes sweep).
+- `TRACEABILITY.md` `>=90/100` readiness wording → **PR-9 `BL-READY-SCORE-ADVISORY`**.
+- Auditor playbooks (`07_TDD`, `08_IPLAN`) already frame cumulative tags as
+  optional/decorative — correct, not touched.
+
+## Approach / Design
+
+### Authoritative contract (`LAYER_REGISTRY.yaml` `required_tags`)
+
+Verified against registry + templates + lint-passing corpus (all agree):
+
+| Layer | Necessary upstream (`required_tags`) |
+| ----- | ------------------------------------ |
+| BRD   | — |
+| PRD   | `@brd` |
+| EARS  | `@prd` (NOT `@brd @prd`) |
+| BDD   | `@ears` |
+| ADR   | `@ears, @bdd` |
+| SPEC  | `@ears, @bdd, @adr` |
+| TDD   | `@ears, @bdd, @adr, @spec` |
+| IPLAN | `@spec, @tdd` |
+
+The chain is **not cumulative**: from ADR on, `@brd`/`@prd` are dropped; IPLAN
+keeps only `@spec`/`@tdd`. `required_tags` is the *minimum* trace-resolution
+set — a doc MAY carry extra provenance tags (e.g. a platform ADR's `@brd`/`@prd`
+in `context`), so the corrected tables describe the **required** column only.
+
+### Consistent corrected language (all surfaces)
+
+- Replace "cumulative tagging / each layer inherits all upstream tags / Maximum
+  8 cumulative tags" with "**necessary-upstream tagging** — each layer cites
+  only its `required_tags`; deeper lineage is transitive (one hop per layer, or
+  `tools/trace_walk.py`)."
+- Any per-layer tag table → the contract table above (required column).
+- "cumulative traceability" used loosely as an end-to-end descriptor (e.g.
+  `framework/README.md:12`, guide overview) → "**end-to-end traceability**" (the
+  chain still spans BRD→IPLAN transitively; just not via redundant local tags).
+
+## Implementation sequence (per sub-PR; each its own branch + CI + merge)
+
+1. **PR-1a** — rewrite `TRACEABILITY.md` "Cumulative Tagging"→"Necessary-upstream
+   tagging" + fix validation table; trim `GATE-08-E003` resolution to
+   `@spec`/`@tdd`; fix `governance/README.md` description.
+2. **PR-1b** — `DOC_GOVERNANCE_CORE.md` Principle 3 reworded; `AI_ASSISTANT_RULES.md:12`
+   corrected (the live bug); `ADR-TEMPLATE.yaml:389` `_guidance` corrected.
+3. **PR-1c** — `SPEC_DRIVEN_DEVELOPMENT_GUIDE.md` (§Cumulative Traceability +
+   overview), `QUICK_REFERENCE.md` table, `framework/README.md:12`.
+4. **PR-1d** — `REVIEW_REMEDIATION_FLOW.md:175` cross-ref.
+
+Sub-PRs land in close succession; none claims "framework now consistent" until
+PR-1d merges (transient cross-PR inconsistency is acceptable per the
+sequenced-PR discipline).
+
+## Verification (each sub-PR + a final repo-wide gate)
+
+| #  | Check | Expected | Maps to |
+| -- | ----- | -------- | ------- |
+| V1 | Each corrected per-layer table == `LAYER_REGISTRY.yaml` `required_tags` | exact | contract |
+| V2 | `GATE-08-E003` resolution lists only `@spec`+`@tdd` | true | PR-1a |
+| V3 | Each sub-PR ≤3 doc surfaces (`git diff --name-only`) | true | Rule-1 |
+| V4 | `python3 -m sdd_doc_lint examples/url-shortener/docs/` | green/unchanged | C-1 guard |
+| V5 | Conformance suite green | green | land-gate |
+| V6 (final, after PR-1d) | `grep -rin "cumulative" framework/ --include=*.md \| grep -vi "non-cumulative"` returns ONLY: the deferred Hermes/plugin mirrors (PR-10), THRESHOLD_NAMING_RULES (unrelated "cumulative total" usage), REVIEW_TEAM origin-note, and auditor-playbook "optional/decorative" framing | no stale per-layer-chain assertion remains in framework-core | Objective |
+
+## Docs to update
+
+- [ ] `plans/FRAMEWORK-TODO.md` — `BL-TAG-CHAIN-GATE-SYNC` → Closed (after PR-1d) with merge SHAs; note the scope expansion.
+- [ ] `plans/CONSUMER-FEEDBACK-001-PLAN.md` — record PR-1 expanded to 1a–1d (cumulative-residue migration).
+- [ ] `CHANGELOG.md` — framework PATCH entry.
+
+## Claim ledger
+
+| #  | Claim | Citation |
+| -- | ----- | -------- |
+| 1 | required_tags per layer (the contract table) | `LAYER_REGISTRY.yaml:25,38,51,71,84,97,110,123` |
+| 2 | Correct wording already exists (reference) | `framework/governance/REVIEW_TEAM.md:266-271,318` |
+| 3 | GATE-08-E003 example is the stale 7-tag chain; rule needs only spec/tdd | `GATE-08_IPLAN.md:225-231` vs `:70,197` |
+| 4 | Stale cumulative surfaces (the 10) | `TRACEABILITY.md:13-24,34-43`; `GATE-08:225-231`; `governance/README.md:13`; `DOC_GOVERNANCE_CORE.md:7`; `AI_ASSISTANT_RULES.md:12`; `ADR-TEMPLATE.yaml:389`; `SPEC_DRIVEN_DEVELOPMENT_GUIDE.md:24-39`; `QUICK_REFERENCE.md:18-20`; `framework/README.md:12`; `REVIEW_REMEDIATION_FLOW.md:175` |
+| 5 | Corpus confirms non-cumulative | `examples/url-shortener/docs/03_EARS/EARS-01.md` (@prd, no @brd); `08_IPLAN/IPLAN-01.md` (@spec/@tdd) |
+
+## Review log
+
+### Pass 1 — 2026-06-26 — self-review
+
+- Scope-vs-triage: validation table (34-43) equally stale; widened within
+  2 surfaces; recorded authoritative table.
+
+### Pass 2 — 2026-06-26 — independent (fresh-context, `Plan` agent)
+
+- **[BLOCKING] Incomplete scope:** the cumulative model survives in ~6+
+  framework-core surfaces (DOC_GOVERNANCE_CORE Principle 3, AI_ASSISTANT_RULES
+  live bug, the guide, quick-ref, framework/README, REVIEW_REMEDIATION) +
+  ADR `_guidance`; fixing only 2 files self-creates a dangling pointer at
+  `governance/README.md:13`. → **Verified all by grep**; founder chose full
+  cleanup. Scope expanded to the 10-surface migration, split into 4 ≤3-surface
+  sub-PRs (1a–1d). Objective re-scoped to "migrate the model," not "2-file fix."
+- Other findings folded: "all three sources agree" softened (ADR provenance
+  nuance); V6 promoted to a repo-wide final gate; ADR `_guidance` brought in.
+
+### Pass 3 — 2026-06-27 — self re-validation (of the expanded scope)
+
+- 10 surfaces enumerated + assigned to 4 sub-PRs, each ≤3 (V3). Deferred
+  surfaces (Hermes/plugin mirrors→PR-10; readiness wording→PR-9) named with
+  owners. Corrected language sourced from REVIEW_TEAM.md (consistent). Contract
+  table re-checked against registry. No new load-bearing gaps.
+
+**Result:** READY for implementation (4 sub-PRs). Independent confirmation of
+the *implemented* PR-1a diff to run before its PR opens (per governance Rule 2).

--- a/platforms/claude-code-plugin/framework/governance/README.md
+++ b/platforms/claude-code-plugin/framework/governance/README.md
@@ -10,7 +10,7 @@ of which engine executes the workflow.
 |------|--------|
 | `DOC_GOVERNANCE_CORE.md` | Core governance principles — single source of truth, YAML-first templates, immutability, validation baseline. |
 | `ID_NAMING_STANDARDS.md` | Document IDs, element IDs, traceability tags, and file-naming formats. |
-| `TRACEABILITY.md` | The 8-layer traceability chain, cumulative tagging, and readiness gates. |
+| `TRACEABILITY.md` | The 8-layer traceability chain, necessary-upstream tagging, and readiness gates. |
 | `DIAGRAM_STANDARDS.md` | Mermaid-only diagram requirement and the C4 + DFD + sequence ownership model. |
 | `THRESHOLD_NAMING_RULES.md` | Naming, boundary, and usage rules for thresholds, limits, and timing parameters. |
 | `SECURITY_REVIEW.md` | Safety checks for agent-authored artifacts — secret leakage, prompt-injection, provenance, active-content sanitization. |

--- a/platforms/claude-code-plugin/framework/governance/TRACEABILITY.md
+++ b/platforms/claude-code-plugin/framework/governance/TRACEABILITY.md
@@ -6,22 +6,34 @@
 BRD (L1) → PRD (L2) → EARS (L3) → BDD (L4) → ADR (L5) → SPEC (L6) → TDD (L7) → IPLAN (L8) → Code
 ```
 
-## Cumulative Tagging
+## Necessary-upstream tagging
 
-Each layer inherits and adds one tag:
+Each layer cites only its **necessary upstream** (`required_tags` in
+`LAYER_REGISTRY.yaml`) — **not** the cumulative closure of every preceding
+layer. Deeper lineage is discoverable transitively (one hop per layer, or
+`tools/trace_walk.py` for a one-shot query).
 
 ```
-Layer 1 (BRD):   @brd
-Layer 2 (PRD):   @brd @prd
-Layer 3 (EARS):  @brd @prd @ears
-Layer 4 (BDD):   @brd @prd @ears @bdd
-Layer 5 (ADR):   @brd @prd @ears @bdd @adr
-Layer 6 (SPEC):  @brd @prd @ears @bdd @adr @spec
-Layer 7 (TDD):   @brd @prd @ears @bdd @adr @spec @tdd
-Layer 8 (IPLAN): @brd @prd @ears @bdd @adr @spec @tdd @iplan
+Layer 1 (BRD):   —
+Layer 2 (PRD):   @brd
+Layer 3 (EARS):  @prd
+Layer 4 (BDD):   @ears
+Layer 5 (ADR):   @ears @bdd
+Layer 6 (SPEC):  @ears @bdd @adr
+Layer 7 (TDD):   @ears @bdd @adr @spec
+Layer 8 (IPLAN): @spec @tdd
 ```
 
-Maximum 8 cumulative tags at IPLAN layer.
+`required_tags` is the **minimum trace-resolution set**: a layer MAY
+additionally carry provenance tags (e.g. a platform ADR recording `@brd`/`@prd`
+in its `context`) but is not required to. Reverse lookup ("which BRD does
+SPEC-07 trace to?") walks the chain transitively, not a local tag.
+
+> *Origin:* NECESSARY-UPSTREAM-001 (spec `0.15.2` → `0.16.0`) replaced the
+> former cumulative-trace contract — every downstream layer redeclaring every
+> upstream layer — after it caused trace fabrication when an upstream layer was
+> genuinely absent from a project. See `governance/REVIEW_TEAM.md`
+> §"Necessary upstream + transitive trace".
 
 > **Cross-layer cardinality (CLEANUP-PR-F item 18):** doc numbers are
 > per-layer sequential and INDEPENDENT across layers. One BRD MAY drive
@@ -35,12 +47,12 @@ Maximum 8 cumulative tags at IPLAN layer.
 |-------|----------------------|---------------------|
 | BRD | — | PRD |
 | PRD | @brd | EARS |
-| EARS | @brd, @prd | BDD |
-| BDD | @brd, @prd, @ears | ADR |
-| ADR | @brd, @prd, @ears, @bdd | SPEC |
-| SPEC | @brd, @prd, @ears, @bdd, @adr | TDD |
-| TDD | @brd, @prd, @ears, @bdd, @adr, @spec | IPLAN |
-| IPLAN | @brd, @prd, @ears, @bdd, @adr, @spec, @tdd | Code |
+| EARS | @prd | BDD |
+| BDD | @ears | ADR |
+| ADR | @ears, @bdd | SPEC |
+| SPEC | @ears, @bdd, @adr | TDD |
+| TDD | @ears, @bdd, @adr, @spec | IPLAN |
+| IPLAN | @spec, @tdd | Code |
 
 ## Layer Readiness Gates
 

--- a/platforms/claude-code-plugin/framework/governance/chg/gates/GATE-08_IPLAN.md
+++ b/platforms/claude-code-plugin/framework/governance/chg/gates/GATE-08_IPLAN.md
@@ -220,15 +220,12 @@ Ensure test-first ordering:
 3. Implementation files fill in the stubs
 
 ## GATE-08-E003 Resolution
-Add upstream traceability tags:
+Add the necessary upstream traceability tags. IPLAN requires only @spec + @tdd
+(per LAYER_REGISTRY.yaml required_tags); BRD/PRD/EARS/BDD/ADR are reached
+transitively through the chain, not cited locally:
 
 @spec: SPEC-XX (Component Definition)
 @tdd: TDD-XX (Test Cases)
-@brd: BRD-XX
-@prd: PRD-XX
-@ears: EARS-XX
-@bdd: BDD-XX
-@adr: ADR-XX
 ```
 
 ---


### PR DESCRIPTION
## What

**Sub-PR 1 of 4** in the cumulative→necessary-upstream doc migration (`CFB-PR-1`, first child of `CONSUMER-FEEDBACK-001`). `NECESSARY-UPSTREAM-001` (spec 0.16.0) changed the trace contract from *cumulative* (every layer redeclares all upstream tags) to *necessary-upstream* (each layer cites only its `required_tags`), but the prose was never scrubbed and survives stale across ~10 framework-core docs. This sub-PR fixes the **3 contract source-of-truth surfaces**:

- **`TRACEABILITY.md`** — "Cumulative Tagging" → "Necessary-upstream tagging"; the per-layer list **and** the Upstream/Downstream validation table now match `LAYER_REGISTRY.yaml` `required_tags` exactly (EARS `@prd` not `@brd @prd`; ADR `@ears @bdd`; SPEC `@ears @bdd @adr`; IPLAN `@spec @tdd`; …). Adds the transitive reverse-lookup note + origin reference.
- **`GATE-08_IPLAN.md`** — `GATE-08-E003` resolution trimmed from the stale 7-tag chain to `@spec` + `@tdd` (matching the gate's own rule at `:70` and the registry).
- **`governance/README.md`** — TRACEABILITY description "cumulative" → "necessary-upstream".

Plus the plugin vendored mirrors (mechanical `sync-plugin-framework.sh`, the **C-2** cross-cutting criterion) and the child plan of record.

## Why expanded from the triaged 2-file scope

The triage entry (`BL-TAG-CHAIN-GATE-SYNC`) named 2 files; the child plan's mandatory independent Pass-2 review found the stale model in ~10 framework-core surfaces (incl. a **live author-facing bug** in `AI_ASSISTANT_RULES.md` that re-creates the trace fabrication 0.16.0 killed). Per founder decision, expanded to a full migration, split into ≤3-surface sub-PRs (1a–1d). This is **1a**; 1b/1c/1d follow.

## Verification

- Contract grounded against 3 independent sources: `LAYER_REGISTRY.yaml` `required_tags`, the layer templates, and the lint-passing `examples/url-shortener/` corpus (all agree; EARS-01 carries `@prd` not `@brd`).
- Conformance: **135 passed / 626 subtests** (the pre-sync byte-identical-bundle failure is what C-2's `sync-plugin-framework.sh` resolves).
- Corpus lint unchanged (no lint rule / template touched).
- Scope: 3 authored surfaces (+ mechanical mirrors), within the ≤3 governance cap.

CHANGELOG / FRAMEWORK-TODO-close land in the final sub-PR (1d) — one logical migration shipped as a sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)