### PR TITLE
feat(tools): YAML-BDD-SCHEMA PR-1 — _THRESHOLD quote-fix + Gherkin→YAML transcoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,30 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added — YAML-BDD-SCHEMA PR-1: `_THRESHOLD` quote-fix + Gherkin→YAML transcoder (2026-06-28)
+
+First implementation increment of the merged YAML-BDD-SCHEMA design
+(`plans/YAML-BDD-SCHEMA-PLAN.md`, PR #197 / D-0038). Migrates BDD scenarios
+toward a structured YAML block; this PR ships the two self-contained pieces.
+
+- **`tools/sdd_doc_lint` `_THRESHOLD` regex** — tightened
+  `@threshold:\s*([^\s|]+)` → `([^\s|'"]+)` so an inline `@threshold:` ending a
+  quoted YAML scalar (`'… @threshold:PRD.01.x'`) no longer glues the closing
+  quote into the value and false-fires **TH01** (YAML-BDD-SCHEMA Pass-2 LB-1).
+  All-layer + regression-free (threshold values never contain quotes; corpus
+  verified). Re-vendored byte-identical to both platform copies.
+- **`tools/gherkin_to_bdd_yaml.py`** — new one-time migration transcoder
+  (YAML-BDD-SCHEMA D-6). Parses a BDD doc's embedded Gherkin
+  (feature/background/scenario outline/examples/multi-step/inline-threshold/
+  `#` comments) into the structured YAML scenario model, **copying each
+  `@scenario-id:` verbatim into `id:`** so the 16 downstream `@bdd:` citations
+  stay stable. `# spec_trace:` → `spec_trace:`, other `#` comments → `notes:`.
+- **Tests:** `tests/unit/test_threshold_quoted_scalar.py` (3),
+  `tests/unit/test_gherkin_to_bdd_yaml.py` (6). Suite green (130 unit / 148
+  conformance); example corpus unchanged vs baseline.
+- **Continuity:** `plans/DECISIONS.md` D-0038 (plan D-1…D-6);
+  `plans/HANDOFF.md` resume banner (PR-2 = the linter dual-mode fork is next).
+
 ### Changed — CI: pin callers to @ci/v1.3.0; drop pull_request_target from composition (IPLAN-0026 P8 + IPLAN-0027 P4; 2026-06-28)
 
 - **`.github/workflows/composition.yml`** — pin `@ci/v1.2.0` → `@ci/v1.3.0`;

--- a/plans/DECISIONS.md
+++ b/plans/DECISIONS.md
@@ -10,6 +10,39 @@ graduation.
 
 ---
 
+## D-0038 — YAML-native BDD scenarios replace Gherkin-in-markdown (YAML-BDD-SCHEMA, plan D-1…D-6)
+
+- **Date:** 2026-06-28T00:00:00Z
+- **Decision:** Migrate the BDD layer's produced artifact from Gherkin-embedded-
+  in-markdown to a structured **YAML scenarios block inside `BDD-NN.md`**. The
+  plan-local decisions (`plans/YAML-BDD-SCHEMA-PLAN.md`):
+  - **D-1 Carrier** — a fenced ` ```yaml ` block in §2/§3 of `BDD-NN.md`; the
+    doc stays markdown with the five `##` sections (STRUCT01 unchanged).
+  - **D-2 Step model** — `given/when/then` phase lists; thresholds stay **inline
+    `@threshold:` in step prose** (a bare `threshold:` field would fire ID03 and
+    bypass TH-RES-001). Requires the `_THRESHOLD` regex to exclude trailing
+    quotes (`([^\s|'"]+)`).
+  - **D-3 Coverage** — the Feature carries **no `ears`**; coverage = union of
+    scenario `ears` (kills the CFB-PR-3 fan-out).
+  - **D-4 Emitter** — on-demand, one-way `tools/bdd_to_gherkin.py` (git-ignored
+    output); these docs are QA-staging-only, not CI-executed.
+  - **D-5 Scope** — plugin skills/engine; Hermes skills/engine deferred; the
+    shared linter code still ships to the Hermes vendored copy (byte-identity).
+  - **D-6 Migration** — a deterministic `tools/gherkin_to_bdd_yaml.py` transcoder
+    (framework tool) that **copies each `@scenario-id:` verbatim** into `id:`,
+    keeping all 16 downstream `@bdd:` citations stable. NOT an LLM regeneration
+    (which would drift the content-hash IDs and break downstream).
+- **Why:** GD-03 mandates pipe-delimited multi-element trace tags, but `|` is
+  Gherkin's table delimiter and Gherkin tags cannot contain whitespace — so the
+  GD-03 form is physically illegal on a Gherkin tag line. Carrying trace as typed
+  YAML fields removes the collision at the root, makes REFGRAN a structural
+  check, and turns element-level COV02 into a direct set computation. The
+  framework is pre-1.0, so realigning the artifact with its own template's
+  already-YAML scenario model is low-cost.
+- **Review:** converged over 3 independent fresh-context passes (Pass 1: 10 gaps;
+  Pass 2: 3 load-bearing + 5 minor; Pass 3: READY). Plan PR #197 merged
+  (`dfb57309`, 2026-06-28). Implementation is a ~6–8 PR sequence.
+
 ## D-0037 — `realized_by` escape authored as an inline FR-bullet token (CFB-PR-2 DD-5)
 
 - **Date:** 2026-06-27T00:00:00Z

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -1,5 +1,62 @@
 # Session Handoff
 
+> **🟢 YAML-BDD-SCHEMA plan MERGED — implementation starting (2026-06-28). `main`
+> at `dfb57309`.**
+>
+> A new design-of-record landed: **`plans/YAML-BDD-SCHEMA-PLAN.md`** (PR #197,
+> `dfb57309`) — migrate BDD scenarios from Gherkin-in-markdown to a structured
+> **YAML scenarios block inside `BDD-NN.md`** + an on-demand YAML→Gherkin
+> emitter. Converged over 3 independent gap-review passes; decision logged as
+> **D-0038** (plan D-1…D-6). This supersedes the BDD portion of
+> CFB-PR-3's REFGRAN fan-out — the Gherkin/GD-03 tag collision is dissolved at
+> the root (typed `ears` lists, no delimiter), feature coverage = union of
+> scenario `ears` (no fan-out), and it sets up the element-level COV02 upgrade.
+>
+> **▶ RESUME HERE — implementation is a ~7 PR sequence:**
+>
+> 1. ✅ **PR-1 (SHIPPED this session) — `_THRESHOLD` fix + transcoder.** The two
+>    self-contained, fully-verified pieces:
+>    (a) `_THRESHOLD` regex tightened to `([^\s|'"]+)` so an inline `@threshold:`
+>    ending a quoted YAML scalar doesn't false-fire TH01 (Pass-2 LB-1; all-layer,
+>    regression-free — verified zero quote-adjacent thresholds in the corpus).
+>    Vendored byte-identical to both platform copies. `tests/unit/test_threshold_quoted_scalar.py`.
+>    (b) `tools/gherkin_to_bdd_yaml.py` transcoder — parses the corpus's Gherkin
+>    constructs (feature/background/outline/examples/multi-step/inline-threshold/
+>    comments) and copies each `@scenario-id:` **verbatim** into `id:` (keeps the
+>    16 downstream `@bdd:` citations stable). `tests/unit/test_gherkin_to_bdd_yaml.py`.
+>    Suite green: 130 unit + 148 conformance; corpus == baseline.
+> 2. **PR-2 (NEXT — the big one) — `sdd_doc_lint` dual-mode BDD parse path.** When
+>    a `scenarios:` YAML block is present, parse it (synthetic **verbatim** `ears`
+>    edges in `build_edge_graph` → REFGRAN/COV01/COV02/TRACE-RES/TAG01; new
+>    `BDD-SCHEMA-001` structural check, structural-only — REFGRAN owns `ears`
+>    granularity, no double-report); else fall back to the legacy `@`-tag path so
+>    the still-Gherkin corpus stays green. Update `test_coverage_engine.py` +
+>    `test_ref_granularity.py` BDD fixtures to the YAML form. (Plan §"Linter
+>    changes" items 1-5 + the Pass-3 `cited_doc = doc_id_from_token` note.)
+> 3. **PR-3** template+schema (`BDD-TEMPLATE.yaml` category-dict → flat list +
+>    `BDD-00_index.TEMPLATE.md`).
+> 4. **PR-4** corpus + the 7 `BDD-01_golden` acceptance fixtures migration (run
+>    the PR-1 transcoder; `missing_section.md` is no-Gherkin/verify-only;
+>    `drift_codes.yaml` verify-only). Verify V4 ID-stability + V11 corpus.
+> 5. **PR-5** `doc-bdd*` skills rewrite (keep `test_skill_template_alignment` /
+>    `plm_lint` / `test_autopilot_saga_parity` green).
+> 6. **PR-6** governance docs (GD-03 note, `TAG_SYNTAX.md` BDD row,
+>    `QUICK_REFERENCE`, 04_BDD playbooks).
+> 7. **PR-7** framework MINOR version bump + re-vendor (incl. Hermes copy) +
+>    docs-of-record (CHANGELOG/ROADMAP/PARITY/README).
+>
+> **How to resume:** read this banner + `plans/YAML-BDD-SCHEMA-PLAN.md` (D-1…D-6,
+> the schema, the 5-function linter-fork contract, V1–V11). Linter lives in
+> `tools/sdd_doc_lint/__init__.py`; transcoder/emitter go in `tools/`; tests in
+> `tests/unit/`. Corpus baseline for the V11 cross-check: 1× TH-RES-001, 7×
+> REFGRAN01, 6× STY02 on `main`.
+>
+> **Note:** YAML-BDD resolves the **2 BDD** REFGRAN edges; the **5
+> SPEC/TDD/IPLAN `@adr`/`@tdd`** edges remain `CORPUS-REFGRAN-RECASCADE`'s job
+> (still open in `FRAMEWORK-TODO.md`).
+
+---
+
 > **🟢 CFB-PR-2 coverage engine — FULL ARC SHIPPED + MERGED (2026-06-27). `main`
 > is clean at framework spec `0.27.0`.**
 >

--- a/platforms/claude-code-plugin/sdd_doc_lint/__init__.py
+++ b/platforms/claude-code-plugin/sdd_doc_lint/__init__.py
@@ -63,7 +63,12 @@ def find_registry(start: Path | None = None) -> Path:
 LAYER_TAGS = ("brd", "prd", "ears", "bdd", "adr", "spec", "tdd", "iplan")
 
 _TAG = re.compile(r"@(" + "|".join(LAYER_TAGS) + r")\s*:\s*([^\s|]+)")
-_THRESHOLD = re.compile(r"@threshold:\s*([^\s|]+)")
+#: A `@threshold:` value terminates on whitespace, a pipe, OR a quote — the
+#: quote-exclusion (YAML-BDD-SCHEMA Pass-2 LB-1) keeps the capture clean when an
+#: inline `@threshold:` ends a quoted YAML scalar (`'… @threshold:PRD.01.x'`),
+#: which would otherwise glom the closing quote into the value and false-fire
+#: TH01. All-layer + regression-free: threshold values never contain quotes.
+_THRESHOLD = re.compile(r"@threshold:\s*([^\s|'\"]+)")
 _THEN_CONNECTIVE = re.compile(r"THEN\s*\[")
 _PLACEHOLDERS = [
     re.compile(r"\bTBD\b"),

--- a/platforms/hermes/sdd_doc_lint/__init__.py
+++ b/platforms/hermes/sdd_doc_lint/__init__.py
@@ -63,7 +63,12 @@ def find_registry(start: Path | None = None) -> Path:
 LAYER_TAGS = ("brd", "prd", "ears", "bdd", "adr", "spec", "tdd", "iplan")
 
 _TAG = re.compile(r"@(" + "|".join(LAYER_TAGS) + r")\s*:\s*([^\s|]+)")
-_THRESHOLD = re.compile(r"@threshold:\s*([^\s|]+)")
+#: A `@threshold:` value terminates on whitespace, a pipe, OR a quote — the
+#: quote-exclusion (YAML-BDD-SCHEMA Pass-2 LB-1) keeps the capture clean when an
+#: inline `@threshold:` ends a quoted YAML scalar (`'… @threshold:PRD.01.x'`),
+#: which would otherwise glom the closing quote into the value and false-fire
+#: TH01. All-layer + regression-free: threshold values never contain quotes.
+_THRESHOLD = re.compile(r"@threshold:\s*([^\s|'\"]+)")
 _THEN_CONNECTIVE = re.compile(r"THEN\s*\[")
 _PLACEHOLDERS = [
     re.compile(r"\bTBD\b"),

--- a/tests/unit/test_gherkin_to_bdd_yaml.py
+++ b/tests/unit/test_gherkin_to_bdd_yaml.py
@@ -1,0 +1,116 @@
+"""Unit: the Gherkin→YAML BDD transcoder (YAML-BDD-SCHEMA D-6).
+
+Verifies the parser/emitter engine handles the corpus's Gherkin constructs and —
+the load-bearing contract (Pass-2 LB-2) — copies each ``@scenario-id:`` VERBATIM
+into ``id:`` so downstream ``@bdd:`` citations stay stable.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+
+import yaml  # noqa: E402
+from gherkin_to_bdd_yaml import (  # noqa: E402
+    parse_gherkin_feature,
+    render_scenarios_yaml,
+    transcode_markdown,
+)
+
+GHERKIN = """\
+@ears:EARS-01 @bdd:BDD-01 @qa-staging-only
+Feature: URL Shortener acceptance behaviour
+  As a Link Submitter
+  I want to shorten public URLs
+  So that long links become compact
+
+  Background:
+    Given the system is in a ready state
+    And the current time is "09:30:00" in "America/New_York"
+
+@scenario-type:success @p0-critical @scenario-id:BDD.01.03.ccd6
+@ears:EARS.01.03.5066 @ears:EARS.01.03.bca8
+Scenario: Shorten a valid public URL
+  Given a Link Submitter with the URL "https://example.com/page"
+  When the submitter posts the URL to the API
+  Then the API SHALL return a short code WITHIN @threshold:PRD.01.perf.screeningdeadline
+  And the API SHALL present "Your short link is ready."
+  # spec_trace: SPEC §3 (Interfaces), SPEC §5 (Behavior)
+  # split from the former combined scenario
+
+@scenario-type:parameterized @p2-medium @scenario-id:BDD.01.03.abcd
+@ears:EARS.01.03.4400
+Scenario Outline: Validation accepts valid <input_type>
+  Given a valid <input_type> value "<value>"
+  When the value is validated
+  Then validation SHALL pass
+
+  Examples:
+    | input_type | value            |
+    | email      | user@example.com |
+    | phone      | +1-555-123-4567  |
+"""
+
+
+class TranscoderEngine(unittest.TestCase):
+    def setUp(self) -> None:
+        self.parsed = parse_gherkin_feature(GHERKIN)
+        self.scn = {s["id"]: s for s in self.parsed["scenarios"]}
+
+    def test_feature_name_description_background(self) -> None:
+        f = self.parsed["feature"]
+        self.assertEqual(f["name"], "URL Shortener acceptance behaviour")
+        self.assertIn("As a Link Submitter", f["description"])
+        self.assertEqual(len(f["background"]["steps"]), 2)
+        # Feature carries NO ears (D-3 — coverage = union of scenarios).
+        self.assertNotIn("ears", f)
+        self.assertEqual(f.get("tags"), ["@qa-staging-only"])
+
+    def test_scenario_id_copied_verbatim(self) -> None:
+        # The load-bearing contract: ids match the source @scenario-id exactly.
+        self.assertEqual(set(self.scn), {"BDD.01.03.ccd6", "BDD.01.03.abcd"})
+
+    def test_success_scenario_fields(self) -> None:
+        s = self.scn["BDD.01.03.ccd6"]
+        self.assertEqual(s["type"], "success")
+        self.assertEqual(s["priority"], "p0-critical")
+        self.assertEqual(s["ears"], ["EARS.01.03.5066", "EARS.01.03.bca8"])
+        self.assertEqual(len(s["given"]), 1)
+        self.assertEqual(len(s["when"]), 1)
+        self.assertEqual(len(s["then"]), 2)  # Then + And
+        self.assertIn("@threshold:PRD.01.perf.screeningdeadline", s["then"][0])
+        self.assertEqual(s["spec_trace"], ["SPEC §3 (Interfaces), SPEC §5 (Behavior)"])
+        self.assertEqual(s["notes"], ["split from the former combined scenario"])
+
+    def test_outline_examples(self) -> None:
+        s = self.scn["BDD.01.03.abcd"]
+        self.assertTrue(s.get("outline"))
+        self.assertEqual(s["examples"]["headers"], ["input_type", "value"])
+        self.assertEqual(len(s["examples"]["rows"]), 2)
+        self.assertEqual(s["examples"]["rows"][0], ["email", "user@example.com"])
+
+    def test_render_is_valid_yaml_roundtrip(self) -> None:
+        out = render_scenarios_yaml(self.parsed["scenarios"])
+        reloaded = yaml.safe_load(out)["scenarios"]
+        self.assertEqual(reloaded[0]["id"], "BDD.01.03.ccd6")
+        self.assertEqual(reloaded[1]["examples"]["headers"], ["input_type", "value"])
+
+    def test_transcode_markdown_replaces_fence(self) -> None:
+        md = (
+            "---\ndoc_id: BDD-01\nartifact_type: BDD\n---\n\n## 3. Scenarios\n\n```gherkin\n"
+            + GHERKIN
+            + "\n```\n"
+        )
+        out = transcode_markdown(md)
+        self.assertNotIn("```gherkin", out)
+        self.assertIn("```yaml", out)
+        self.assertIn("BDD.01.03.ccd6", out)
+        # downstream-citation stability: the id survives the transcode verbatim.
+        self.assertIn("id: BDD.01.03.ccd6", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_threshold_quoted_scalar.py
+++ b/tests/unit/test_threshold_quoted_scalar.py
@@ -1,0 +1,60 @@
+"""Unit: an inline ``@threshold:`` that ends a quoted YAML scalar must NOT
+false-fire TH01 (YAML-BDD-SCHEMA Pass-2 LB-1).
+
+When BDD scenarios move into a ``​```yaml`` block, a step is a quoted scalar
+and a trailing ``@threshold:`` sits right before the closing ``'``/``"``. The
+``_THRESHOLD`` capture must stop before that quote so the threshold token stays
+well-formed (else the quote is glommed into the value and TH01 fires).
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+# Resolve sdd_doc_lint to the canonical tools/ copy.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+
+from sdd_doc_lint import (  # noqa: E402
+    _THRESHOLD,
+    _THRESHOLD_FORM,
+    _load_registry,
+    lint_text,
+)
+
+
+class ThresholdQuotedScalar(unittest.TestCase):
+    def test_capture_excludes_trailing_quote(self) -> None:
+        for line in (
+            "  - 'the API SHALL redirect WITHIN @threshold:PRD.01.perf.redirectp95'",
+            '  - "the API SHALL redirect WITHIN @threshold:PRD.01.perf.redirectp95"',
+        ):
+            m = _THRESHOLD.search(line)
+            self.assertIsNotNone(m, line)
+            self.assertEqual(m.group(1), "PRD.01.perf.redirectp95", line)
+            self.assertTrue(_THRESHOLD_FORM.match(m.group(1)), line)
+
+    def test_mid_scalar_threshold_still_captured(self) -> None:
+        # A threshold not at the quote boundary must remain unaffected.
+        line = "  - 'within @threshold:PRD.01.rate.window per second'"
+        m = _THRESHOLD.search(line)
+        self.assertIsNotNone(m)
+        self.assertEqual(m.group(1), "PRD.01.rate.window")
+
+    def test_no_th01_on_quoted_scalar_threshold(self) -> None:
+        layers, doc_re, elem_re = _load_registry(None)
+        text = (
+            "---\ndoc_id: BDD-01\nartifact_type: BDD\n---\n\n"
+            "```yaml\n"
+            "scenarios:\n"
+            "  then:\n"
+            "    - 'the API SHALL redirect WITHIN @threshold:PRD.01.perf.redirectp95'\n"
+            "```\n"
+        )
+        findings = lint_text(text, "BDD", "BDD-01.md", layers, doc_re, elem_re)
+        self.assertEqual([f for f in findings if f.code == "TH01"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/gherkin_to_bdd_yaml.py
+++ b/tools/gherkin_to_bdd_yaml.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""gherkin_to_bdd_yaml — one-time migration transcoder (YAML-BDD-SCHEMA D-6).
+
+Parse a BDD doc's embedded Gherkin (``​```gherkin`` fences) into the structured
+YAML scenario model (plan §Schema) and rewrite §2 Feature Definition + §3
+Scenario Structure to carry ``​```yaml`` blocks instead.
+
+**ID stability is the contract (Pass-2 LB-2):** each scenario's existing
+``@scenario-id:`` value is copied **verbatim** into the YAML ``id:`` field — the
+content hash is never recomputed — so every downstream ``@bdd:`` citation keeps
+resolving. ``name``/steps are carried for fidelity but are not what stabilises
+the ID.
+
+Lossy only on cosmetics: ``#`` comments are lifted into ``spec_trace:`` (for
+``# spec_trace:`` lines) / ``notes:`` (everything else); exact whitespace is not
+preserved. Pure stdlib + PyYAML (already a linter dependency).
+
+This is the parser/emitter engine + a CLI. The engine
+(``parse_gherkin_feature`` / ``render_scenarios_yaml``) is what the unit tests
+exercise; the CLI ``transcode_markdown`` does the §2/§3 in-place rewrite for the
+corpus migration (PR-3).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+# --- Gherkin token patterns ---------------------------------------------------
+_SCENARIO_ID = re.compile(r"@scenario-id:\s*(BDD\.\d+\.\d+\.[a-z0-9]+)")
+_SCENARIO_TYPE = re.compile(r"@scenario-type:\s*([a-z]+)")
+_PRIORITY = re.compile(r"@(p\d-[a-z]+)")
+_EARS = re.compile(r"@ears:\s*(EARS\.\d+\.\d+\.[a-z0-9]+)")
+_STEP = re.compile(r"^\s*(Given|When|Then|And|But)\s+(.*\S)\s*$")
+_SCENARIO = re.compile(r"^\s*(Scenario Outline|Scenario):\s*(.*\S)\s*$")
+_SPEC_TRACE_C = re.compile(r"^\s*#\s*spec_trace:\s*(.*\S)\s*$")
+_COMMENT = re.compile(r"^\s*#\s*(.*\S)\s*$")
+_EXAMPLES = re.compile(r"^\s*Examples:\s*$")
+_TABLE_ROW = re.compile(r"^\s*\|(.+)\|\s*$")
+_PHASE = {"Given": "given", "When": "when", "Then": "then"}
+
+
+def _table_cells(line: str) -> list[str]:
+    return [c.strip() for c in _TABLE_ROW.match(line).group(1).split("|")]
+
+
+def parse_gherkin_feature(gherkin: str) -> dict:
+    """Parse one Gherkin feature block into the YAML scenario model.
+
+    Returns ``{"feature": {...}, "scenarios": [...]}``. Scenario IDs are taken
+    verbatim from ``@scenario-id:`` (never recomputed).
+    """
+    feature: dict = {}
+    scenarios: list[dict] = []
+    pending_tags: list[str] = []  # raw tag-line text awaiting the next Scenario
+    desc_lines: list[str] = []
+    cur: dict | None = None
+    phase: str | None = None
+    in_examples = False
+    ex_headers: list[str] | None = None
+    section = "preamble"  # preamble | feature | background | scenario
+
+    def flush_scenario() -> None:
+        nonlocal cur
+        if cur is not None:
+            scenarios.append(cur)
+            cur = None
+
+    for raw in gherkin.splitlines():
+        line = raw.rstrip()
+        if not line.strip():
+            continue
+
+        if line.lstrip().startswith("Feature:"):
+            feature["name"] = line.split("Feature:", 1)[1].strip()
+            # feature-level tags (no element @ears per D-3): keep runner tags only
+            runner = [t for t in pending_tags if not t.startswith(("@ears", "@bdd"))]
+            if runner:
+                feature["tags"] = runner
+            pending_tags = []
+            section = "feature"
+            continue
+
+        if line.lstrip().startswith("Background:"):
+            flush_scenario()
+            feature.setdefault("background", {"steps": []})
+            section = "background"
+            phase = None
+            continue
+
+        m_scn = _SCENARIO.match(line)
+        if m_scn:
+            flush_scenario()
+            cur = {
+                "id": _first(_SCENARIO_ID, pending_tags),
+                "name": m_scn.group(2),
+                "type": _first(_SCENARIO_TYPE, pending_tags) or "success",
+                "priority": _first(_PRIORITY, pending_tags) or "p2-medium",
+                "ears": _all(_EARS, pending_tags),
+            }
+            if m_scn.group(1) == "Scenario Outline":
+                cur["outline"] = True
+            pending_tags = []
+            section = "scenario"
+            phase = None
+            in_examples = False
+            ex_headers = None
+            continue
+
+        if _TAGLINE_OK(line) and section in ("preamble", "feature", "scenario", "background"):
+            # A tag line precedes a Feature/Scenario. Buffer raw tag tokens.
+            if line.lstrip().startswith("@"):
+                pending_tags.extend(line.split())  # one entry per @-token
+                continue
+
+        # Example tables (scenario outline).
+        if cur is not None and _EXAMPLES.match(line):
+            in_examples = True
+            cur["examples"] = {"headers": [], "rows": []}
+            continue
+        if cur is not None and in_examples and _TABLE_ROW.match(line):
+            cells = _table_cells(line)
+            if ex_headers is None:
+                ex_headers = cells
+                cur["examples"]["headers"] = cells
+            else:
+                cur["examples"]["rows"].append(cells)
+            continue
+
+        # Comments → spec_trace / notes (scenario scope).
+        if cur is not None and _SPEC_TRACE_C.match(line):
+            cur.setdefault("spec_trace", []).append(_SPEC_TRACE_C.match(line).group(1))
+            continue
+        if cur is not None and _COMMENT.match(line):
+            cur.setdefault("notes", []).append(_COMMENT.match(line).group(1))
+            continue
+
+        # Steps.
+        m_step = _STEP.match(line)
+        if m_step:
+            kw, text = m_step.group(1), m_step.group(2)
+            if kw in _PHASE:
+                phase = _PHASE[kw]
+            if section == "background":
+                feature["background"]["steps"].append(text)
+            elif cur is not None and phase:
+                cur.setdefault(phase, []).append(text)
+            continue
+
+        # Feature narrative (As a / I want / So that).
+        if section == "feature":
+            desc_lines.append(line.strip())
+
+    flush_scenario()
+    if desc_lines:
+        feature["description"] = "\n".join(desc_lines)
+    return {"feature": feature, "scenarios": scenarios}
+
+
+def _TAGLINE_OK(line: str) -> bool:
+    return line.lstrip().startswith("@")
+
+
+def _first(pat: re.Pattern, tags: list[str]) -> str | None:
+    for t in tags:
+        m = pat.search(t)
+        if m:
+            return m.group(1)
+    return None
+
+
+def _all(pat: re.Pattern, tags: list[str]) -> list[str]:
+    out: list[str] = []
+    for t in tags:
+        out.extend(m.group(1) for m in pat.finditer(t))
+    return out
+
+
+def render_scenarios_yaml(scenarios: list[dict]) -> str:
+    """Deterministic YAML for the ``scenarios:`` block (field order preserved)."""
+    return yaml.safe_dump({"scenarios": scenarios}, sort_keys=False, allow_unicode=True, width=100)
+
+
+def render_feature_yaml(feature: dict) -> str:
+    return yaml.safe_dump({"feature": feature}, sort_keys=False, allow_unicode=True, width=100)
+
+
+def transcode_markdown(md_text: str) -> str:
+    """Rewrite a BDD doc's ``​```gherkin`` block(s) into ``​```yaml`` feature +
+    scenarios blocks. Non-Gherkin content is preserved verbatim."""
+    fence = re.compile(r"```gherkin\n(.*?)\n```", re.DOTALL)
+    blocks = fence.findall(md_text)
+    if not blocks:
+        return md_text
+    parsed = parse_gherkin_feature("\n\n".join(blocks))
+    feature_yaml = "```yaml\n" + render_feature_yaml(parsed["feature"]) + "```"
+    scenarios_yaml = "```yaml\n" + render_scenarios_yaml(parsed["scenarios"]) + "```"
+
+    first = True
+
+    def _replace(_m: re.Match) -> str:
+        nonlocal first
+        if first:
+            first = False
+            return feature_yaml + "\n\n" + scenarios_yaml
+        return ""  # subsequent gherkin blocks folded into the first
+
+    return fence.sub(_replace, md_text)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = argv if argv is not None else sys.argv[1:]
+    if not args:
+        print("usage: gherkin_to_bdd_yaml.py <BDD-NN.md> [--in-place]", file=sys.stderr)
+        return 2
+    path = Path(args[0])
+    out = transcode_markdown(path.read_text(encoding="utf-8"))
+    if "--in-place" in args:
+        path.write_text(out, encoding="utf-8")
+    else:
+        sys.stdout.write(out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/sdd_doc_lint/__init__.py
+++ b/tools/sdd_doc_lint/__init__.py
@@ -63,7 +63,12 @@ def find_registry(start: Path | None = None) -> Path:
 LAYER_TAGS = ("brd", "prd", "ears", "bdd", "adr", "spec", "tdd", "iplan")
 
 _TAG = re.compile(r"@(" + "|".join(LAYER_TAGS) + r")\s*:\s*([^\s|]+)")
-_THRESHOLD = re.compile(r"@threshold:\s*([^\s|]+)")
+#: A `@threshold:` value terminates on whitespace, a pipe, OR a quote — the
+#: quote-exclusion (YAML-BDD-SCHEMA Pass-2 LB-1) keeps the capture clean when an
+#: inline `@threshold:` ends a quoted YAML scalar (`'… @threshold:PRD.01.x'`),
+#: which would otherwise glom the closing quote into the value and false-fire
+#: TH01. All-layer + regression-free: threshold values never contain quotes.
+_THRESHOLD = re.compile(r"@threshold:\s*([^\s|'\"]+)")
 _THEN_CONNECTIVE = re.compile(r"THEN\s*\[")
 _PLACEHOLDERS = [
     re.compile(r"\bTBD\b"),


### PR DESCRIPTION
## Summary

First implementation increment of the merged **YAML-BDD-SCHEMA** design (`plans/YAML-BDD-SCHEMA-PLAN.md`, PR #197 / decision D-0038). Ships the two self-contained, fully-verified pieces of PR-1; the larger `sdd_doc_lint` dual-mode BDD parse-path fork is split into **PR-2**.

## Changes

- **`_THRESHOLD` regex quote-fix** (`tools/sdd_doc_lint/__init__.py`) — tightened `@threshold:\s*([^\s|]+)` → `([^\s|'"]+)` so an inline `@threshold:` ending a quoted YAML scalar (`'… @threshold:PRD.01.x'`) no longer glues the closing quote into the value and **false-fires TH01** (Pass-2 finding LB-1). All-layer, regression-free (threshold values never contain quotes; corpus verified). Re-vendored **byte-identical** into both platform copies.
- **`tools/gherkin_to_bdd_yaml.py`** — new one-time migration transcoder (decision D-6). Parses the corpus's Gherkin constructs (feature / background / scenario outline + examples / multi-step / inline-threshold / `#` comments) into the structured YAML scenario model, **copying each `@scenario-id:` verbatim into `id:`** so the 16 downstream `@bdd:` citations stay stable. `# spec_trace:` → `spec_trace:`; other comments → `notes:`.
- **Tests:** `tests/unit/test_threshold_quoted_scalar.py` (3, incl. the RED→GREEN LB-1 reproduction), `tests/unit/test_gherkin_to_bdd_yaml.py` (6).
- **Docs of record:** `CHANGELOG.md`, `plans/DECISIONS.md` (D-0038), `plans/HANDOFF.md` (resume banner → PR-2 next).

## Verification

- `tests/unit/` — **130 passed** (+211 subtests).
- `tests/conformance/` — **148 passed** (+636 subtests); vendored byte-identity intact.
- Example corpus cross-check — **unchanged vs baseline** (1× TH-RES-001, 7× REFGRAN01, 6× STY02); the `_THRESHOLD` change introduces no new findings.

## Scope

No spec change; no version bump (that's PR-7). The linter BDD parse-path fork (the piece that makes BDD read YAML) is **PR-2** — it touches `build_edge_graph`/REFGRAN/COV/TRACE-RES/TAG01 across the corpus and warrants its own focused review.

Touches `plans/DECISIONS.md` → governance-tier (Rule 1: 3 doc surfaces; Rule 2 self-review done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)