### PR TITLE
feat(tools): YAML-BDD-SCHEMA PR-2 — sdd_doc_lint dual-mode BDD parse path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,37 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added — YAML-BDD-SCHEMA PR-2: `sdd_doc_lint` dual-mode BDD parse path (2026-06-28)
+
+Second implementation increment. The linter now reads a migrated BDD doc's
+trace from its structured ``scenarios:`` YAML block; a doc with no scenarios
+block falls back to the legacy Gherkin ``@``-tag path (dual-mode), so the
+still-Gherkin example corpus is byte-for-byte unaffected.
+
+- **`build_edge_graph`** — for a BDD doc with a ``scenarios:`` block, synthesises
+  one upstream edge per scenario ``ears`` token **verbatim** (doc-form included),
+  with ``cited_doc = doc_id_from_token(token)``. So **REFGRAN01** fires on a
+  doc-form ``ears`` while COV01/COV02 see BDD↔EARS lineage identically (Pass-2
+  LB-3 / Pass-3 finding 2). Scenario ``id`` declarations self-register via the
+  existing ``_ELEM_ID`` scan.
+- **`_check_trace_resolution` (TRACE-RES-001)** — resolves scenario ``ears``
+  tokens against the corpus (the ``ears:`` list carries no ``@`` for the legacy
+  scan to see).
+- **`lint_text` TAG01** — BDD ``required_tags: [ears]`` is satisfied from the
+  parsed scenario ``ears``.
+- **`BDD-SCHEMA-001`** (new) — structural validation only: malformed block,
+  non-mapping scenario, missing required field
+  (id/name/type/priority/ears/given/when/then), or invalid type/priority enum.
+  Element-level ``ears`` granularity stays REFGRAN01's job — no double-report.
+- Re-vendored byte-identical into both platform copies.
+- **Tests:** `tests/unit/test_bdd_yaml_mode.py` (11) — REFGRAN verbatim-edge
+  behaviour, TRACE-RES, TAG01, BDD-SCHEMA-001, no-double-report, and the legacy
+  dual-mode fallback. Existing `test_ref_granularity.py`/`test_coverage_engine.py`
+  legacy fixtures unchanged (supplemented, not replaced — Pass-3 finding 1).
+- **Verification:** 141 unit + 148 conformance green; example corpus unchanged
+  vs baseline; end-to-end smoke — the PR-1 transcoder converts the real BDD-01
+  (31 scenarios / 50 ears tokens) and this fork reads it with IDs verbatim.
+
 ### Added — YAML-BDD-SCHEMA PR-1: `_THRESHOLD` quote-fix + Gherkin→YAML transcoder (2026-06-28)
 
 First implementation increment of the merged YAML-BDD-SCHEMA design

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -25,16 +25,17 @@
 >    comments) and copies each `@scenario-id:` **verbatim** into `id:` (keeps the
 >    16 downstream `@bdd:` citations stable). `tests/unit/test_gherkin_to_bdd_yaml.py`.
 >    Suite green: 130 unit + 148 conformance; corpus == baseline.
-> 2. **PR-2 (NEXT — the big one) — `sdd_doc_lint` dual-mode BDD parse path.** When
->    a `scenarios:` YAML block is present, parse it (synthetic **verbatim** `ears`
->    edges in `build_edge_graph` → REFGRAN/COV01/COV02/TRACE-RES/TAG01; new
->    `BDD-SCHEMA-001` structural check, structural-only — REFGRAN owns `ears`
->    granularity, no double-report); else fall back to the legacy `@`-tag path so
->    the still-Gherkin corpus stays green. Update `test_coverage_engine.py` +
->    `test_ref_granularity.py` BDD fixtures to the YAML form. (Plan §"Linter
->    changes" items 1-5 + the Pass-3 `cited_doc = doc_id_from_token` note.)
-> 3. **PR-3** template+schema (`BDD-TEMPLATE.yaml` category-dict → flat list +
->    `BDD-00_index.TEMPLATE.md`).
+> 2. ✅ **PR-2 (SHIPPED this session) — `sdd_doc_lint` dual-mode BDD parse path.**
+>    `build_edge_graph` synthesises verbatim `ears` edges (doc-form included →
+>    REFGRAN fires; `cited_doc = doc_id_from_token`); TRACE-RES-001 + TAG01 read
+>    scenario `ears`; new `BDD-SCHEMA-001` structural-only check (no double-report
+>    with REFGRAN); legacy Gherkin docs fall back to the `@`-tag path. Re-vendored
+>    byte-identical. `tests/unit/test_bdd_yaml_mode.py` (11); legacy fixtures
+>    supplemented not replaced (Pass-3 finding 1). 141 unit + 148 conformance;
+>    corpus == baseline; end-to-end smoke (transcoder → fork) on the real BDD-01.
+> 3. **PR-3 (NEXT) — template+schema** (`BDD-TEMPLATE.yaml` category-dict → flat
+>    list + `type:` discriminator; `BDD-00_index.TEMPLATE.md`). The normative
+>    schema + `_load_section_targets`/acceptance `.yaml` heading-parser impact.
 > 4. **PR-4** corpus + the 7 `BDD-01_golden` acceptance fixtures migration (run
 >    the PR-1 transcoder; `missing_section.md` is no-Gherkin/verify-only;
 >    `drift_codes.yaml` verify-only). Verify V4 ID-stability + V11 corpus.

--- a/platforms/claude-code-plugin/sdd_doc_lint/__init__.py
+++ b/platforms/claude-code-plugin/sdd_doc_lint/__init__.py
@@ -544,6 +544,16 @@ def lint_text(
                 )
             )
 
+    # BDD YAML dual-mode (YAML-BDD-SCHEMA PR-2): a migrated BDD doc carries its
+    # upstream `@ears` trace as scenario `ears` lists (not `@ears:` tags), and
+    # gets the structural BDD-SCHEMA-001 check. Legacy Gherkin docs (no
+    # scenarios block) fall through to the `@`-tag path above unchanged.
+    if artifact == "BDD":
+        _bdd_scenarios, _bdd_malformed = _bdd_yaml_scenarios(text)
+        if _bdd_scenarios is not None and _bdd_ears_tokens(_bdd_scenarios):
+            seen_tags.add("ears")
+        findings.extend(_check_bdd_schema(rel, text, _bdd_scenarios, _bdd_malformed))
+
     # Required upstream tags present (document-level, reported at line 0).
     required = layers[artifact].get("required_tags", []) or []
     for tag in required:
@@ -1159,6 +1169,121 @@ def _artifact_code(fm: dict | None) -> str:
     return m.group(1) if m else ""
 
 
+# --- BDD YAML dual-mode parse (YAML-BDD-SCHEMA PR-2) ---------------------------
+# A migrated BDD doc carries scenarios as a ```yaml ``scenarios:`` block instead
+# of Gherkin ``@``-tag lines. These helpers extract its trace data so the
+# ``@``-tag-based machinery (build_edge_graph / TRACE-RES-001 / TAG01) keeps
+# working; a doc with no scenarios block falls back to the legacy Gherkin path
+# (dual-mode). ``ears`` granularity is enforced by REFGRAN01 (via the verbatim
+# synthetic edges build_edge_graph emits) — BDD-SCHEMA-001 owns structural faults
+# only, so the two never double-report (YAML-BDD-SCHEMA Pass-2 LB-3).
+_YAML_FENCE = re.compile(r"```yaml\n(.*?)\n```", re.DOTALL)
+_BDD_SCEN_TYPES = {"success", "error", "recovery", "parameterized", "optional"}
+_BDD_PRIORITIES = {"p0-critical", "p1-high", "p2-medium", "p3-low"}
+_BDD_REQUIRED_FIELDS = ("id", "name", "type", "priority", "ears", "given", "when", "then")
+
+
+def _bdd_yaml_scenarios(text: str) -> tuple[list | None, bool]:
+    """Return ``(scenarios, malformed)`` for a BDD doc.
+
+    ``scenarios`` is the parsed list when a ```yaml block declares ``scenarios:``
+    as a list; ``None`` when no scenarios block is present (legacy Gherkin →
+    dual-mode fallback). ``malformed`` is True when a block intends a
+    ``scenarios:`` mapping but fails to parse or has the wrong shape.
+    """
+    for m in _YAML_FENCE.finditer(text):
+        raw = m.group(1)
+        if not re.search(r"^\s*scenarios\s*:", raw, re.MULTILINE):
+            continue
+        try:
+            obj = yaml.safe_load(raw)
+        except yaml.YAMLError:
+            return None, True
+        if isinstance(obj, dict) and isinstance(obj.get("scenarios"), list):
+            return obj["scenarios"], False
+        return None, True
+    return None, False
+
+
+def _bdd_ears_tokens(scenarios: list) -> list[str]:
+    """Every ``ears`` token across scenarios, verbatim (doc-form included)."""
+    out: list[str] = []
+    for s in scenarios:
+        if not isinstance(s, dict):
+            continue
+        e = s.get("ears")
+        if isinstance(e, str):
+            out.append(e)
+        elif isinstance(e, list):
+            out.extend(x for x in e if isinstance(x, str))
+    return out
+
+
+def _bdd_line_of(text: str, token: str | None) -> int:
+    """1-based line of the first occurrence of ``token`` in ``text`` (else 1)."""
+    if token:
+        for i, line in enumerate(text.splitlines(), 1):
+            if token in line:
+                return i
+    return 1
+
+
+def _check_bdd_schema(
+    rel: str, text: str, scenarios: list | None, malformed: bool
+) -> list[Finding]:
+    """BDD-SCHEMA-001 — structural validation of the ``scenarios:`` YAML block.
+
+    Structural only: malformed block, non-mapping scenario, missing required
+    field, or invalid ``type``/``priority`` enum. Element-level ``ears``
+    granularity is REFGRAN01's job (Pass-2 LB-3), not this check.
+    """
+    findings: list[Finding] = []
+    if malformed:
+        return [
+            Finding(
+                rel,
+                _bdd_line_of(text, "scenarios:"),
+                "BDD-SCHEMA-001",
+                "BDD `scenarios:` YAML block is malformed or not a list",
+            )
+        ]
+    if scenarios is None:
+        return findings  # legacy Gherkin doc — dual-mode fallback
+    for idx, s in enumerate(scenarios, 1):
+        if not isinstance(s, dict):
+            findings.append(
+                Finding(rel, 1, "BDD-SCHEMA-001", f"BDD scenario #{idx} is not a mapping")
+            )
+            continue
+        sid = s.get("id") if isinstance(s.get("id"), str) else None
+        line = _bdd_line_of(text, sid)
+        label = sid or f"#{idx}"
+        for field in _BDD_REQUIRED_FIELDS:
+            v = s.get(field)
+            if v is None or v == "" or v == []:
+                findings.append(
+                    Finding(
+                        rel,
+                        line,
+                        "BDD-SCHEMA-001",
+                        f"BDD scenario '{label}' missing required field '{field}'",
+                    )
+                )
+        t = s.get("type")
+        if isinstance(t, str) and t not in _BDD_SCEN_TYPES:
+            findings.append(
+                Finding(rel, line, "BDD-SCHEMA-001", f"BDD scenario '{label}' invalid type '{t}'")
+            )
+        p = s.get("priority")
+        if isinstance(p, str) and p not in _BDD_PRIORITIES:
+            findings.append(
+                Finding(
+                    rel, line, "BDD-SCHEMA-001", f"BDD scenario '{label}' invalid priority '{p}'"
+                )
+            )
+    return findings
+
+
 def build_edge_graph(corpus: list[tuple[str, str]]) -> EdgeGraph:
     """Build the net-new bidirectional element edge-graph (CFB-PR-2 DD-1 / R-c).
 
@@ -1212,6 +1337,23 @@ def build_edge_graph(corpus: list[tuple[str, str]]) -> EdgeGraph:
                 if citer_n and cited_n and cited_n > citer_n:
                     continue
                 edges.append(TraceEdge(doc_id, citer_code, value, cited_doc, i))
+        # BDD YAML dual-mode: synthesize one upstream edge per scenario `ears`
+        # token, VERBATIM (doc-form included) so REFGRAN01 fires on a doc-form
+        # ears while COV01/COV02 see BDD↔EARS lineage identically (Pass-2 LB-3 /
+        # Pass-3 finding 2). Scenario ids self-register via `_ELEM_ID` above.
+        if citer_code == "BDD":
+            scenarios, _ = _bdd_yaml_scenarios(text)
+            if scenarios is not None:
+                for tok in _bdd_ears_tokens(scenarios):
+                    cited_doc = doc_id_from_token(tok)
+                    if cited_doc is None or cited_doc == doc_id:
+                        continue
+                    cited_n = _LAYER_INDEX.get(cited_doc.split("-", 1)[0], 0)
+                    if citer_n and cited_n and cited_n > citer_n:
+                        continue
+                    edges.append(
+                        TraceEdge(doc_id, citer_code, tok, cited_doc, _bdd_line_of(text, tok))
+                    )
     return EdgeGraph(element_host, doc_layer, tuple(edges))
 
 
@@ -1330,6 +1472,38 @@ def _check_trace_resolution(
                                 f"trace tag '@{m.group(1)}: {value}' "
                                 f"unresolvable ({host_status}; expected host "
                                 f"'{host_doc}')",
+                            )
+                        )
+        # BDD YAML dual-mode: resolve scenario `ears` tokens (no @-tags to scan).
+        if artifact_code == "BDD":
+            scenarios, _ = _bdd_yaml_scenarios(text)
+            if scenarios is not None:
+                for tok in _bdd_ears_tokens(scenarios):
+                    if doc_re.match(tok):
+                        if tok not in doc_index:
+                            findings.append(
+                                Finding(
+                                    rel,
+                                    _bdd_line_of(text, tok),
+                                    "TRACE-RES-001",
+                                    f"BDD scenario `ears: {tok}` references unknown "
+                                    f"document (no corpus member has doc_id '{tok}')",
+                                )
+                            )
+                    elif elem_re.match(tok) and tok not in element_index:
+                        head = tok.split(".", 2)
+                        host_doc = (
+                            f"{head[0]}-{head[1]}"
+                            if len(head) >= 2 and head[1].isdigit()
+                            else "<unknown>"
+                        )
+                        findings.append(
+                            Finding(
+                                rel,
+                                _bdd_line_of(text, tok),
+                                "TRACE-RES-001",
+                                f"BDD scenario `ears: {tok}` unresolvable "
+                                f"(element not declared in host '{host_doc}')",
                             )
                         )
     return findings

--- a/platforms/hermes/sdd_doc_lint/__init__.py
+++ b/platforms/hermes/sdd_doc_lint/__init__.py
@@ -544,6 +544,16 @@ def lint_text(
                 )
             )
 
+    # BDD YAML dual-mode (YAML-BDD-SCHEMA PR-2): a migrated BDD doc carries its
+    # upstream `@ears` trace as scenario `ears` lists (not `@ears:` tags), and
+    # gets the structural BDD-SCHEMA-001 check. Legacy Gherkin docs (no
+    # scenarios block) fall through to the `@`-tag path above unchanged.
+    if artifact == "BDD":
+        _bdd_scenarios, _bdd_malformed = _bdd_yaml_scenarios(text)
+        if _bdd_scenarios is not None and _bdd_ears_tokens(_bdd_scenarios):
+            seen_tags.add("ears")
+        findings.extend(_check_bdd_schema(rel, text, _bdd_scenarios, _bdd_malformed))
+
     # Required upstream tags present (document-level, reported at line 0).
     required = layers[artifact].get("required_tags", []) or []
     for tag in required:
@@ -1159,6 +1169,121 @@ def _artifact_code(fm: dict | None) -> str:
     return m.group(1) if m else ""
 
 
+# --- BDD YAML dual-mode parse (YAML-BDD-SCHEMA PR-2) ---------------------------
+# A migrated BDD doc carries scenarios as a ```yaml ``scenarios:`` block instead
+# of Gherkin ``@``-tag lines. These helpers extract its trace data so the
+# ``@``-tag-based machinery (build_edge_graph / TRACE-RES-001 / TAG01) keeps
+# working; a doc with no scenarios block falls back to the legacy Gherkin path
+# (dual-mode). ``ears`` granularity is enforced by REFGRAN01 (via the verbatim
+# synthetic edges build_edge_graph emits) — BDD-SCHEMA-001 owns structural faults
+# only, so the two never double-report (YAML-BDD-SCHEMA Pass-2 LB-3).
+_YAML_FENCE = re.compile(r"```yaml\n(.*?)\n```", re.DOTALL)
+_BDD_SCEN_TYPES = {"success", "error", "recovery", "parameterized", "optional"}
+_BDD_PRIORITIES = {"p0-critical", "p1-high", "p2-medium", "p3-low"}
+_BDD_REQUIRED_FIELDS = ("id", "name", "type", "priority", "ears", "given", "when", "then")
+
+
+def _bdd_yaml_scenarios(text: str) -> tuple[list | None, bool]:
+    """Return ``(scenarios, malformed)`` for a BDD doc.
+
+    ``scenarios`` is the parsed list when a ```yaml block declares ``scenarios:``
+    as a list; ``None`` when no scenarios block is present (legacy Gherkin →
+    dual-mode fallback). ``malformed`` is True when a block intends a
+    ``scenarios:`` mapping but fails to parse or has the wrong shape.
+    """
+    for m in _YAML_FENCE.finditer(text):
+        raw = m.group(1)
+        if not re.search(r"^\s*scenarios\s*:", raw, re.MULTILINE):
+            continue
+        try:
+            obj = yaml.safe_load(raw)
+        except yaml.YAMLError:
+            return None, True
+        if isinstance(obj, dict) and isinstance(obj.get("scenarios"), list):
+            return obj["scenarios"], False
+        return None, True
+    return None, False
+
+
+def _bdd_ears_tokens(scenarios: list) -> list[str]:
+    """Every ``ears`` token across scenarios, verbatim (doc-form included)."""
+    out: list[str] = []
+    for s in scenarios:
+        if not isinstance(s, dict):
+            continue
+        e = s.get("ears")
+        if isinstance(e, str):
+            out.append(e)
+        elif isinstance(e, list):
+            out.extend(x for x in e if isinstance(x, str))
+    return out
+
+
+def _bdd_line_of(text: str, token: str | None) -> int:
+    """1-based line of the first occurrence of ``token`` in ``text`` (else 1)."""
+    if token:
+        for i, line in enumerate(text.splitlines(), 1):
+            if token in line:
+                return i
+    return 1
+
+
+def _check_bdd_schema(
+    rel: str, text: str, scenarios: list | None, malformed: bool
+) -> list[Finding]:
+    """BDD-SCHEMA-001 — structural validation of the ``scenarios:`` YAML block.
+
+    Structural only: malformed block, non-mapping scenario, missing required
+    field, or invalid ``type``/``priority`` enum. Element-level ``ears``
+    granularity is REFGRAN01's job (Pass-2 LB-3), not this check.
+    """
+    findings: list[Finding] = []
+    if malformed:
+        return [
+            Finding(
+                rel,
+                _bdd_line_of(text, "scenarios:"),
+                "BDD-SCHEMA-001",
+                "BDD `scenarios:` YAML block is malformed or not a list",
+            )
+        ]
+    if scenarios is None:
+        return findings  # legacy Gherkin doc — dual-mode fallback
+    for idx, s in enumerate(scenarios, 1):
+        if not isinstance(s, dict):
+            findings.append(
+                Finding(rel, 1, "BDD-SCHEMA-001", f"BDD scenario #{idx} is not a mapping")
+            )
+            continue
+        sid = s.get("id") if isinstance(s.get("id"), str) else None
+        line = _bdd_line_of(text, sid)
+        label = sid or f"#{idx}"
+        for field in _BDD_REQUIRED_FIELDS:
+            v = s.get(field)
+            if v is None or v == "" or v == []:
+                findings.append(
+                    Finding(
+                        rel,
+                        line,
+                        "BDD-SCHEMA-001",
+                        f"BDD scenario '{label}' missing required field '{field}'",
+                    )
+                )
+        t = s.get("type")
+        if isinstance(t, str) and t not in _BDD_SCEN_TYPES:
+            findings.append(
+                Finding(rel, line, "BDD-SCHEMA-001", f"BDD scenario '{label}' invalid type '{t}'")
+            )
+        p = s.get("priority")
+        if isinstance(p, str) and p not in _BDD_PRIORITIES:
+            findings.append(
+                Finding(
+                    rel, line, "BDD-SCHEMA-001", f"BDD scenario '{label}' invalid priority '{p}'"
+                )
+            )
+    return findings
+
+
 def build_edge_graph(corpus: list[tuple[str, str]]) -> EdgeGraph:
     """Build the net-new bidirectional element edge-graph (CFB-PR-2 DD-1 / R-c).
 
@@ -1212,6 +1337,23 @@ def build_edge_graph(corpus: list[tuple[str, str]]) -> EdgeGraph:
                 if citer_n and cited_n and cited_n > citer_n:
                     continue
                 edges.append(TraceEdge(doc_id, citer_code, value, cited_doc, i))
+        # BDD YAML dual-mode: synthesize one upstream edge per scenario `ears`
+        # token, VERBATIM (doc-form included) so REFGRAN01 fires on a doc-form
+        # ears while COV01/COV02 see BDD↔EARS lineage identically (Pass-2 LB-3 /
+        # Pass-3 finding 2). Scenario ids self-register via `_ELEM_ID` above.
+        if citer_code == "BDD":
+            scenarios, _ = _bdd_yaml_scenarios(text)
+            if scenarios is not None:
+                for tok in _bdd_ears_tokens(scenarios):
+                    cited_doc = doc_id_from_token(tok)
+                    if cited_doc is None or cited_doc == doc_id:
+                        continue
+                    cited_n = _LAYER_INDEX.get(cited_doc.split("-", 1)[0], 0)
+                    if citer_n and cited_n and cited_n > citer_n:
+                        continue
+                    edges.append(
+                        TraceEdge(doc_id, citer_code, tok, cited_doc, _bdd_line_of(text, tok))
+                    )
     return EdgeGraph(element_host, doc_layer, tuple(edges))
 
 
@@ -1330,6 +1472,38 @@ def _check_trace_resolution(
                                 f"trace tag '@{m.group(1)}: {value}' "
                                 f"unresolvable ({host_status}; expected host "
                                 f"'{host_doc}')",
+                            )
+                        )
+        # BDD YAML dual-mode: resolve scenario `ears` tokens (no @-tags to scan).
+        if artifact_code == "BDD":
+            scenarios, _ = _bdd_yaml_scenarios(text)
+            if scenarios is not None:
+                for tok in _bdd_ears_tokens(scenarios):
+                    if doc_re.match(tok):
+                        if tok not in doc_index:
+                            findings.append(
+                                Finding(
+                                    rel,
+                                    _bdd_line_of(text, tok),
+                                    "TRACE-RES-001",
+                                    f"BDD scenario `ears: {tok}` references unknown "
+                                    f"document (no corpus member has doc_id '{tok}')",
+                                )
+                            )
+                    elif elem_re.match(tok) and tok not in element_index:
+                        head = tok.split(".", 2)
+                        host_doc = (
+                            f"{head[0]}-{head[1]}"
+                            if len(head) >= 2 and head[1].isdigit()
+                            else "<unknown>"
+                        )
+                        findings.append(
+                            Finding(
+                                rel,
+                                _bdd_line_of(text, tok),
+                                "TRACE-RES-001",
+                                f"BDD scenario `ears: {tok}` unresolvable "
+                                f"(element not declared in host '{host_doc}')",
                             )
                         )
     return findings

--- a/tests/unit/test_bdd_yaml_mode.py
+++ b/tests/unit/test_bdd_yaml_mode.py
@@ -1,0 +1,151 @@
+"""Unit: the dual-mode BDD YAML parse path (YAML-BDD-SCHEMA PR-2).
+
+A migrated BDD doc carries scenarios as a ```yaml ``scenarios:`` block. The
+linter must read its trace from the structured ``ears`` lists (not ``@ears:``
+tags) — feeding build_edge_graph (verbatim synthetic edges), REFGRAN01,
+TRACE-RES-001, and TAG01 — plus a structural ``BDD-SCHEMA-001`` check. A doc
+with no scenarios block falls back to the legacy Gherkin ``@``-tag path.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+
+import yaml  # noqa: E402
+from sdd_doc_lint import (  # noqa: E402
+    _check_ref_granularity,
+    _check_trace_resolution,
+    _load_registry,
+    build_edge_graph,
+    lint_text,
+)
+
+LAYERS, DOC_RE, ELEM_RE = _load_registry(None)
+
+
+def _scn(ears, sid="BDD.01.03.ccd6", **kw):
+    s = {
+        "id": sid,
+        "name": "Shorten a valid URL",
+        "type": "success",
+        "priority": "p0-critical",
+        "ears": ears,
+        "given": ["a precondition"],
+        "when": ["an action"],
+        "then": ["an outcome"],
+    }
+    s.update(kw)
+    return s
+
+
+def _bdd(scenarios, doc_id="BDD-01"):
+    block = yaml.safe_dump({"scenarios": scenarios}, sort_keys=False, allow_unicode=True)
+    text = (
+        f"---\ndoc_id: {doc_id}\nartifact_type: BDD\n---\n\n"
+        f"## 3. Scenario Structure\n\n```yaml\n{block}```\n"
+    )
+    return (f"{doc_id}.md", text)
+
+
+def _ears(*ids, doc_id="EARS-01"):
+    body = "\n".join(f"- {i}: a requirement." for i in ids)
+    return (
+        f"{doc_id}.md",
+        f"---\ndoc_id: {doc_id}\nartifact_type: EARS\n---\n\n## 4. Reqs\n{body}\n",
+    )
+
+
+def _codes(findings, code):
+    return [f for f in findings if f.code == code]
+
+
+class BddYamlMode(unittest.TestCase):
+    # --- REFGRAN via verbatim synthetic edges (LB-3) -------------------------
+    def test_refgran_fires_on_doc_form_ears(self):
+        corpus = [_ears("EARS.01.03.aaaa"), _bdd([_scn(["EARS-01"])])]
+        f = _check_ref_granularity(corpus, "gate-code")
+        self.assertEqual([(x.code, x.severity) for x in f], [("REFGRAN01", "error")])
+
+    def test_refgran_silent_on_element_form(self):
+        corpus = [_ears("EARS.01.03.aaaa"), _bdd([_scn(["EARS.01.03.aaaa"])])]
+        self.assertEqual(_check_ref_granularity(corpus, "gate-code"), [])
+
+    # --- build_edge_graph emits verbatim synthetic edges --------------------
+    def test_synthetic_edges_verbatim(self):
+        corpus = [_ears("EARS.01.03.aaaa"), _bdd([_scn(["EARS.01.03.aaaa", "EARS.01.03.bbbb"])])]
+        g = build_edge_graph(corpus)
+        bdd_edges = {e.cited_token for e in g.edges if e.citer_doc == "BDD-01"}
+        self.assertEqual(bdd_edges, {"EARS.01.03.aaaa", "EARS.01.03.bbbb"})
+        # ...and they resolve to the EARS host doc for COV reach.
+        self.assertEqual({e.cited_doc for e in g.edges if e.citer_doc == "BDD-01"}, {"EARS-01"})
+
+    # --- TRACE-RES-001 over scenario ears -----------------------------------
+    def test_trace_res_fires_on_unresolved_ears(self):
+        corpus = [_ears("EARS.01.03.aaaa"), _bdd([_scn(["EARS.01.03.ffff"])])]  # ffff not declared
+        f = _check_trace_resolution(corpus, LAYERS, DOC_RE, ELEM_RE)
+        self.assertTrue(_codes(f, "TRACE-RES-001"))
+
+    def test_trace_res_silent_on_resolved_ears(self):
+        corpus = [_ears("EARS.01.03.aaaa"), _bdd([_scn(["EARS.01.03.aaaa"])])]
+        self.assertEqual(
+            _codes(_check_trace_resolution(corpus, LAYERS, DOC_RE, ELEM_RE), "TRACE-RES-001"), []
+        )
+
+    # --- TAG01 satisfied from scenario ears (no @ears tag) ------------------
+    def test_tag01_satisfied_from_scenario_ears(self):
+        _, text = _bdd([_scn(["EARS.01.03.aaaa"])])
+        f = lint_text(text, "BDD", "BDD-01.md", LAYERS, DOC_RE, ELEM_RE)
+        self.assertEqual(_codes(f, "TAG01"), [])
+
+    # --- BDD-SCHEMA-001 structural -----------------------------------------
+    def test_schema_missing_required_field(self):
+        bad = _scn(["EARS.01.03.aaaa"])
+        del bad["when"]
+        _, text = _bdd([bad])
+        f = lint_text(text, "BDD", "BDD-01.md", LAYERS, DOC_RE, ELEM_RE)
+        msgs = [x.message for x in _codes(f, "BDD-SCHEMA-001")]
+        self.assertTrue(any("'when'" in m for m in msgs), msgs)
+
+    def test_schema_invalid_type_and_priority(self):
+        _, text = _bdd([_scn(["EARS.01.03.aaaa"], type="bogus", priority="p9-ultra")])
+        msgs = " ".join(
+            x.message
+            for x in _codes(
+                lint_text(text, "BDD", "BDD-01.md", LAYERS, DOC_RE, ELEM_RE), "BDD-SCHEMA-001"
+            )
+        )
+        self.assertIn("invalid type", msgs)
+        self.assertIn("invalid priority", msgs)
+
+    def test_schema_malformed_block(self):
+        text = (
+            "---\ndoc_id: BDD-01\nartifact_type: BDD\n---\n\n## 3. Scenario Structure\n\n"
+            "```yaml\nscenarios:\n  - id: BDD.01.03.ccd6\n  bad-indent: [unbalanced\n```\n"
+        )
+        f = lint_text(text, "BDD", "BDD-01.md", LAYERS, DOC_RE, ELEM_RE)
+        self.assertTrue(_codes(f, "BDD-SCHEMA-001"))
+
+    def test_no_double_report_refgran_vs_schema(self):
+        # A well-formed doc-form ears: REFGRAN fires (granularity), but
+        # BDD-SCHEMA-001 must NOT also flag ears (structural only).
+        _, text = _bdd([_scn(["EARS-01"])])
+        f = lint_text(text, "BDD", "BDD-01.md", LAYERS, DOC_RE, ELEM_RE)
+        self.assertEqual(_codes(f, "BDD-SCHEMA-001"), [])
+
+    # --- Dual-mode: legacy Gherkin still works ------------------------------
+    def test_legacy_gherkin_still_satisfies_tag01_and_no_schema(self):
+        text = (
+            "---\ndoc_id: BDD-01\nartifact_type: BDD\n---\n\n## 3. Scenario Structure\n\n"
+            "```gherkin\n@ears:EARS.01.03.aaaa\nScenario: x\n```\n"
+        )
+        f = lint_text(text, "BDD", "BDD-01.md", LAYERS, DOC_RE, ELEM_RE)
+        self.assertEqual(_codes(f, "TAG01"), [])
+        self.assertEqual(_codes(f, "BDD-SCHEMA-001"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/sdd_doc_lint/__init__.py
+++ b/tools/sdd_doc_lint/__init__.py
@@ -544,6 +544,16 @@ def lint_text(
                 )
             )
 
+    # BDD YAML dual-mode (YAML-BDD-SCHEMA PR-2): a migrated BDD doc carries its
+    # upstream `@ears` trace as scenario `ears` lists (not `@ears:` tags), and
+    # gets the structural BDD-SCHEMA-001 check. Legacy Gherkin docs (no
+    # scenarios block) fall through to the `@`-tag path above unchanged.
+    if artifact == "BDD":
+        _bdd_scenarios, _bdd_malformed = _bdd_yaml_scenarios(text)
+        if _bdd_scenarios is not None and _bdd_ears_tokens(_bdd_scenarios):
+            seen_tags.add("ears")
+        findings.extend(_check_bdd_schema(rel, text, _bdd_scenarios, _bdd_malformed))
+
     # Required upstream tags present (document-level, reported at line 0).
     required = layers[artifact].get("required_tags", []) or []
     for tag in required:
@@ -1159,6 +1169,121 @@ def _artifact_code(fm: dict | None) -> str:
     return m.group(1) if m else ""
 
 
+# --- BDD YAML dual-mode parse (YAML-BDD-SCHEMA PR-2) ---------------------------
+# A migrated BDD doc carries scenarios as a ```yaml ``scenarios:`` block instead
+# of Gherkin ``@``-tag lines. These helpers extract its trace data so the
+# ``@``-tag-based machinery (build_edge_graph / TRACE-RES-001 / TAG01) keeps
+# working; a doc with no scenarios block falls back to the legacy Gherkin path
+# (dual-mode). ``ears`` granularity is enforced by REFGRAN01 (via the verbatim
+# synthetic edges build_edge_graph emits) — BDD-SCHEMA-001 owns structural faults
+# only, so the two never double-report (YAML-BDD-SCHEMA Pass-2 LB-3).
+_YAML_FENCE = re.compile(r"```yaml\n(.*?)\n```", re.DOTALL)
+_BDD_SCEN_TYPES = {"success", "error", "recovery", "parameterized", "optional"}
+_BDD_PRIORITIES = {"p0-critical", "p1-high", "p2-medium", "p3-low"}
+_BDD_REQUIRED_FIELDS = ("id", "name", "type", "priority", "ears", "given", "when", "then")
+
+
+def _bdd_yaml_scenarios(text: str) -> tuple[list | None, bool]:
+    """Return ``(scenarios, malformed)`` for a BDD doc.
+
+    ``scenarios`` is the parsed list when a ```yaml block declares ``scenarios:``
+    as a list; ``None`` when no scenarios block is present (legacy Gherkin →
+    dual-mode fallback). ``malformed`` is True when a block intends a
+    ``scenarios:`` mapping but fails to parse or has the wrong shape.
+    """
+    for m in _YAML_FENCE.finditer(text):
+        raw = m.group(1)
+        if not re.search(r"^\s*scenarios\s*:", raw, re.MULTILINE):
+            continue
+        try:
+            obj = yaml.safe_load(raw)
+        except yaml.YAMLError:
+            return None, True
+        if isinstance(obj, dict) and isinstance(obj.get("scenarios"), list):
+            return obj["scenarios"], False
+        return None, True
+    return None, False
+
+
+def _bdd_ears_tokens(scenarios: list) -> list[str]:
+    """Every ``ears`` token across scenarios, verbatim (doc-form included)."""
+    out: list[str] = []
+    for s in scenarios:
+        if not isinstance(s, dict):
+            continue
+        e = s.get("ears")
+        if isinstance(e, str):
+            out.append(e)
+        elif isinstance(e, list):
+            out.extend(x for x in e if isinstance(x, str))
+    return out
+
+
+def _bdd_line_of(text: str, token: str | None) -> int:
+    """1-based line of the first occurrence of ``token`` in ``text`` (else 1)."""
+    if token:
+        for i, line in enumerate(text.splitlines(), 1):
+            if token in line:
+                return i
+    return 1
+
+
+def _check_bdd_schema(
+    rel: str, text: str, scenarios: list | None, malformed: bool
+) -> list[Finding]:
+    """BDD-SCHEMA-001 — structural validation of the ``scenarios:`` YAML block.
+
+    Structural only: malformed block, non-mapping scenario, missing required
+    field, or invalid ``type``/``priority`` enum. Element-level ``ears``
+    granularity is REFGRAN01's job (Pass-2 LB-3), not this check.
+    """
+    findings: list[Finding] = []
+    if malformed:
+        return [
+            Finding(
+                rel,
+                _bdd_line_of(text, "scenarios:"),
+                "BDD-SCHEMA-001",
+                "BDD `scenarios:` YAML block is malformed or not a list",
+            )
+        ]
+    if scenarios is None:
+        return findings  # legacy Gherkin doc — dual-mode fallback
+    for idx, s in enumerate(scenarios, 1):
+        if not isinstance(s, dict):
+            findings.append(
+                Finding(rel, 1, "BDD-SCHEMA-001", f"BDD scenario #{idx} is not a mapping")
+            )
+            continue
+        sid = s.get("id") if isinstance(s.get("id"), str) else None
+        line = _bdd_line_of(text, sid)
+        label = sid or f"#{idx}"
+        for field in _BDD_REQUIRED_FIELDS:
+            v = s.get(field)
+            if v is None or v == "" or v == []:
+                findings.append(
+                    Finding(
+                        rel,
+                        line,
+                        "BDD-SCHEMA-001",
+                        f"BDD scenario '{label}' missing required field '{field}'",
+                    )
+                )
+        t = s.get("type")
+        if isinstance(t, str) and t not in _BDD_SCEN_TYPES:
+            findings.append(
+                Finding(rel, line, "BDD-SCHEMA-001", f"BDD scenario '{label}' invalid type '{t}'")
+            )
+        p = s.get("priority")
+        if isinstance(p, str) and p not in _BDD_PRIORITIES:
+            findings.append(
+                Finding(
+                    rel, line, "BDD-SCHEMA-001", f"BDD scenario '{label}' invalid priority '{p}'"
+                )
+            )
+    return findings
+
+
 def build_edge_graph(corpus: list[tuple[str, str]]) -> EdgeGraph:
     """Build the net-new bidirectional element edge-graph (CFB-PR-2 DD-1 / R-c).
 
@@ -1212,6 +1337,23 @@ def build_edge_graph(corpus: list[tuple[str, str]]) -> EdgeGraph:
                 if citer_n and cited_n and cited_n > citer_n:
                     continue
                 edges.append(TraceEdge(doc_id, citer_code, value, cited_doc, i))
+        # BDD YAML dual-mode: synthesize one upstream edge per scenario `ears`
+        # token, VERBATIM (doc-form included) so REFGRAN01 fires on a doc-form
+        # ears while COV01/COV02 see BDD↔EARS lineage identically (Pass-2 LB-3 /
+        # Pass-3 finding 2). Scenario ids self-register via `_ELEM_ID` above.
+        if citer_code == "BDD":
+            scenarios, _ = _bdd_yaml_scenarios(text)
+            if scenarios is not None:
+                for tok in _bdd_ears_tokens(scenarios):
+                    cited_doc = doc_id_from_token(tok)
+                    if cited_doc is None or cited_doc == doc_id:
+                        continue
+                    cited_n = _LAYER_INDEX.get(cited_doc.split("-", 1)[0], 0)
+                    if citer_n and cited_n and cited_n > citer_n:
+                        continue
+                    edges.append(
+                        TraceEdge(doc_id, citer_code, tok, cited_doc, _bdd_line_of(text, tok))
+                    )
     return EdgeGraph(element_host, doc_layer, tuple(edges))
 
 
@@ -1330,6 +1472,38 @@ def _check_trace_resolution(
                                 f"trace tag '@{m.group(1)}: {value}' "
                                 f"unresolvable ({host_status}; expected host "
                                 f"'{host_doc}')",
+                            )
+                        )
+        # BDD YAML dual-mode: resolve scenario `ears` tokens (no @-tags to scan).
+        if artifact_code == "BDD":
+            scenarios, _ = _bdd_yaml_scenarios(text)
+            if scenarios is not None:
+                for tok in _bdd_ears_tokens(scenarios):
+                    if doc_re.match(tok):
+                        if tok not in doc_index:
+                            findings.append(
+                                Finding(
+                                    rel,
+                                    _bdd_line_of(text, tok),
+                                    "TRACE-RES-001",
+                                    f"BDD scenario `ears: {tok}` references unknown "
+                                    f"document (no corpus member has doc_id '{tok}')",
+                                )
+                            )
+                    elif elem_re.match(tok) and tok not in element_index:
+                        head = tok.split(".", 2)
+                        host_doc = (
+                            f"{head[0]}-{head[1]}"
+                            if len(head) >= 2 and head[1].isdigit()
+                            else "<unknown>"
+                        )
+                        findings.append(
+                            Finding(
+                                rel,
+                                _bdd_line_of(text, tok),
+                                "TRACE-RES-001",
+                                f"BDD scenario `ears: {tok}` unresolvable "
+                                f"(element not declared in host '{host_doc}')",
                             )
                         )
     return findings


### PR DESCRIPTION
## Summary

Second implementation increment of **YAML-BDD-SCHEMA** (`plans/YAML-BDD-SCHEMA-PLAN.md`). The `sdd_doc_lint` **dual-mode BDD parse path**: when a BDD doc carries a `scenarios:` YAML block the linter reads its trace from the structured `ears` lists; a doc with no scenarios block falls back to the legacy Gherkin `@`-tag path. The still-Gherkin example corpus is therefore **byte-for-byte unaffected**.

## Changes (`tools/sdd_doc_lint/__init__.py`, re-vendored to both platforms)

- **`build_edge_graph`** — synthesises one upstream edge per scenario `ears` token **verbatim** (doc-form included), `cited_doc = doc_id_from_token(token)`. So **REFGRAN01** fires on a doc-form `ears` while COV01/COV02 see BDD↔EARS lineage identically (Pass-2 LB-3 / Pass-3 finding 2). Scenario `id`s self-register via the existing `_ELEM_ID` scan.
- **`_check_trace_resolution` (TRACE-RES-001)** — resolves scenario `ears` tokens (the `ears:` list has no `@` for the legacy scan).
- **`lint_text` TAG01** — BDD `required_tags: [ears]` satisfied from parsed scenario `ears`.
- **`BDD-SCHEMA-001`** (new) — structural-only: malformed block, non-mapping scenario, missing required field, invalid `type`/`priority` enum. Element-level `ears` granularity stays REFGRAN01's job → **no double-report**.

## Verification

- `tests/unit/test_bdd_yaml_mode.py` (**11**) — REFGRAN verbatim-edge behaviour, TRACE-RES, TAG01, BDD-SCHEMA-001, no-double-report, legacy dual-mode fallback.
- **141 unit** (+211 subtests) + **148 conformance** (+636 subtests) green; vendored byte-identity intact.
- **Example corpus unchanged vs baseline** (1× TH-RES-001, 7× REFGRAN01, 6× STY02) — the fork no-ops on the still-Gherkin corpus.
- **End-to-end smoke:** the PR-1 transcoder converts the real BDD-01 (31 scenarios / 50 `ears` tokens) and this fork reads it with IDs verbatim (`BDD.01.03.ccd6`…).
- Legacy `test_ref_granularity.py`/`test_coverage_engine.py` fixtures unchanged — supplemented, not replaced (Pass-3 finding 1).

## Scope

No spec change; no version bump (PR-7). Next: **PR-3** (template+schema — `BDD-TEMPLATE.yaml` category-dict → flat list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)