### PR TITLE
chore(ci): bump ai-review pin @ci/v1.1.3 → @ci/v1.1.5 (IPLAN-0024 P4 — CRITICAL GitHub-hosted validation)

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,15 +1,19 @@
-# Pinned at @ci/v1.1.3 — IPLAN-0022 PR-A sparse-checkout pattern hot-fix
-# (aidoc-flow-ci PR #29; CLASS-aware terminology cleanup PR #30 also
-# in-flight on aidoc-flow-ci). Prior @ci/v1.1.0 had a sparse-checkout
-# pattern bug that broke ai-review on GitHub-hosted runners (worked on
-# self-hosted only due to cached state). @ci/v1.1.3 fixes that.
+# Pinned at @ci/v1.1.5 per IPLAN-0024 (operations PR #145 + aidoc-flow-ci
+# PR #36 + operations P3 PR #148) — the reusable workflow now uses `curl`
+# instead of `actions/checkout` for cross-repo rubric/schema/config
+# fetches, eliminating the v1.1.0→v1.1.3 sparse-checkout / clean-flag /
+# INIT-time-content-delete bug class. **Framework is the CRITICAL
+# validation:** GitHub-hosted runners (`ubuntu-latest`) are the bug-
+# class home that v1.1.0-v1.1.3 couldn't escape — every prior sparse-
+# checkout iteration failed here while passing on operations' self-
+# hosted. Per IPLAN-0022 PR-C reviewer rubric + schema live at
+# aidoc-flow-ci/ai-review/ (no longer in operations@main); per-consumer
+# config.json still comes from operations@main (transitional; per-
+# consumer-from-each-consumer-repo move tracked as a follow-up IPLAN).
 #
-# Pinned at @ci/v1.1.0 was — IPLAN-0022 PR-C: reviewer rubric + schema
-# now fetched from aidoc-flow-ci/ai-review/ at this pin (no longer
-# from operations@main; see IPLAN-0022 §3.7 P2). Per-consumer
-# config.json preservation via transitional sparse-checkout in the
-# reusable workflow (per-consumer-config improvement tracked as a
-# follow-up IPLAN).
+# Prior @ci/v1.1.3 was — IPLAN-0022 PR-A sparse-checkout pattern hot-fix
+# lineage (aidoc-flow-ci PR #29 + #33; cone-mode → full-clone →
+# clean: false saga). Superseded by IPLAN-0024 mechanism-level fix.
 #
 # Prior @ci/v1.0.5 — first PUBLIC consumer of aidoc-flow-ci
 # (framework Phase A 2026-06-24). The reusable ai-review.yml installs
@@ -45,7 +49,7 @@ permissions:
   issues: write          # labels
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/ai-review.yml@ci/v1.1.3
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/ai-review.yml@ci/v1.1.5
     with:
       reviewer: claude
       runner_labels_routine: '"ubuntu-latest"'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,39 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed — `.github/workflows/ai-review.yml`: pin `@ci/v1.1.3` → `@ci/v1.1.5` (IPLAN-0024 P4 — CRITICAL GitHub-hosted-runner validation) (2026-06-27)
+
+- Framework caller pin bumped from `@ci/v1.1.3` to `@ci/v1.1.5` to
+  consume the curl-replaces-`actions/checkout` fix shipped on aidoc-
+  flow-ci main (PR #36 merged + tag `ci/v1.1.5` pushed; operations P3
+  PR #148 merged earlier this session with all 9 checks green
+  including ai-review on self-hosted). The reusable workflow at
+  `@ci/v1.1.5` replaces 2 cross-repo `actions/checkout` steps with
+  `curl`, eliminating the v1.1.0→v1.1.3 sparse-checkout / clean-flag /
+  INIT-time-content-delete bug class. Header comment block refreshed
+  to reference IPLAN-0024 instead of the v1.1.x saga context.
+- **Framework is the CRITICAL validation:** GitHub-hosted runners
+  (`ubuntu-latest`) are the bug-class home that v1.1.0-v1.1.3 couldn't
+  escape — every prior sparse-checkout iteration failed here while
+  passing on operations' self-hosted runners. P3 (operations on self-
+  hosted) was the KNOWN-GOOD class. THIS PR is where curl's
+  effectiveness is actually proven.
+- **Chicken-and-egg:** BASE main still pins v1.1.3 → ai-review on this
+  PR fires using the still-buggy v1.1.3 workflow on `ubuntu-latest`.
+  Expected to fail or hang the same way prior framework PRs in the
+  v1.1.x lineage did; ship via `skip-ai-review` label + admin-merge.
+  After merge the new pin takes effect for all subsequent PRs and
+  curl's GitHub-hosted-runner behavior is the validation gate.
+- **R1 + R2 bundle from operations HANDOFF — BOTH DROPPED** in P1 (R1
+  would have broken `docs/troubleshooting.md §15` force-fresh-review
+  path; R2's bare 1-line `workflow_dispatch:` doesn't work without
+  reusable workflow inputs design). Both tracked for separate future
+  small IPLANs.
+- **Plan:** IPLAN-0024 (operations PR #145; approved + merged
+  2026-06-26).
+- **Next:** if ai-review on the next post-merge framework PR fires
+  cleanly using v1.1.5 on ubuntu-latest, IPLAN-0024 closes successfully.
+
 ### Fixed — Framework Spec 0.23.1: cumulative→necessary-upstream doc reconciliation (2026-06-27)
 
 - Completed the doc migration `NECESSARY-UPSTREAM-001` (spec 0.16.0) left

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -1,5 +1,19 @@
 # Session Handoff
 
+> **🟢 IPLAN-0024 P4 — `ai-review.yml` pin `@ci/v1.1.3` → `@ci/v1.1.5` (2026-06-27).**
+>
+> Consumes the curl-replaces-`actions/checkout` fix shipped on
+> aidoc-flow-ci main (PR #36) and validated on operations P3 (PR #148
+> merged earlier this session — all 9 checks green including ai-review
+> on operations' self-hosted runners). **This PR is the CRITICAL test**:
+> framework runs on `ubuntu-latest` (GitHub-hosted), the runner class
+> where every v1.1.0→v1.1.3 sparse-checkout iteration failed. If ai-
+> review fires cleanly post-merge using v1.1.5 here, IPLAN-0024 closes
+> successfully. Chicken-and-egg: BASE main pins v1.1.3 → ai-review on
+> this PR fires using the still-buggy v1.1.3 workflow; ship via
+> `skip-ai-review` label + admin-merge. Operations carries IPLAN-0024
+> primary tracking (`ops/iplans/IPLAN-0024_template-pattern.md`).
+>
 > **🟢 SAGA-PARITY-001 PHASE 4 SHIPPED + CI RESTORED (2026-06-22).**
 >
 > **Phase 4 merged** — PR #161, merge `f277ea1a`, plugin `0.20.1 → 0.21.0`.


### PR DESCRIPTION
## Summary

Framework caller pin `.github/workflows/ai-review.yml` bumped `@ci/v1.1.3` → `@ci/v1.1.5` to consume the curl-replaces-`actions/checkout` fix shipped on aidoc-flow-ci main (PR #36 merged + tag `ci/v1.1.5` pushed; operations P3 PR vladm3105/aidoc-flow-operations#148 merged earlier this session with all 9 checks green including ai-review on operations' self-hosted runners).

Header comment refreshed to reference IPLAN-0024 instead of the v1.1.0→v1.1.3 sparse-checkout saga context. `CHANGELOG.md` entry at top of [Unreleased]; `plans/HANDOFF.md` newest-on-top note pointing to operations for primary IPLAN-0024 tracking.

## Framework is the CRITICAL validation

GitHub-hosted runners (`ubuntu-latest`) are the bug-class home that v1.1.0-v1.1.3 couldn't escape — every prior sparse-checkout iteration failed here while passing on operations' self-hosted runners. **P3 (operations on self-hosted) was the KNOWN-GOOD class. THIS PR is where curl's effectiveness is actually proven.** If ai-review on the next post-merge framework PR fires cleanly using v1.1.5 on ubuntu-latest, IPLAN-0024 closes successfully.

## R1 + R2 bundle from operations HANDOFF — BOTH DROPPED in P1

- **R1** (narrow ai-review `if:` to fire on `labeled` only for `skip-ai-review`) dropped after pre-push adversarial self-review caught it would break `docs/troubleshooting.md §15` "force fresh review on stale verdict after rebase" path. R3 (early-exit) is the right fix; tracked for its own future small IPLAN.
- **R2** (bare 1-line `workflow_dispatch:` on composition templates) dropped at implementation time — bare addition doesn't achieve retrigger goal without `inputs.pr_number:` + reusable workflow fallback. Tracked for its own future small IPLAN.

## Chicken-and-egg (ship via skip-ai-review label + admin-merge)

BASE main pins `@ci/v1.1.3` → ai-review on this PR fires using the still-buggy v1.1.3 workflow on ubuntu-latest. Expected to fail or hang the same way prior framework PRs in the v1.1.x lineage did; ship via `skip-ai-review` label + admin-merge per `docs/troubleshooting.md §15`. After merge the new pin takes effect for all subsequent PRs and curl's GitHub-hosted-runner behavior is the validation gate.

## Surfaces (Rule 1 compliance)

3 surfaces (at the Rule-1 limit, not over):
1. `.github/workflows/ai-review.yml` (pin + header comment) — explicitly governance-listed per CLAUDE.md
2. `CHANGELOG.md` (Unreleased entry)
3. `plans/HANDOFF.md` (newest-on-top note)

## Plan

[IPLAN-0024](https://github.com/vladm3105/aidoc-flow-operations/blob/main/ops/iplans/IPLAN-0024_template-pattern.md) (operations PR #145; approved + merged 2026-06-26).

## Pre-push verification

- ✅ Pre-commit hooks all passed (yamllint, secret-scan, **framework/platform conformance suite**)
- ✅ Adversarial code-reviewer agent: **APPROVED** (no findings)

## Test plan

- [ ] ai-review fires on this PR using v1.1.3 workflow on ubuntu-latest (chicken-and-egg) → admin-merge via skip-ai-review label
- [ ] After merge: next framework PR's ai-review fires using v1.1.5 workflow on ubuntu-latest → **CRITICAL** — verify clean curl-based asset fetch on GitHub-hosted runner
- [ ] If clean: **IPLAN-0024 CLOSES SUCCESSFULLY** — curl-replaces-checkout proven across both runner classes