### PR TITLE
feat(ci): IPLAN-0026 P8 + IPLAN-0027 P4 — pin callers to @ci/v1.3.0; drop pull_request_target from composition

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,4 +1,30 @@
-# Pinned at @ci/v1.1.6 — adds the auto-merge anti-recursion fix (aidoc-
+# Pinned at @ci/v1.3.0 per IPLAN-0027 P4 (bundled Phase-2 release with
+# IPLAN-0026 P8). v1.3.0's reusable adds an R3 early-exit step at the
+# top of the ai-review job: gh-api queries existing reviews; if the
+# reviewer App has already APPROVED the current HEAD SHA, sets
+# SKIP_REVIEW=1 + SKIP_REASON=r3 via $GITHUB_ENV so downstream heavy
+# steps skip via their existing if: env.SKIP_REVIEW != '1' guards.
+# Saves ~$0.10-0.20 + ~2-3 min per redundant re-fire (typical case:
+# label-cycle-retriggered ai-review after the App had already approved
+# the same HEAD). Fail-OPEN on persistent gh-api failure (7-retry x
+# backoff capped at 20s); HEAD-SHA-tied; INERT when App not armed.
+# Force-fresh-review path (when fresh review needed at the same HEAD):
+# dismiss the App's prior review via gh-api per
+# aidoc-flow-ci/docs/troubleshooting.md §15 (ci/v1.3.0+).
+# Consumer caller shape unchanged — R3 lives entirely inside the
+# reusable; pin bump activates it automatically.
+#
+# Prior @ci/v1.2.0 per IPLAN-0026 P5 — reusable's composition body
+# refactored to handle BOTH event shapes (pull_request_review +
+# workflow_run) via ||-fallback expressions (Phase 1 mechanism).
+#
+# Also inherits @ci/v1.1.7 — defensive `bash -e` + assignment-with-
+# failing-command-substitution guard around the App-token auto-merge
+# `merge_err` capture (aidoc-flow-ci PR #38; surfaced on operations
+# PR #152). Framework was carrying the same latent bug at v1.1.6;
+# the v1.1.6 → v1.3.0 jump silently activates this defensive fix.
+#
+# Prior @ci/v1.1.6 — adds the auto-merge anti-recursion fix (aidoc-
 # flow-ci PR #37). Auto-merge now authenticated as the reviewer App
 # (APP_TOKEN) instead of the default GITHUB_TOKEN, so the App-authored
 # merge commit triggers downstream push: workflows on every routine
@@ -61,7 +87,7 @@ permissions:
   issues: write          # labels
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/ai-review.yml@ci/v1.1.6
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/ai-review.yml@ci/v1.3.0
     with:
       reviewer: claude
       runner_labels_routine: '"ubuntu-latest"'

--- a/.github/workflows/composition.yml
+++ b/.github/workflows/composition.yml
@@ -1,33 +1,31 @@
 # Caller for vladm3105/aidoc-flow-ci/.github/workflows/composition.yml.
-# Pinned at @ci/v1.2.0 per IPLAN-0026 P5 (Phase 1 P5). The reusable now
-# handles BOTH event shapes (pull_request_review + workflow_run) via
-# ||-fallback expressions in its env block (aidoc-flow-ci PR #39 +
-# install templates updated in PR #40; tag ci/v1.2.0 pushed against
-# d339f6a). This caller adds the `workflow_run` trigger ALONGSIDE the
-# existing `pull_request_target` + `pull_request_review` triggers —
-# parallel-trigger transition for safety per IPLAN-0017 §3.4 + IPLAN-
-# 0026 §2.3 D2 migration discipline.
+# Pinned at @ci/v1.3.0 per IPLAN-0026 P8 (Phase 2). The reusable handles
+# BOTH event shapes (pull_request_review + workflow_run) via ||-fallback
+# expressions in its env block (shipped in aidoc-flow-ci PR #39 / v1.2.0).
+# Phase 2 (ci/v1.3.0, aidoc-flow-ci PR #41) drops pull_request_target from
+# the install template; this caller mirrors the drop. Composition now
+# fires only on real state changes:
+#   - pull_request_review (submitted/dismissed/edited): App reviewer's
+#     APPROVED/REQUEST_CHANGES posted at HEAD.
+#   - workflow_run (ai-review completed, any conclusion): the consumer's
+#     ai-review caller workflow finished — success / failure / skipped /
+#     cancelled.
+# No more wasted early-fire `pull_request_target` run on PR open. The
+# stale-red FAILURE that branch-protection's rollup retained until a
+# `skip-ai-review` label-cycle is GONE.
 #
-# Phase 1 ships MECHANISM only. The early-fire stale-red friction is
-# NOT yet eliminated — `pull_request_target` is kept in parallel during
-# Phase 1. Phase 2 (ci/v1.3.0, separate small IPLAN after empirical
-# validation) drops `pull_request_target` and delivers the friction
-# relief.
-#
-# Chicken-and-egg expected on THIS PR: BASE main pins v1.0.5 (pre-v1.2.0
-# caller-trigger shape); the new workflow_run trigger only activates AFTER
-# this PR merges. Same pattern as every prior v1.X.X bump.
+# Force-fresh-review path (when the App approval should be re-evaluated
+# at the same HEAD): dismiss the App's prior review via gh-api per
+# aidoc-flow-ci/docs/troubleshooting.md §15 (ci/v1.3.0+).
 name: composition
 on:
-  # KEPT during Phase-1 transition for safety (drop in Phase 2 after 1+ clean cycle on workflow_run).
-  pull_request_target:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
   pull_request_review:
     types: [submitted, dismissed, edited]
   workflow_run:
-    # NEW per IPLAN-0026 P5: fires AFTER this repo's `ai-review` caller workflow completes (any
-    # conclusion — success / failure / skipped / cancelled via the default `types: [completed]`).
-    # Long-term path to eliminate the early-fire stale-red pattern; activates on Phase 2.
+    # Fires AFTER this repo's `ai-review` caller workflow completes (any
+    # conclusion — success / failure / skipped / cancelled via the default
+    # `types: [completed]`). The load-bearing trigger for Phase-2: every
+    # composition fire is now event-causal from ai-review, not from PR-open.
     workflows: ["ai-review"]
     types: [completed]
 # Caller-level permissions — see ai-review.yml header for rationale.
@@ -37,7 +35,7 @@ permissions:
   contents: read
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/composition.yml@ci/v1.2.0
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/composition.yml@ci/v1.3.0
     with:
       runner_labels: '"ubuntu-latest"'
     secrets: inherit  # pragma: allowlist secret

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,35 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed — CI: pin callers to @ci/v1.3.0; drop pull_request_target from composition (IPLAN-0026 P8 + IPLAN-0027 P4; 2026-06-28)
+
+- **`.github/workflows/composition.yml`** — pin `@ci/v1.2.0` → `@ci/v1.3.0`;
+  trigger set reduced to `pull_request_review` + `workflow_run` only
+  (drop `pull_request_target`). Activates Phase 2's friction-relief benefit
+  on framework: composition no longer early-fires on PR open, and therefore
+  no longer creates the stale-red FAILURE that branch-protection's rollup
+  retained until a `skip-ai-review` label-cycle. Header refreshed
+  (drops Phase-1 chicken-and-egg admission; references new force-fresh path).
+- **`.github/workflows/ai-review.yml`** — pin `@ci/v1.1.6` → `@ci/v1.3.0`.
+  Activates the R3 early-exit step in the v1.3.0 reusable. Saves ~$0.10-
+  0.20 + ~2-3 min per redundant re-fire (label-cycle-retriggered ai-review
+  after the App has already APPROVED at HEAD). Consumer caller shape
+  unchanged.
+- **Bundled release**: ci/v1.3.0 was tagged on aidoc-flow-ci main commit
+  `3dcb0e8` after PRs #41 (IPLAN-0026 P7) + #42 (IPLAN-0027 P1) merged
+  earlier today. This framework PR is the public-runner activation of
+  both benefits in a single pin-bump cycle (operations PR #163 is the
+  self-hosted-runner activation).
+- **Chicken-and-egg on THIS PR**: BASE main's composition.yml caller
+  still has `pull_request_target` (Phase-1 parallel-trigger shape), so
+  this PR fires under the old triggers. After merge, every subsequent
+  framework PR uses the post-v1.3.0 trigger set (no `pull_request_target`
+  on composition). Same pattern as every prior v1.X.X bump per
+  IPLAN-0026 §3 P4/P5.
+- **Plans (in `aidoc-flow-operations`):**
+  `ops/iplans/IPLAN-0026_composition-workflow-run-redesign.md` P8 +
+  `ops/iplans/IPLAN-0027_r3-ai-review-early-exit.md` P4.
+
 ### Added — Framework Spec 0.26.0 → 0.27.0: REFGRAN01 ref-granularity enforcement (CFB-PR-3) (2026-06-27)
 
 Enforces GD-03 (0.26.0): the deterministic lint that makes the coverage engine


### PR DESCRIPTION
## Summary

Framework-side activation of the bundled **ci/v1.3.0** release (tag pushed on aidoc-flow-ci main `3dcb0e8` after PRs [#41](https://github.com/vladm3105/aidoc-flow-ci/pull/41) (IPLAN-0026 P7) and [#42](https://github.com/vladm3105/aidoc-flow-ci/pull/42) (IPLAN-0027 P1) both merged earlier today). Public-runner (ubuntu-latest) consumer counterpart to operations [PR #163](https://github.com/vladm3105/aidoc-flow-operations/pull/163).

- **IPLAN-0026 P8** — drop `pull_request_target` from framework's composition caller + pin bump. Composition no longer early-fires on PR open, and therefore no longer creates the stale-red FAILURE that branch-protection's rollup retained until a `skip-ai-review` label-cycle.
- **IPLAN-0027 P4** — pin-bump ai-review caller (v1.1.6 → v1.3.0). Activates the R3 early-exit step + silently inherits the v1.1.7 defensive `bash -e` guard. Saves ~$0.10–0.20 + ~2–3 min per redundant re-fire when the App has already APPROVED at HEAD.

## Surfaces (3 — within governance Rule 1 ≤3 cap)

- `.github/workflows/composition.yml`: pin `@ci/v1.2.0` → `@ci/v1.3.0`; trigger set reduced to `pull_request_review` + `workflow_run` (drop `pull_request_target`); header refreshed.
- `.github/workflows/ai-review.yml`: pin `@ci/v1.1.6` → `@ci/v1.3.0`; header chronology refreshed (acknowledges v1.1.7 defensive fix inheritance, v1.2.0 composition body refactor, v1.3.0 R3 step).
- `CHANGELOG.md`: bundled-release entry.

HANDOFF refresh deliberately omitted to stay within the 3-surface cap.

## Governance PR — no auto-merge

Per framework's CLAUDE.md OPS-0062 exception, AI does NOT auto-merge PRs touching `.github/workflows/ai-review.yml`. **This PR awaits founder approval.**

## Chicken-and-egg expected on THIS PR

BASE main's composition.yml caller still has `pull_request_target` (Phase-1 parallel-trigger shape), so this PR's CI fires under the old trigger set. After merge, every subsequent framework PR uses the post-v1.3.0 trigger set. Same pattern as every prior v1.X.X bump per IPLAN-0026 §3 P4/P5.

## Self-review

Pre-push code-reviewer agent dispatched: **APPROVE**.
- MEDIUM-1: header chronology omitted v1.1.7 inheritance — folded inline.
- LOW-1: CHANGELOG grammar polish — folded inline.

## Plans

- `aidoc-flow-operations/ops/iplans/IPLAN-0026_composition-workflow-run-redesign.md` P8
- `aidoc-flow-operations/ops/iplans/IPLAN-0027_r3-ai-review-early-exit.md` P4

## Test plan

- [ ] Required checks green (ai-review, composition, links, markdown-lint, etc.).
- [ ] Chicken-and-egg observed once on this PR's open (last PR with mixed Phase-1/Phase-2 triggers).
- [ ] After merge: composition no longer fires on PR open; fires only via `workflow_run` after ai-review completes / on `pull_request_review`.
- [ ] R3 early-exit notice on label-cycle-retriggered ai-review of an already-approved PR.