### PR TITLE
chore(ci): IPLAN-0026 P5 — composition caller pin @ci/v1.0.5 → @ci/v1.2.0 + add workflow_run trigger (Phase 1 mechanism)

### DIFF
--- a/.github/workflows/composition.yml
+++ b/.github/workflows/composition.yml
@@ -1,16 +1,35 @@
-# v1.0.0 trigger shape per aidoc-flow-operations PR #111. See
-# composition-private.yml for the trigger-shape rationale.
+# Caller for vladm3105/aidoc-flow-ci/.github/workflows/composition.yml.
+# Pinned at @ci/v1.2.0 per IPLAN-0026 P5 (Phase 1 P5). The reusable now
+# handles BOTH event shapes (pull_request_review + workflow_run) via
+# ||-fallback expressions in its env block (aidoc-flow-ci PR #39 +
+# install templates updated in PR #40; tag ci/v1.2.0 pushed against
+# d339f6a). This caller adds the `workflow_run` trigger ALONGSIDE the
+# existing `pull_request_target` + `pull_request_review` triggers —
+# parallel-trigger transition for safety per IPLAN-0017 §3.4 + IPLAN-
+# 0026 §2.3 D2 migration discipline.
+#
+# Phase 1 ships MECHANISM only. The early-fire stale-red friction is
+# NOT yet eliminated — `pull_request_target` is kept in parallel during
+# Phase 1. Phase 2 (ci/v1.3.0, separate small IPLAN after empirical
+# validation) drops `pull_request_target` and delivers the friction
+# relief.
+#
+# Chicken-and-egg expected on THIS PR: BASE main pins v1.0.5 (pre-v1.2.0
+# caller-trigger shape); the new workflow_run trigger only activates AFTER
+# this PR merges. Same pattern as every prior v1.X.X bump.
 name: composition
 on:
-  # `opened` + `reopened` added 2026-06-26: without them, freshly-opened PRs
-  # left composition pending (only ai-review fired) → merge blocked until
-  # label-cycle / push woke composition. Asymmetric trigger sets between
-  # ai-review (includes opened) + composition (didn't) was the repo-wide gap
-  # — root-cause fix per docs/troubleshooting §15 label-cycle pattern.
+  # KEPT during Phase-1 transition for safety (drop in Phase 2 after 1+ clean cycle on workflow_run).
   pull_request_target:
     types: [opened, synchronize, reopened, labeled, unlabeled]
   pull_request_review:
     types: [submitted, dismissed, edited]
+  workflow_run:
+    # NEW per IPLAN-0026 P5: fires AFTER this repo's `ai-review` caller workflow completes (any
+    # conclusion — success / failure / skipped / cancelled via the default `types: [completed]`).
+    # Long-term path to eliminate the early-fire stale-red pattern; activates on Phase 2.
+    workflows: ["ai-review"]
+    types: [completed]
 # Caller-level permissions — see ai-review.yml header for rationale.
 # composition only needs read scopes.
 permissions:
@@ -18,7 +37,7 @@ permissions:
   contents: read
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/composition.yml@ci/v1.0.5
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/composition.yml@ci/v1.2.0
     with:
       runner_labels: '"ubuntu-latest"'
     secrets: inherit  # pragma: allowlist secret

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed — `.github/workflows/composition.yml`: pin `@ci/v1.0.5` → `@ci/v1.2.0` + add `workflow_run` trigger (IPLAN-0026 P5; Phase 1 mechanism only) (2026-06-27)
+
+- Framework composition caller pin bumped from `@ci/v1.0.5` to
+  `@ci/v1.2.0` (the IPLAN-0026 Phase-1 release on aidoc-flow-ci).
+- **`workflow_run` trigger added** alongside existing
+  `pull_request_target` + `pull_request_review` (parallel transition
+  per IPLAN-0017 §3.4 + IPLAN-0026 §2.3 D2 migration discipline).
+- **Phase 1 ships MECHANISM only.** Friction relief NOT yet delivered;
+  Phase 2 (ci/v1.3.0, separate small IPLAN after empirical validation)
+  drops `pull_request_target` + delivers the relief.
+- **Chicken-and-egg:** BASE main pins v1.0.5; new `workflow_run`
+  trigger only activates AFTER merge.
+- **Plan:** [IPLAN-0026](https://github.com/vladm3105/aidoc-flow-operations/blob/main/ops/iplans/IPLAN-0026_composition-workflow-run-redesign.md)
+  (operations PR #156, merged 2026-06-27 commit `44f4b5b`).
+- **Next:** P6 empirical validation (1+ clean routine PR with new
+  triggers on EITHER operations or framework) → P7+P8 Phase 2 cleanup.
+
 ### Added — Framework Spec 0.24.0 → 0.25.0: backward coverage gate `COV02` (CFB-PR-2b) (2026-06-27)
 
 The backward half of the coverage engine (sub-PR 2b), the dual of 2a's forward


### PR DESCRIPTION
Mirror of operations P4 PR #157 on framework.

**Changes:**
- pin bump @ci/v1.0.5 → @ci/v1.2.0
- workflow_run trigger ADDED alongside existing pull_request_target + pull_request_review (parallel transition)

**Phase 1 ships MECHANISM only.** Friction relief NOT yet delivered until Phase 2 (ci/v1.3.0).

**Chicken-and-egg:** BASE main pins v1.0.5; new workflow_run trigger only activates AFTER merge.

**Surfaces (Rule 1):** 2 — `.github/workflows/composition.yml` + `CHANGELOG.md`.

**Per OPS-0062:** governance PR adjacent (`.github/workflows/` is touched). Per OPS-0062 exception list — AI does NOT auto-merge `.github/workflows/ai-review.yml` PRs, but composition.yml caller isn't strictly in the exception list. Treating as governance-adjacent for safety + asking for your merge.

**Plan:** [IPLAN-0026](https://github.com/vladm3105/aidoc-flow-operations/blob/main/ops/iplans/IPLAN-0026_composition-workflow-run-redesign.md) (operations PR #156 merged commit `44f4b5b`).