### PR TITLE
fix(tools): bump_version.py bumps playbooks + plugin README; decouples plugin VERSION

### DIFF
--- a/tools/bump_version.py
+++ b/tools/bump_version.py
@@ -1,8 +1,18 @@
 #!/usr/bin/env python3
-"""Bump framework/VERSION + FRAMEWORK_SPEC_VERSION files + every skill's
-framework_spec_version, then re-sync the bundle.
+"""Bump the FRAMEWORK SPEC version across everything that must equal it.
+
+Bumps `framework/VERSION`, both platforms' `FRAMEWORK_SPEC_VERSION` pins, and
+the `framework_spec_version` of every skill manifest AND every playbook (and
+`SKILL_AUTHORING.md`), then runs the sync scripts (bundle + vendored lint +
+`sync-version-refs.sh`, which fans the spec-version string into the READMEs /
+PARITY / CLAUDE.md).
 
 Usage:  python3 tools/bump_version.py <semver>
+
+Does NOT touch the plugin's own `VERSION` (independent stream — bump it
+separately when the plugin releases). One manual step remains: the deliberate
+hard-pin in `tests/conformance/platforms/test_plugin_release_metadata.py`
+(printed as a reminder).
 
 Portable (no GNU-sed deps).
 """
@@ -19,15 +29,48 @@ FRAMEWORK_SPEC = REPO_ROOT / "framework"
 BUNDLE = REPO_ROOT / "platforms" / "claude-code-plugin"
 
 SEMVER = re.compile(r"^\d+\.\d+\.\d+$")
-SKILL_SPEC_RE = re.compile(
-    r'^(?P<lead>\s+framework_spec_version:\s*")[^"]+(?P<trail>".*)$',
+# `\s*` (not `\s+`): skill frontmatter indents framework_spec_version under
+# metadata.custom_fields, but playbook frontmatter declares it at column 0.
+# The old `\s+` silently skipped all 51 playbooks → conformance red after a bump.
+FSV_RE = re.compile(
+    r'^(?P<lead>\s*framework_spec_version:\s*")[^"]+(?P<trail>".*)$',
     re.MULTILINE,
 )
+
+
+def bump_plugin_readme(new: str) -> None:
+    """Update the plugin README's framework-spec strings (conformance-checked):
+    the prose ``framework spec `X``` and the ``$ cat FRAMEWORK_SPEC_VERSION`` block.
+    Conformance runs BEFORE sync-version-refs.sh at commit time, so this can't be
+    left to that hook."""
+    readme = BUNDLE / "README.md"
+    if not readme.exists():
+        return
+    text = readme.read_text(encoding="utf-8")
+    text = re.sub(r"(framework spec `)\d+\.\d+\.\d+(`)", rf"\g<1>{new}\g<2>", text)
+    text = re.sub(
+        r"(\$ cat FRAMEWORK_SPEC_VERSION\n)\d+\.\d+\.\d+",
+        rf"\g<1>{new}",
+        text,
+    )
+    readme.write_text(text, encoding="utf-8")
 
 
 def die(msg: str, code: int = 2) -> None:
     print(f"bump_version: {msg}", file=sys.stderr)
     sys.exit(code)
+
+
+def bump_fsv(paths, new: str) -> int:
+    """Rewrite every `framework_spec_version: "..."` to `new`. Returns count."""
+    updated = 0
+    for path in paths:
+        original = path.read_text(encoding="utf-8")
+        patched = FSV_RE.sub(rf"\g<lead>{new}\g<trail>", original)
+        if patched != original:
+            path.write_text(patched, encoding="utf-8")
+            updated += 1
+    return updated
 
 
 def main(argv: list[str]) -> int:
@@ -39,49 +82,64 @@ def main(argv: list[str]) -> int:
     if not version_file.exists():
         die(f"missing {version_file}", 1)
     old = version_file.read_text(encoding="utf-8").strip()
-    print(f"Bumping {old} -> {new}")
+    print(f"Bumping framework spec {old} -> {new}")
 
+    # framework/VERSION + the two platform FRAMEWORK_SPEC_VERSION pins.
+    # NOT the plugin's own VERSION (BUNDLE / "VERSION") — independent stream.
     for path in [
         FRAMEWORK_SPEC / "VERSION",
-        BUNDLE / "VERSION",
         BUNDLE / "FRAMEWORK_SPEC_VERSION",
         REPO_ROOT / "platforms" / "hermes" / "FRAMEWORK_SPEC_VERSION",
     ]:
         if path.exists():
             path.write_text(new + "\n", encoding="utf-8")
 
-    skills_root = BUNDLE / "skills"
-    updated = 0
-    if skills_root.exists():
-        for skill_md in skills_root.glob("*/SKILL.md"):
-            original = skill_md.read_text(encoding="utf-8")
-            patched = SKILL_SPEC_RE.sub(rf"\g<lead>{new}\g<trail>", original)
-            if patched != original:
-                skill_md.write_text(patched, encoding="utf-8")
-                updated += 1
-    print(f"Updated {updated} skill manifest(s)")
+    # Single-declaration files (clean frontmatter — straggler-guarded):
+    #   - plugin skills (indented frontmatter)
+    #   - canonical playbooks (column-0 frontmatter) — bundle copies follow via sync
+    strict_paths = sorted((BUNDLE / "skills").glob("*/SKILL.md"))
+    strict_paths += sorted((FRAMEWORK_SPEC / "playbooks").glob("**/*.md"))
+    n = bump_fsv(strict_paths, new)
 
+    # SKILL_AUTHORING.md carries the canonical declaration in its frontmatter
+    # example PLUS illustrative `framework_spec_version: "..."` strings in prose
+    # (the §6 checklist). Bump it but do NOT straggler-guard it — a stale doc
+    # example is not a contract violation; conformance only asserts the new value
+    # is present.
+    skill_authoring = BUNDLE / "docs" / "SKILL_AUTHORING.md"
+    if skill_authoring.exists():
+        n += bump_fsv([skill_authoring], new)
+    print(f"Updated {n} framework_spec_version declaration(s)")
+
+    # Plugin README framework-spec strings (conformance-checked; must be fixed
+    # before the pre-commit conformance hook, which runs before sync-version-refs).
+    bump_plugin_readme(new)
+
+    # Sync: bundle (propagates canonical playbooks → vendored copies), vendored
+    # lint, and the version-string fanout into README/PARITY/CLAUDE.md.
     for sync in [
         REPO_ROOT / "tools" / "sync-plugin-framework.sh",
         REPO_ROOT / "tools" / "sdd_doc_lint" / "sync-vendored.sh",
+        REPO_ROOT / "scripts" / "sync-version-refs.sh",
     ]:
         if sync.exists():
             subprocess.run(["bash", str(sync)], check=True)
 
-    if skills_root.exists():
-        stragglers = [
-            p
-            for p in skills_root.glob("*/SKILL.md")
-            if f'framework_spec_version: "{old}"' in p.read_text(encoding="utf-8")
-        ]
-        if stragglers:
-            die(
-                f"{len(stragglers)} skill(s) still reference {old}: "
-                f"{[str(p.relative_to(REPO_ROOT)) for p in stragglers]}",
-                1,
-            )
+    # Straggler guard — no skill/playbook frontmatter may still declare old.
+    stragglers = [
+        str(p.relative_to(REPO_ROOT))
+        for p in strict_paths
+        if f'framework_spec_version: "{old}"' in p.read_text(encoding="utf-8")
+    ]
+    if stragglers:
+        die(f"{len(stragglers)} file(s) still reference {old}: {stragglers}", 1)
 
-    print(f"Bump complete: {old} -> {new}")
+    print(f"Bump complete: framework spec {old} -> {new}")
+    print(
+        "  Reminder: update the hard-pin in "
+        "tests/conformance/platforms/test_plugin_release_metadata.py "
+        f'(assertEqual(..., "{new}")) — a deliberate per-release tripwire.'
+    )
     return 0
 
 


### PR DESCRIPTION
## What

`tools/bump_version.py` left a framework-spec bump in a broken state — it silently skipped **all 51 playbooks**, so conformance went red after every bump and needed extensive manual fix-up (hit hard during CFB-PR-1 / PR #180). Root cause: the `framework_spec_version` regex required `\s+` (leading indentation), but **playbook frontmatter declares it at column 0** — the regex couldn't match them even when present.

## Fix

- **`\s+` → `\s*`** so the regex matches both indented (skills) and column-0 (playbooks) frontmatter.
- **Bump set extended:** the 52 skills (as before) + the **51 canonical playbooks** + `SKILL_AUTHORING.md` frontmatter (bundle copies follow via sync).
- **Plugin README** framework-spec strings (the prose `framework spec \`X\`` + the `$ cat FRAMEWORK_SPEC_VERSION` block) bumped directly — conformance checks these and runs *before* `sync-version-refs.sh` at commit time, so they can't be left to that hook.
- **Decoupled the plugin's own `VERSION`** — no longer bumped to the framework-spec value (independent stream; the old behavior forced an incorrect plugin version jump).
- Straggler guard extended across skills + playbooks; `SKILL_AUTHORING` excluded (it carries illustrative `framework_spec_version` strings in prose that aren't contract declarations).

## Effect

A framework-spec bump now leaves conformance with **1** failure instead of 54 — the single deliberate hard-pin tripwire in `test_plugin_release_metadata.py`, which the tool now prints a reminder to update.

## Verification

Ran `bump_version.py 0.23.2` on a throwaway: 104 `framework_spec_version` declarations updated, plugin VERSION stayed `0.22.0`, conformance 135 tests → 1 failure (the intentional tripwire). Reverted; this PR changes only `tools/bump_version.py` (no `framework/**` change → no GATE-SPEC bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)