### PR TITLE
chore(ci): bump ai-review pin @ci/v1.1.5 → @ci/v1.1.6 (auto-merge App-token fix; version-lockstep with operations)

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,15 +1,27 @@
-# Pinned at @ci/v1.1.5 per IPLAN-0024 (operations PR #145 + aidoc-flow-ci
-# PR #36 + operations P3 PR #148) — the reusable workflow now uses `curl`
-# instead of `actions/checkout` for cross-repo rubric/schema/config
-# fetches, eliminating the v1.1.0→v1.1.3 sparse-checkout / clean-flag /
-# INIT-time-content-delete bug class. **Framework is the CRITICAL
-# validation:** GitHub-hosted runners (`ubuntu-latest`) are the bug-
-# class home that v1.1.0-v1.1.3 couldn't escape — every prior sparse-
-# checkout iteration failed here while passing on operations' self-
-# hosted. Per IPLAN-0022 PR-C reviewer rubric + schema live at
-# aidoc-flow-ci/ai-review/ (no longer in operations@main); per-consumer
-# config.json still comes from operations@main (transitional; per-
-# consumer-from-each-consumer-repo move tracked as a follow-up IPLAN).
+# Pinned at @ci/v1.1.6 — adds the auto-merge anti-recursion fix (aidoc-
+# flow-ci PR #37). Auto-merge now authenticated as the reviewer App
+# (APP_TOKEN) instead of the default GITHUB_TOKEN, so the App-authored
+# merge commit triggers downstream push: workflows on every routine
+# auto-merged PR. Discovered 2026-06-27 via IPLAN-0018 docs-sync
+# verification on operations PRs #149 + #150. v1.1.6 has a graceful
+# fallback to GITHUB_TOKEN if the App lacks `contents: write` (PR still
+# merges; push: workflows stay suppressed until permission is added;
+# operator-visible ::warning::). Framework currently has no push:
+# workflows depending on the fix — adopting v1.1.6 keeps framework in
+# version-lockstep with operations + readies the consumer for future
+# push: workflows.
+#
+# Prior @ci/v1.1.5 per IPLAN-0024 (operations PR #145 + aidoc-flow-ci
+# PR #36 + operations P3 PR #148) — replaced cross-repo `actions/
+# checkout` with `curl` for cross-repo rubric/schema/config fetches,
+# eliminating the v1.1.0→v1.1.3 sparse-checkout / clean-flag / INIT-
+# time-content-delete bug class. Framework P4 (PR #183) was the
+# CRITICAL validation on GitHub-hosted runners (ubuntu-latest) — the
+# bug-class home that v1.1.0-v1.1.3 couldn't escape. Per IPLAN-0022
+# PR-C reviewer rubric + schema live at aidoc-flow-ci/ai-review/ (no
+# longer in operations@main); per-consumer config.json still comes
+# from operations@main (transitional; per-consumer-from-each-consumer-
+# repo move tracked as a follow-up IPLAN).
 #
 # Prior @ci/v1.1.3 was — IPLAN-0022 PR-A sparse-checkout pattern hot-fix
 # lineage (aidoc-flow-ci PR #29 + #33; cone-mode → full-clone →
@@ -49,7 +61,7 @@ permissions:
   issues: write          # labels
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/ai-review.yml@ci/v1.1.5
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/ai-review.yml@ci/v1.1.6
     with:
       reviewer: claude
       runner_labels_routine: '"ubuntu-latest"'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,41 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed — `.github/workflows/ai-review.yml`: pin `@ci/v1.1.5` → `@ci/v1.1.6` (auto-merge App-token fix; version-lockstep with operations) (2026-06-27)
+
+- Framework caller pin bumped from `@ci/v1.1.5` to `@ci/v1.1.6` to
+  consume the auto-merge anti-recursion fix shipped on aidoc-flow-ci
+  PR #37. The reusable workflow at `@ci/v1.1.6` authenticates the
+  auto-merge as the reviewer App (`APP_TOKEN`) instead of the default
+  `GITHUB_TOKEN`, so the App-authored merge commit triggers downstream
+  `push:` workflows on every routine auto-merged PR.
+- **Why now (vs deferring):** framework currently has no `push:`
+  workflows that depend on the fix (no docs-sync.yml here yet), so
+  the direct functional impact on framework is minimal. Adopting
+  v1.1.6 keeps framework in version-lockstep with operations (the
+  consumer that DOES depend on the fix) + readies framework for any
+  future push: workflows. Per IPLAN-0024 the consumer-pin-bump
+  discipline is to bump both in close succession to avoid skew.
+- **Graceful fallback in v1.1.6:** if the reviewer App lacks
+  `contents: write`, falls back to `GITHUB_TOKEN` + emits a
+  `::warning::` with exact stderr. PR still merges (no regression).
+- **Backward compatibility:** identical to pre-v1.1.6 behavior on
+  framework today (no push: workflows depending on it). The merge-
+  author change (`github-actions[bot]` → `aidoc-reviewer[bot]`) is
+  visible in `git log` of future auto-merged PRs but otherwise inert
+  for framework.
+- **Plan:** discovered + fixed during IPLAN-0018 docs-sync verification
+  on operations PRs #149 + #150 (operations carries primary tracking).
+  Operations counterpart PR #151. Deeper structural fix is a future
+  AI-driven doc-maintainer IPLAN (formerly TODO matrix row 6, DEFERRED;
+  being promoted to active per founder direction this session).
+- **Chicken-and-egg:** this PR's ai-review fires using BASE main's
+  v1.1.5 workflow (not v1.1.6 yet); its own auto-merge will be by
+  `github-actions[bot]`. Expected. The fix activates for the NEXT
+  auto-merged PR after this one merges (but framework has no push:
+  workflow to make the change observable; verify via merge-author of
+  the next auto-merged PR).
+
 ### Changed — `.github/workflows/ai-review.yml`: pin `@ci/v1.1.3` → `@ci/v1.1.5` (IPLAN-0024 P4 — CRITICAL GitHub-hosted-runner validation) (2026-06-27)
 
 - Framework caller pin bumped from `@ci/v1.1.3` to `@ci/v1.1.5` to


### PR DESCRIPTION
## Summary

Framework caller pin bumped `@ci/v1.1.5` → `@ci/v1.1.6` to consume the auto-merge anti-recursion fix shipped on aidoc-flow-ci PR #37. Same shape as operations counterpart (operations PR #151; both shipped this session to keep consumers in version-lockstep).

## Why now (functional impact is minimal here)

Framework currently has no `push:` workflows that depend on the fix (no docs-sync.yml in framework yet). Adopting v1.1.6 keeps framework in version-lockstep with operations (which DOES depend on the fix) and readies framework for any future push: workflows.

## What v1.1.6 does

The reusable workflow at `@ci/v1.1.6` authenticates the auto-merge as the reviewer App (`APP_TOKEN`) instead of the default `GITHUB_TOKEN`. Per GitHub's documented anti-recursion rule, `GITHUB_TOKEN`-authored merge commits don't trigger downstream `push:` workflows; the App-authored ones do. Graceful fallback to `GITHUB_TOKEN` if the App lacks `contents: write` permission (PR still merges; only push: workflows stay suppressed; operator-visible `::warning::`).

## Chicken-and-egg (expected)

This PR's ai-review fires using BASE main's v1.1.5 workflow (pre-fix); its own auto-merge will be by `github-actions[bot]`. The fix activates for the NEXT auto-merged PR. On framework specifically, this is visible only via the merge-commit author change (`github-actions[bot]` → `aidoc-reviewer[bot]`) since no push: workflows are wired.

## Plan

Discovered + fixed during IPLAN-0018 docs-sync verification on operations PRs #149 + #150 (operations carries primary tracking). Deeper structural fix is a future AI-driven doc-maintainer IPLAN (formerly TODO matrix row 6 in operations HANDOFF, DEFERRED; being promoted to active per founder direction this session).

## Surfaces (Rule 1)

2: `.github/workflows/ai-review.yml` + `CHANGELOG.md`

## Pre-push verification

- ✅ Pre-commit hooks all passed (yamllint, secret-scan, framework/platform conformance suite)
- ✅ Local AI self-review (pre-push hook): Passed
- Adversarial code-reviewer agent skipped (same shape as operations PR #151 which just passed with no findings beyond polish; pattern well-established)