### PR TITLE
feat: YAML-BDD-SCHEMA PR-4 — migrate example corpus BDD-01 to YAML scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed — YAML-BDD-SCHEMA PR-4: example corpus BDD-01 migrated to YAML scenarios (2026-06-28)
+
+The corpus payoff — the framework migrates its own showcase artifact end-to-end
+(machine-produced by the transcoder; never hand-edited).
+
+- **`examples/url-shortener/docs/04_BDD/BDD-01.md`** — Gherkin → structured YAML
+  `scenarios:` block via the hardened transcoder. 31 scenarios; each
+  `@scenario-id` **copied verbatim** so all **16 downstream `@bdd:` citations
+  still resolve** (V4 ID-stability); inline `@threshold:` preserved; `#`
+  comments lifted to `spec_trace:`/`notes:`. **Drops the 2 BDD REFGRAN edges:
+  corpus REFGRAN 7 → 5** (the remaining 5 are SPEC/TDD/IPLAN `@adr`/`@tdd` —
+  `CORPUS-REFGRAN-RECASCADE`). New corpus baseline: 1 TH-RES, 5 REFGRAN, 6 STY02.
+- **`tools/gherkin_to_bdd_yaml.py`** — hardened for the real corpus:
+  fence-classified placement (feature → §2, scenarios → §3), Document Control
+  reference-row strip, empty category sub-heading collapse. +1 multi-fence test
+  (`tests/unit/test_gherkin_to_bdd_yaml.py`, now 7).
+- Acceptance `BDD-01_golden` fixtures are already non-Gherkin → no change.
+- **Verification:** 290 unit + conformance green; acceptance unchanged (the 3
+  failing SPEC `@adr` REFGRAN cases are pre-existing `CORPUS-REFGRAN-RECASCADE`,
+  not BDD). Not a `framework/` change → no version bump.
+
 ### Added — Framework Spec 0.27.0 → 0.28.0: GD-04 ratifies IPLAN-ASSURANCE L1 (2026-06-28)
 
 - **`governance/DECISIONS.md` — GD-04:** ratifies **IPLAN-ASSURANCE L1** at

--- a/examples/url-shortener/docs/04_BDD/BDD-01.md
+++ b/examples/url-shortener/docs/04_BDD/BDD-01.md
@@ -28,7 +28,6 @@ custom_fields:
 | Status | Draft |
 | Version | 1.0.2 |
 | Priority | P1 |
-| EARS reference | @ears: EARS-01 |
 | ADR readiness score | 94/100 |
 | Created | 2026-06-10 |
 | Last updated | 2026-06-10 |
@@ -51,18 +50,22 @@ The necessary-upstream tag (`@ears`, Gherkin-native, no space after the colon)
 plus the `@bdd` self-tag apply to the feature and appear before the `Feature:`
 keyword. Each scenario carries the specific `@ears` element lines it exercises.
 
-```gherkin
-@ears:EARS-01 @bdd:BDD-01 @qa-staging-only
-Feature: URL Shortener acceptance behaviour
-  As a Link Submitter, Link Visitor, and Service Owner
-  I want to shorten public URLs, resolve them quickly, and observe adoption
-  So that long links become compact, dependable, and abuse-resistant short links
+```yaml
+feature:
+  name: URL Shortener acceptance behaviour
+  tags:
+  - '@qa-staging-only'
+  background:
+    steps:
+    - the Shorten/Redirect API is in a ready state
+    - the Mapping Store is empty and reachable
+    - the destination-reputation source returns "clean" by default
+    - the current time is "09:30:00" in "America/New_York"
+  description: 'As a Link Submitter, Link Visitor, and Service Owner
 
-  Background:
-    Given the Shorten/Redirect API is in a ready state
-    And the Mapping Store is empty and reachable
-    And the destination-reputation source returns "clean" by default
-    And the current time is "09:30:00" in "America/New_York"
+    I want to shorten public URLs, resolve them quickly, and observe adoption
+
+    So that long links become compact, dependable, and abuse-resistant short links'
 ```
 
 Timing budgets reference threshold keys forwarded from EARS-01; each scenario
@@ -76,353 +79,626 @@ referenced keys are enumerated in §4.
 
 ### 3.1 Success scenarios
 
-```gherkin
-@scenario-type:success @p0-critical @scenario-id:BDD.01.03.ccd6
-@ears:EARS.01.03.5066 @ears:EARS.01.03.bca8 @ears:EARS.01.03.6811
-Scenario: Shorten a valid public URL
-  Given a Link Submitter with the well-formed public URL "https://example.com/page" within @threshold:PRD.01.quota.urlmaxlen
-  When the submitter posts the URL to the Shorten/Redirect API
-  Then the API SHALL return a unique short code that resolves to exactly "https://example.com/page" WITHIN @threshold:PRD.01.perf.screeningdeadline
-  And the API SHALL present the confirmation "Your short link is ready."
-  # spec_trace: SPEC §3 (Interfaces), SPEC §5 (Behavior)
-
-@scenario-type:success @p0-critical @scenario-id:BDD.01.03.613b
-@ears:EARS.01.03.c4c9 @ears:EARS.01.04.cea3
-Scenario: Redirect a known short code
-  Given an issued short code "/abc123" mapping to "https://example.com/page"
-  When a Link Visitor requests "/abc123"
-  Then the Shorten/Redirect API SHALL redirect to "https://example.com/page" WITHIN @threshold:PRD.01.perf.redirectp95
-  # spec_trace: SPEC §3 (Interfaces), SPEC §5 (Behavior)
-
-@scenario-type:success @p1-high @scenario-id:BDD.01.03.5645
-@ears:EARS.01.03.4425 @ears:EARS.01.04.1898
-Scenario: Visit count increments exactly once on redirect
-  Given an issued short code "/abc123" with a visit count of 0
-  When a Link Visitor completes one redirect of "/abc123"
-  Then the Visit Counter SHALL increment that code's visit count to exactly 1, dispatched off the synchronous redirect path, WITHIN @threshold:PRD.01.reliability.countstaleness
-  # split from the former combined counting+idempotency scenario (QA-BDD-01-F002); idempotency under re-delivery is asserted separately in BDD.01.03.1365
-  # spec_trace: SPEC §5 (Behavior — async increment), SPEC §4 (Data Models)
-
-@scenario-type:success @p1-high @scenario-id:BDD.01.03.1365
-@ears:EARS.01.03.4425 @ears:EARS.01.04.1898
-Scenario: Duplicate redirect event does not double-count
-  Given an issued short code "/abc123" with a visit count of 1 after one confirmed redirect event
-  When the same redirect event is re-delivered to the Visit Counter
-  Then the visit count for "/abc123" SHALL remain exactly 1, WITHIN @threshold:PRD.01.reliability.countstaleness
-  # idempotency half of the split counting scenario (QA-BDD-01-F002); proves off-path exactly-once delivery under event re-delivery
-  # spec_trace: SPEC §5 (Behavior — async increment idempotency), SPEC §4 (Data Models)
-
-@scenario-type:success @p1-high @scenario-id:BDD.01.03.cb64
-@ears:EARS.01.03.aa59
-Scenario: Service Owner sees created-link and per-link counts
-  Given a caller bearing the Service-Owner role
-  And one issued short code "/abc123" with a visit count of 7
-  When the caller requests adoption counts
-  Then the Visit Counter SHALL return the created-link count and the per-link visit count 7 for "/abc123"
-  # spec_trace: SPEC §3 (Interfaces), SPEC §5 (Behavior — authorization)
-
-@scenario-type:success @p1-high @scenario-id:BDD.01.03.a688
-@ears:EARS.01.03.bca8
-Scenario: Issued code maps to exactly one URL for its lifetime
-  Given an issued short code "/abc123" mapping to "https://example.com/page"
-  When the same destination "https://example.com/page" is submitted again
-  Then the API SHALL return a code that resolves to exactly "https://example.com/page"
-  And the returned code SHALL resolve to exactly one original URL, namely "https://example.com/page"
-  # the system-wide code-to-URL uniqueness invariant (EARS.01.03.bca8) is verified as a property/contract test at the TDD layer, not as an observable of this single resubmission
-  # spec_trace: SPEC §4 (Data Models — invariant), SPEC §5 (Behavior)
-
-@scenario-type:success @p1-high @scenario-id:BDD.01.03.ed49
-@ears:EARS.01.03.feaa @ears:EARS.01.04.1598 @ears:EARS.01.04.cea3
-Scenario: Redirect latency and availability hold under sustained load
-  Given a single issued short code "/abc123" served at @threshold:PRD.01.rate.redirectsustained with 20 concurrent visitors
-  When the load is sustained for 5 minutes over at least 30,000 sampled requests
-  Then the Shorten/Redirect API SHALL sustain redirect latency WITHIN @threshold:PRD.01.perf.redirectp95
-  And the API SHALL sustain a within-window success rate of at least 99.9% over the sampled requests, with no non-shed 5xx responses
-  And the redirect-path latency histogram metric SHALL be emitted with its route and status labels for every sampled request
-  # the monthly availability SLO @threshold:PRD.01.reliability.availabilitymonthly is a long-horizon target asserted separately; the within-window success rate above is its observable proxy
-  # measurement window (5 minutes) and minimum sample count are author assumptions pending a PRD §12 load-envelope element
-  # spec_trace: SPEC §5 (Behavior — performance), SPEC §6 (NFR)
-
-@scenario-type:success @p1-high @scenario-id:BDD.01.03.f774
-@ears:EARS.01.03.eca5
-Scenario: Capacity-utilization alert fires at the alert threshold
-  Given short-code utilization is just below the capacity alert threshold
-  When utilization reaches @threshold:PRD.01.quota.codespacecapacity alert level
-  Then the Shorten/Redirect API SHALL emit exactly one capacity-utilization alert identifying the current utilization
-  # detection counterpart to the reject-at-capacity recovery (BDD.01.03.177e)
-  # spec_trace: SPEC §5 (Behavior — capacity), SPEC §6 (NFR — observability)
-
-@scenario-type:success @p1-high @scenario-id:BDD.01.03.9b90
-@ears:EARS.01.04.5e5b
-Scenario: Mapping survives a crash immediately after acknowledgement
-  Given a Link Submitter posts a well-formed public URL
-  When the Shorten/Redirect API acknowledges the issued short code
-  And the Mapping Store is hard-killed before any post-acknowledgement flush
-  Then after the Mapping Store restarts the issued short code SHALL still resolve to the original URL, confirming the mapping was durably committed at recovery-point-objective zero before acknowledgement
-  # crash-recovery probe gives "durably committed at ack" a deterministic observation point (TL-BDD-01): RPO-zero is verified by survival of the hard-kill, not by an unobservable point-in-time assertion at acknowledgement
-  # spec_trace: SPEC §4 (Data Models — durability), SPEC §5 (Behavior — write ordering)
-
-@scenario-type:success @p1-high @scenario-id:BDD.01.03.e5ec
-@ears:EARS.01.03.ac68 @ears:EARS.01.04.cb3b
-Scenario: Issued codes are high-entropy and non-sequential
-  Given the Shorten/Redirect API issues short codes on the public resolution surface
-  When 1,000 codes are issued in sequence
-  Then no issued code SHALL be derivable by incrementing or decrementing another issued code
-  And the 1,000 issued codes SHALL be pairwise distinct and SHALL pass a monobit frequency test over their concatenated bit-string at the significance level @threshold:PRD.01.security.codeentropy
-  # spec_trace: SPEC §4 (Data Models — code generation), SPEC §6 (NFR — security)
-
-@scenario-type:success @p1-high @scenario-id:BDD.01.03.567d
-@ears:EARS.01.03.9903 @ears:EARS.01.04.cb3b
-Scenario: Resolution requests are rate-limited per source
-  Given the per-source resolution rate limit is @threshold:PRD.01.rate.resolutionpersource requests per @threshold:PRD.01.rate.resolutionwindow
-  When one source issues one more than @threshold:PRD.01.rate.resolutionpersource resolution requests within a single @threshold:PRD.01.rate.resolutionwindow
-  Then the Shorten/Redirect API SHALL throttle the request beyond the limit for that source
-  And resolution for other sources SHALL be unaffected
-  # spec_trace: SPEC §3 (Interfaces — rate limiting), SPEC §6 (NFR — security)
-
-@scenario-type:success @p1-high @scenario-id:BDD.01.03.c8a6
-@ears:EARS.01.03.4ebf
-Scenario: Mapping-store denies original-URL read to a principal without least-privilege grant
-  Given a stored code-to-URL mapping whose original-URL value is classified as may-contain-PII
-  When a principal without the least-privilege read grant reads the mapping
-  Then the Mapping Store SHALL deny access to the original-URL value
-  # concrete access and erasure parameters are owned by the data-protection ADR topic
-  # spec_trace: SPEC §4 (Data Models — classification), SPEC §6 (NFR — access control)
-
-@scenario-type:success @p1-high @scenario-id:BDD.01.03.167e
-@ears:EARS.01.03.4ebf
-Scenario: Mapping-store permits original-URL read to a principal with least-privilege grant
-  Given a stored code-to-URL mapping whose original-URL value is classified as may-contain-PII
-  When a principal holding the least-privilege read grant reads the mapping
-  Then the Mapping Store SHALL permit access to the original-URL value
-  # granted-path companion to the denied-path control (BDD.01.03.c8a6); access parameters owned by the data-protection ADR topic
-  # spec_trace: SPEC §4 (Data Models — classification), SPEC §6 (NFR — access control)
-```
-
-### 3.2 Error scenarios
-
-```gherkin
-@scenario-type:error @p1-high @scenario-id:BDD.01.03.5ab2
-@ears:EARS.01.03.e4db
-Scenario: Unknown short code returns not found
-  Given no short code is issued for "/zzz999"
-  When a Link Visitor requests "/zzz999"
-  Then the Shorten/Redirect API SHALL return "No such short link exists." WITHIN @threshold:PRD.01.perf.redirectp95
-  And the API SHALL NOT redirect the visitor
-  # spec_trace: SPEC §5 (Behavior — error_handling), SPEC §3 (Interfaces)
-
-@scenario-type:error @p1-high @scenario-id:BDD.01.03.177e
-@ears:EARS.01.03.5442
-Scenario: Code-space exhaustion returns a non-retryable capacity error
-  Given the short-code space is at @threshold:PRD.01.quota.codespacecapacity
-  When a Link Submitter posts a well-formed public URL
-  Then the Shorten/Redirect API SHALL reject creation with "Short links are at capacity and can't be created right now. Existing links still work."
-  And the API SHALL continue to resolve existing issued codes
-  And the API SHALL issue no short code
-  # spec_trace: SPEC §5 (Behavior — capacity), SPEC §6 (Error Handling)
-
-@scenario-type:error @p1-high @scenario-id:BDD.01.03.3c70
-@ears:EARS.01.03.f62a
-Scenario: Flagged or taken-down code returns not found
-  Given an issued short code "/abc123" whose destination is later flagged and taken down
-  When a Link Visitor requests "/abc123"
-  Then the Shorten/Redirect API SHALL return "No such short link exists." WITHIN @threshold:PRD.01.perf.takedownsla
-  And the API SHALL NOT redirect the visitor
-  And the API SHALL emit a "link_takedown_applied" event identifying the taken-down code
-  # the "link_takedown_applied" event assertion (observability plane) is intentionally co-located with the user-facing not-found outcome here; failure isolation between the behavioural and instrumentation planes is accepted as a documented dual-plane verification trade-off for this single takedown scenario (QA-BDD-01-F003)
-  # spec_trace: SPEC §5 (Behavior — state_transitions), SPEC §6 (Error Handling)
-
-@scenario-type:error @p1-high @scenario-id:BDD.01.03.6921
-@ears:EARS.01.03.aa59
-Scenario: Adoption counts are withheld from a caller without the Service-Owner role
-  Given a caller NOT bearing the Service-Owner role
-  And one issued short code "/abc123" with a visit count of 7
-  When the caller requests adoption counts
-  Then the Visit Counter SHALL deny access with the not-authorised status
-  And the response body SHALL NOT disclose any created-link count or per-link visit count
-  # denied-path companion to the granted-path count scenario (BDD.01.03.cb64)
-  # spec_trace: SPEC §3 (Interfaces), SPEC §5 (Behavior — authorization)
-
-@scenario-type:error @p1-high @scenario-id:BDD.01.03.f0a5
-@ears:EARS.01.03.4400 @ears:EARS.01.04.6f59
-Scenario: Flagged destination is withheld a short code
-  Given destination-reputation screening is enabled
-  And a Link Submitter with a destination the reputation source flags "harmful"
-  When the submitter posts the URL to the Shorten/Redirect API
-  Then the API SHALL NOT issue a short code for the flagged destination
-  And the API SHALL reject the submission with "That address can't be shortened — only public http/https web addresses are accepted."
-  # spec_trace: SPEC §5 (Behavior — abuse_control), SPEC §6 (Error Handling)
-
-@scenario-type:error @p2-medium @scenario-id:BDD.01.03.c65d
-@ears:EARS.01.03.fa0b
-Scenario: Automated-repeat visits are distinguished from the owner-visible adoption count
-  Given an issued short code "/abc123" receiving 10 visits within 1 second, of which 6 share a single automated source-signature and 4 are distinct human-attributed visits
-  When the repeated visits are processed
-  Then the Visit Counter SHALL exclude the 6 automated-repeat visits from the owner-visible adoption count for "/abc123", retaining each excluded visit tagged "automated=true", WITHIN @threshold:PRD.01.reliability.countstaleness
-  And the owner-visible adoption count for "/abc123" SHALL equal exactly 4, the number of human-attributed visits only
-  # the distinguish-not-bound branch is chosen so the observable is determinate; the input partition (10 visits → 6 automated / 4 human) pins the test oracle in-scenario (TL-BDD-02), leaving only the production detection heuristic to the adoption-metric-integrity ADR topic
-  # spec_trace: SPEC §5 (Behavior — adoption_integrity), SPEC §6 (Error Handling)
-```
-
-### 3.3 Recovery scenarios
-
-```gherkin
-@scenario-type:recovery @p1-high @scenario-id:BDD.01.03.41c7
-@ears:EARS.01.03.50d1 @ears:EARS.01.04.6f59
-Scenario Outline: Fail closed when the reputation source is degraded
-  Given destination-reputation screening is enabled
-  And the reputation source is "<degradation>"
-  When a Link Submitter posts a well-formed public URL
-  Then the Shorten/Redirect API SHALL reject create fail-closed with "Short links can't be created right now. Existing links still work." WITHIN @threshold:PRD.01.perf.screeningdeadline
-  And the API SHALL continue to redirect issued codes
-  And the API SHALL issue no short code
-  And the API SHALL emit a "screening_fail_closed" counter increment for the rejected create
-
-  Examples:
-    | degradation                          |
-    | unreachable                          |
-    | dns resolution failure               |
-    | tls handshake failure                |
-    | slow beyond the screening deadline   |
-  # dns-resolution and tls-handshake fixtures exercise partition variants on a different code path than an unreachable host (chaos partition breadth)
-  # spec_trace: SPEC §5 (Behavior — fail_closed), SPEC §6 (Error Handling — recovery)
-
-@scenario-type:recovery @p1-high @scenario-id:BDD.01.03.3757
-@ears:EARS.01.03.50d1
-Scenario: Reputation source recovers and a resubmission is issued a code
-  Given the reputation source was degraded and is now restored to "reachable"
-  When a Link Submitter resubmits a well-formed public URL
-  Then the Shorten/Redirect API SHALL screen the destination and issue a short code WITHIN @threshold:PRD.01.perf.screeningdeadline
-  # spec_trace: SPEC §5 (Behavior — recovery), SPEC §6 (Error Handling — recovery)
-
-@scenario-type:recovery @p1-high @scenario-id:BDD.01.03.3322
-@ears:EARS.01.03.9425
-Scenario: Counting outage never blocks redirect
-  Given the visit-counting path is stalled or failing
-  When a Link Visitor requests an otherwise-known short code "/abc123"
-  Then the Shorten/Redirect API SHALL still resolve the redirect to the original URL WITHIN @threshold:PRD.01.perf.redirectp95
-  And the system SHALL emit a "counting_path_degraded" metric increment, or a structured WARN log entry carrying a degradation_type field, marking the degraded-mode entry
-  # the degraded-mode observable makes silent counting degradation detectable by operators (OP-I2-001)
-  # spec_trace: SPEC §5 (Behavior — degraded_mode), SPEC §6 (Error Handling — recovery)
-
-@scenario-type:recovery @p1-high @scenario-id:BDD.01.03.02c1
-@ears:EARS.01.03.f766
-Scenario: Concurrent visits are recorded without loss
-  Given an issued short code "/abc123" with a visit count of 0
-  When 50 visits to "/abc123" are processed concurrently
-  Then the Visit Counter SHALL record every confirmed visit without loss, counting each distinct confirmed visit exactly once, WITHIN @threshold:PRD.01.reliability.countstaleness
-  And the reconciled visit count SHALL equal 50
-  # spec_trace: SPEC §5 (Behavior — concurrency), SPEC §4 (Data Models)
-
-@scenario-type:recovery @p1-high @scenario-id:BDD.01.03.1f90
-@ears:EARS.01.03.c4c9 @ears:EARS.01.04.5e5b @ears:EARS.01.04.cea3
-Scenario Outline: Mapping Store degradation during redirect returns a bounded error
-  Given an issued short code "/abc123" mapping to "https://example.com/page"
-  And the Mapping Store is "<degradation>"
-  When a Link Visitor requests "/abc123"
-  Then the Shorten/Redirect API SHALL return the bounded degraded response "Redirect temporarily unavailable, please retry." WITHIN @threshold:PRD.01.perf.redirectp95
-  And the API SHALL NOT hang beyond @threshold:PRD.01.perf.redirectp95 and SHALL NOT emit an unshed 5xx
-  And the system SHALL emit a "mapping_store_degraded" counter increment labelled with the "<degradation>" degradation_type for the degraded redirect
-
-  Examples:
-    | degradation                     |
-    | unreachable                     |
-    | dns resolution failure          |
-    | tls handshake failure           |
-    | slow beyond the redirect budget |
-  # the store-partition (unreachable), dns-resolution, tls-handshake, and slow-read variants exercise distinct client-side timeout/retry code paths (CHAOS-BDD-01 partition breadth, matching BDD.01.03.41c7); the "temporarily unavailable" wording is an author assumption pending a PRD §10 degraded-redirect message; the "mapping_store_degraded" observable makes silent store failure detectable by operators (OP-I2-002); recovery is asserted in BDD.01.03.44fe
-  # spec_trace: SPEC §5 (Behavior — degraded_mode), SPEC §6 (Error Handling — recovery)
-
-@scenario-type:recovery @p1-high @scenario-id:BDD.01.03.44fe
-@ears:EARS.01.04.5e5b @ears:EARS.01.03.c4c9
-Scenario: Mapping Store recovers and redirects resume
-  Given the Mapping Store was unreachable and is now restored to reachable
-  And an issued short code "/abc123" mapping to "https://example.com/page" committed at recovery-point-objective zero
-  When a Link Visitor requests "/abc123" after restoration
-  Then the Shorten/Redirect API SHALL redirect to "https://example.com/page" WITHIN @threshold:PRD.01.perf.redirectp95
-  # restoration counterpart to the degradation outline (BDD.01.03.1f90); RTO ≤ 30 min per EARS.01.04.5e5b
-  # spec_trace: SPEC §5 (Behavior — recovery), SPEC §4 (Data Models — durability)
-
-@scenario-type:recovery @p1-high @scenario-id:BDD.01.03.076f
-@ears:EARS.01.03.4425 @ears:EARS.01.03.9425
-Scenario: A slow visit counter never delays the redirect
-  Given an issued short code "/abc123" mapping to "https://example.com/page"
-  And the visit-counting dispatch is lagging beyond @threshold:PRD.01.reliability.countstaleness
-  When a Link Visitor requests "/abc123"
-  Then the Shorten/Redirect API SHALL resolve the redirect to "https://example.com/page" WITHIN @threshold:PRD.01.perf.redirectp95
-  And the increment SHALL be deferred or buffered off the synchronous redirect path
-  # proves the off-path dispatch decouples redirect latency from counter latency (EARS.01.03.4425); slow-but-not-failed counterpart to the counting-outage scenario (BDD.01.03.3322)
-  # spec_trace: SPEC §5 (Behavior — degraded_mode), SPEC §6 (NFR — performance isolation)
-
-@scenario-type:recovery @p1-high @scenario-id:BDD.01.03.976e
-@ears:EARS.01.03.f766 @ears:EARS.01.04.1898 @ears:EARS.01.03.4425
-Scenario: Counting path recovers and reconciles missed visits
-  Given the visit-counting path was stalled while 12 confirmed visits to "/abc123" occurred
-  And the counting path is now restored
-  When the counting path resumes
-  Then the Visit Counter SHALL reconcile the 12 confirmed visits without loss to the exactly-once outcome WITHIN @threshold:PRD.01.reliability.countstaleness
-  And the reconciled visit count for "/abc123" SHALL include every confirmed visit that occurred during the outage
-  And the system SHALL emit a "counting_path_recovered" event, or a structured INFO log entry carrying a reconciled_count field, when the counting path resumes and reconciliation completes
-  # recovery pair for the counting-outage degraded-mode scenario (BDD.01.03.3322); the recovery observable confirms self-heal in real time, not only via eventual count correctness (OP-I2-003)
-  # spec_trace: SPEC §5 (Behavior — recovery), SPEC §4 (Data Models — count durability)
-
-@scenario-type:recovery @p1-high @scenario-id:BDD.01.03.2a8c
-@ears:EARS.01.03.5442 @ears:EARS.01.03.eca5
-Scenario: Code-space capacity is reclaimed and creation resumes
-  Given the short-code space was at @threshold:PRD.01.quota.codespacecapacity and capacity has since been reclaimed
-  When a Link Submitter posts a well-formed public URL "https://example.com/page"
-  Then the Shorten/Redirect API SHALL resume issuing a unique short code that resolves to "https://example.com/page"
-  # recovery pair for the code-space-exhaustion rejection (BDD.01.03.177e); confirms no permanent capacity lockout
-  # spec_trace: SPEC §5 (Behavior — capacity), SPEC §6 (Error Handling — recovery)
-
-@scenario-type:recovery @p1-high @scenario-id:BDD.01.03.e61c
-@ears:EARS.01.03.50d1 @ears:EARS.01.03.5442
-Scenario: Concurrent reputation-unreachable and code-space-at-capacity yields the retryable message
-  Given destination-reputation screening is enabled
-  And the reputation source is "unreachable"
-  And the short-code space is at @threshold:PRD.01.quota.codespacecapacity
-  When a Link Submitter posts a well-formed public URL
-  Then the Shorten/Redirect API SHALL reject creation with the retryable "Short links can't be created right now. Existing links still work." message, not the non-retryable at-capacity message
-  And the API SHALL issue no short code
-  # exercises the EARS precedence note for simultaneous failure: the retryable fail-closed response (EARS.01.03.50d1) takes precedence over the non-retryable at-capacity response (EARS.01.03.5442) (CHAOS-BDD-02)
-  # spec_trace: SPEC §5 (Behavior — fail_closed precedence), SPEC §6 (Error Handling — recovery)
-```
-
-### 3.4 Parameterized scenarios
-
-```gherkin
-@scenario-type:parameterized @p1-high @scenario-id:BDD.01.03.588f
-@ears:EARS.01.03.97be
-Scenario Outline: Invalid destination is rejected across all invalid classes
-  Given a Link Submitter with the destination "<destination>" of class "<class>"
-  When the submitter posts the destination to the Shorten/Redirect API
-  Then the API SHALL reject it with "That address can't be shortened — only public http/https web addresses are accepted."
-  And the API SHALL return neither a 5xx response nor an issued code
-
-  Examples:
-    | class               | destination                              |
-    | empty               |                                          |
-    | over max length     | https://example.com/<2049-char-path>     |
-    | javascript scheme   | javascript:alert(1)                      |
-    | data scheme         | data:text/html,<script>1</script>        |
-    | file scheme         | file:///etc/passwd                       |
-    | malformed/relative  | /relative/path                           |
-  # over-max-length destination exceeds @threshold:PRD.01.quota.urlmaxlen by one character
-  # spec_trace: SPEC §5 (Behavior — input_validation), SPEC §6 (Error Handling)
-```
-
-### 3.5 Optional / feature-gated scenarios
-
-```gherkin
-@scenario-type:optional @p2-medium @scenario-id:BDD.01.03.3708
-@ears:EARS.01.03.6811
-Scenario: Destination screening is enforced when the feature gate is enabled
-  Given destination-reputation screening is enabled as a go-live precondition
-  And a Link Submitter with a destination the reputation source rates "clean"
-  When the destination passes URL validation
-  Then the Shorten/Redirect API SHALL screen the candidate destination at create time before issuing a short code
-  And the reputation-source test double SHALL record exactly one screening call
-  # spec_trace: SPEC §5 (Behavior — feature_gate), SPEC §3 (Interfaces)
+```yaml
+scenarios:
+- id: BDD.01.03.ccd6
+  name: Shorten a valid public URL
+  type: success
+  priority: p0-critical
+  ears:
+  - EARS.01.03.5066
+  - EARS.01.03.bca8
+  - EARS.01.03.6811
+  given:
+  - a Link Submitter with the well-formed public URL "https://example.com/page" within @threshold:PRD.01.quota.urlmaxlen
+  when:
+  - the submitter posts the URL to the Shorten/Redirect API
+  then:
+  - the API SHALL return a unique short code that resolves to exactly "https://example.com/page" WITHIN
+    @threshold:PRD.01.perf.screeningdeadline
+  - the API SHALL present the confirmation "Your short link is ready."
+  spec_trace:
+  - SPEC §3 (Interfaces), SPEC §5 (Behavior)
+- id: BDD.01.03.613b
+  name: Redirect a known short code
+  type: success
+  priority: p0-critical
+  ears:
+  - EARS.01.03.c4c9
+  - EARS.01.04.cea3
+  given:
+  - an issued short code "/abc123" mapping to "https://example.com/page"
+  when:
+  - a Link Visitor requests "/abc123"
+  then:
+  - the Shorten/Redirect API SHALL redirect to "https://example.com/page" WITHIN @threshold:PRD.01.perf.redirectp95
+  spec_trace:
+  - SPEC §3 (Interfaces), SPEC §5 (Behavior)
+- id: BDD.01.03.5645
+  name: Visit count increments exactly once on redirect
+  type: success
+  priority: p1-high
+  ears:
+  - EARS.01.03.4425
+  - EARS.01.04.1898
+  given:
+  - an issued short code "/abc123" with a visit count of 0
+  when:
+  - a Link Visitor completes one redirect of "/abc123"
+  then:
+  - the Visit Counter SHALL increment that code's visit count to exactly 1, dispatched off the synchronous
+    redirect path, WITHIN @threshold:PRD.01.reliability.countstaleness
+  notes:
+  - split from the former combined counting+idempotency scenario (QA-BDD-01-F002); idempotency under re-delivery
+    is asserted separately in BDD.01.03.1365
+  spec_trace:
+  - SPEC §5 (Behavior — async increment), SPEC §4 (Data Models)
+- id: BDD.01.03.1365
+  name: Duplicate redirect event does not double-count
+  type: success
+  priority: p1-high
+  ears:
+  - EARS.01.03.4425
+  - EARS.01.04.1898
+  given:
+  - an issued short code "/abc123" with a visit count of 1 after one confirmed redirect event
+  when:
+  - the same redirect event is re-delivered to the Visit Counter
+  then:
+  - the visit count for "/abc123" SHALL remain exactly 1, WITHIN @threshold:PRD.01.reliability.countstaleness
+  notes:
+  - idempotency half of the split counting scenario (QA-BDD-01-F002); proves off-path exactly-once delivery
+    under event re-delivery
+  spec_trace:
+  - SPEC §5 (Behavior — async increment idempotency), SPEC §4 (Data Models)
+- id: BDD.01.03.cb64
+  name: Service Owner sees created-link and per-link counts
+  type: success
+  priority: p1-high
+  ears:
+  - EARS.01.03.aa59
+  given:
+  - a caller bearing the Service-Owner role
+  - one issued short code "/abc123" with a visit count of 7
+  when:
+  - the caller requests adoption counts
+  then:
+  - the Visit Counter SHALL return the created-link count and the per-link visit count 7 for "/abc123"
+  spec_trace:
+  - SPEC §3 (Interfaces), SPEC §5 (Behavior — authorization)
+- id: BDD.01.03.a688
+  name: Issued code maps to exactly one URL for its lifetime
+  type: success
+  priority: p1-high
+  ears:
+  - EARS.01.03.bca8
+  given:
+  - an issued short code "/abc123" mapping to "https://example.com/page"
+  when:
+  - the same destination "https://example.com/page" is submitted again
+  then:
+  - the API SHALL return a code that resolves to exactly "https://example.com/page"
+  - the returned code SHALL resolve to exactly one original URL, namely "https://example.com/page"
+  notes:
+  - the system-wide code-to-URL uniqueness invariant (EARS.01.03.bca8) is verified as a property/contract
+    test at the TDD layer, not as an observable of this single resubmission
+  spec_trace:
+  - SPEC §4 (Data Models — invariant), SPEC §5 (Behavior)
+- id: BDD.01.03.ed49
+  name: Redirect latency and availability hold under sustained load
+  type: success
+  priority: p1-high
+  ears:
+  - EARS.01.03.feaa
+  - EARS.01.04.1598
+  - EARS.01.04.cea3
+  given:
+  - a single issued short code "/abc123" served at @threshold:PRD.01.rate.redirectsustained with 20 concurrent
+    visitors
+  when:
+  - the load is sustained for 5 minutes over at least 30,000 sampled requests
+  then:
+  - the Shorten/Redirect API SHALL sustain redirect latency WITHIN @threshold:PRD.01.perf.redirectp95
+  - the API SHALL sustain a within-window success rate of at least 99.9% over the sampled requests, with
+    no non-shed 5xx responses
+  - the redirect-path latency histogram metric SHALL be emitted with its route and status labels for every
+    sampled request
+  notes:
+  - the monthly availability SLO @threshold:PRD.01.reliability.availabilitymonthly is a long-horizon target
+    asserted separately; the within-window success rate above is its observable proxy
+  - measurement window (5 minutes) and minimum sample count are author assumptions pending a PRD §12 load-envelope
+    element
+  spec_trace:
+  - SPEC §5 (Behavior — performance), SPEC §6 (NFR)
+- id: BDD.01.03.f774
+  name: Capacity-utilization alert fires at the alert threshold
+  type: success
+  priority: p1-high
+  ears:
+  - EARS.01.03.eca5
+  given:
+  - short-code utilization is just below the capacity alert threshold
+  when:
+  - utilization reaches @threshold:PRD.01.quota.codespacecapacity alert level
+  then:
+  - the Shorten/Redirect API SHALL emit exactly one capacity-utilization alert identifying the current
+    utilization
+  notes:
+  - detection counterpart to the reject-at-capacity recovery (BDD.01.03.177e)
+  spec_trace:
+  - SPEC §5 (Behavior — capacity), SPEC §6 (NFR — observability)
+- id: BDD.01.03.9b90
+  name: Mapping survives a crash immediately after acknowledgement
+  type: success
+  priority: p1-high
+  ears:
+  - EARS.01.04.5e5b
+  given:
+  - a Link Submitter posts a well-formed public URL
+  when:
+  - the Shorten/Redirect API acknowledges the issued short code
+  - the Mapping Store is hard-killed before any post-acknowledgement flush
+  then:
+  - after the Mapping Store restarts the issued short code SHALL still resolve to the original URL, confirming
+    the mapping was durably committed at recovery-point-objective zero before acknowledgement
+  notes:
+  - 'crash-recovery probe gives "durably committed at ack" a deterministic observation point (TL-BDD-01):
+    RPO-zero is verified by survival of the hard-kill, not by an unobservable point-in-time assertion
+    at acknowledgement'
+  spec_trace:
+  - SPEC §4 (Data Models — durability), SPEC §5 (Behavior — write ordering)
+- id: BDD.01.03.e5ec
+  name: Issued codes are high-entropy and non-sequential
+  type: success
+  priority: p1-high
+  ears:
+  - EARS.01.03.ac68
+  - EARS.01.04.cb3b
+  given:
+  - the Shorten/Redirect API issues short codes on the public resolution surface
+  when:
+  - 1,000 codes are issued in sequence
+  then:
+  - no issued code SHALL be derivable by incrementing or decrementing another issued code
+  - the 1,000 issued codes SHALL be pairwise distinct and SHALL pass a monobit frequency test over their
+    concatenated bit-string at the significance level @threshold:PRD.01.security.codeentropy
+  spec_trace:
+  - SPEC §4 (Data Models — code generation), SPEC §6 (NFR — security)
+- id: BDD.01.03.567d
+  name: Resolution requests are rate-limited per source
+  type: success
+  priority: p1-high
+  ears:
+  - EARS.01.03.9903
+  - EARS.01.04.cb3b
+  given:
+  - the per-source resolution rate limit is @threshold:PRD.01.rate.resolutionpersource requests per @threshold:PRD.01.rate.resolutionwindow
+  when:
+  - one source issues one more than @threshold:PRD.01.rate.resolutionpersource resolution requests within
+    a single @threshold:PRD.01.rate.resolutionwindow
+  then:
+  - the Shorten/Redirect API SHALL throttle the request beyond the limit for that source
+  - resolution for other sources SHALL be unaffected
+  spec_trace:
+  - SPEC §3 (Interfaces — rate limiting), SPEC §6 (NFR — security)
+- id: BDD.01.03.c8a6
+  name: Mapping-store denies original-URL read to a principal without least-privilege grant
+  type: success
+  priority: p1-high
+  ears:
+  - EARS.01.03.4ebf
+  given:
+  - a stored code-to-URL mapping whose original-URL value is classified as may-contain-PII
+  when:
+  - a principal without the least-privilege read grant reads the mapping
+  then:
+  - the Mapping Store SHALL deny access to the original-URL value
+  notes:
+  - concrete access and erasure parameters are owned by the data-protection ADR topic
+  spec_trace:
+  - SPEC §4 (Data Models — classification), SPEC §6 (NFR — access control)
+- id: BDD.01.03.167e
+  name: Mapping-store permits original-URL read to a principal with least-privilege grant
+  type: success
+  priority: p1-high
+  ears:
+  - EARS.01.03.4ebf
+  given:
+  - a stored code-to-URL mapping whose original-URL value is classified as may-contain-PII
+  when:
+  - a principal holding the least-privilege read grant reads the mapping
+  then:
+  - the Mapping Store SHALL permit access to the original-URL value
+  notes:
+  - granted-path companion to the denied-path control (BDD.01.03.c8a6); access parameters owned by the
+    data-protection ADR topic
+  spec_trace:
+  - SPEC §4 (Data Models — classification), SPEC §6 (NFR — access control)
+- id: BDD.01.03.5ab2
+  name: Unknown short code returns not found
+  type: error
+  priority: p1-high
+  ears:
+  - EARS.01.03.e4db
+  given:
+  - no short code is issued for "/zzz999"
+  when:
+  - a Link Visitor requests "/zzz999"
+  then:
+  - the Shorten/Redirect API SHALL return "No such short link exists." WITHIN @threshold:PRD.01.perf.redirectp95
+  - the API SHALL NOT redirect the visitor
+  spec_trace:
+  - SPEC §5 (Behavior — error_handling), SPEC §3 (Interfaces)
+- id: BDD.01.03.177e
+  name: Code-space exhaustion returns a non-retryable capacity error
+  type: error
+  priority: p1-high
+  ears:
+  - EARS.01.03.5442
+  given:
+  - the short-code space is at @threshold:PRD.01.quota.codespacecapacity
+  when:
+  - a Link Submitter posts a well-formed public URL
+  then:
+  - the Shorten/Redirect API SHALL reject creation with "Short links are at capacity and can't be created
+    right now. Existing links still work."
+  - the API SHALL continue to resolve existing issued codes
+  - the API SHALL issue no short code
+  spec_trace:
+  - SPEC §5 (Behavior — capacity), SPEC §6 (Error Handling)
+- id: BDD.01.03.3c70
+  name: Flagged or taken-down code returns not found
+  type: error
+  priority: p1-high
+  ears:
+  - EARS.01.03.f62a
+  given:
+  - an issued short code "/abc123" whose destination is later flagged and taken down
+  when:
+  - a Link Visitor requests "/abc123"
+  then:
+  - the Shorten/Redirect API SHALL return "No such short link exists." WITHIN @threshold:PRD.01.perf.takedownsla
+  - the API SHALL NOT redirect the visitor
+  - the API SHALL emit a "link_takedown_applied" event identifying the taken-down code
+  notes:
+  - the "link_takedown_applied" event assertion (observability plane) is intentionally co-located with
+    the user-facing not-found outcome here; failure isolation between the behavioural and instrumentation
+    planes is accepted as a documented dual-plane verification trade-off for this single takedown scenario
+    (QA-BDD-01-F003)
+  spec_trace:
+  - SPEC §5 (Behavior — state_transitions), SPEC §6 (Error Handling)
+- id: BDD.01.03.6921
+  name: Adoption counts are withheld from a caller without the Service-Owner role
+  type: error
+  priority: p1-high
+  ears:
+  - EARS.01.03.aa59
+  given:
+  - a caller NOT bearing the Service-Owner role
+  - one issued short code "/abc123" with a visit count of 7
+  when:
+  - the caller requests adoption counts
+  then:
+  - the Visit Counter SHALL deny access with the not-authorised status
+  - the response body SHALL NOT disclose any created-link count or per-link visit count
+  notes:
+  - denied-path companion to the granted-path count scenario (BDD.01.03.cb64)
+  spec_trace:
+  - SPEC §3 (Interfaces), SPEC §5 (Behavior — authorization)
+- id: BDD.01.03.f0a5
+  name: Flagged destination is withheld a short code
+  type: error
+  priority: p1-high
+  ears:
+  - EARS.01.03.4400
+  - EARS.01.04.6f59
+  given:
+  - destination-reputation screening is enabled
+  - a Link Submitter with a destination the reputation source flags "harmful"
+  when:
+  - the submitter posts the URL to the Shorten/Redirect API
+  then:
+  - the API SHALL NOT issue a short code for the flagged destination
+  - the API SHALL reject the submission with "That address can't be shortened — only public http/https
+    web addresses are accepted."
+  spec_trace:
+  - SPEC §5 (Behavior — abuse_control), SPEC §6 (Error Handling)
+- id: BDD.01.03.c65d
+  name: Automated-repeat visits are distinguished from the owner-visible adoption count
+  type: error
+  priority: p2-medium
+  ears:
+  - EARS.01.03.fa0b
+  given:
+  - an issued short code "/abc123" receiving 10 visits within 1 second, of which 6 share a single automated
+    source-signature and 4 are distinct human-attributed visits
+  when:
+  - the repeated visits are processed
+  then:
+  - the Visit Counter SHALL exclude the 6 automated-repeat visits from the owner-visible adoption count
+    for "/abc123", retaining each excluded visit tagged "automated=true", WITHIN @threshold:PRD.01.reliability.countstaleness
+  - the owner-visible adoption count for "/abc123" SHALL equal exactly 4, the number of human-attributed
+    visits only
+  notes:
+  - the distinguish-not-bound branch is chosen so the observable is determinate; the input partition (10
+    visits → 6 automated / 4 human) pins the test oracle in-scenario (TL-BDD-02), leaving only the production
+    detection heuristic to the adoption-metric-integrity ADR topic
+  spec_trace:
+  - SPEC §5 (Behavior — adoption_integrity), SPEC §6 (Error Handling)
+- id: BDD.01.03.41c7
+  name: Fail closed when the reputation source is degraded
+  type: recovery
+  priority: p1-high
+  ears:
+  - EARS.01.03.50d1
+  - EARS.01.04.6f59
+  outline: true
+  given:
+  - destination-reputation screening is enabled
+  - the reputation source is "<degradation>"
+  when:
+  - a Link Submitter posts a well-formed public URL
+  then:
+  - the Shorten/Redirect API SHALL reject create fail-closed with "Short links can't be created right
+    now. Existing links still work." WITHIN @threshold:PRD.01.perf.screeningdeadline
+  - the API SHALL continue to redirect issued codes
+  - the API SHALL issue no short code
+  - the API SHALL emit a "screening_fail_closed" counter increment for the rejected create
+  examples:
+    headers:
+    - degradation
+    rows:
+    - - unreachable
+    - - dns resolution failure
+    - - tls handshake failure
+    - - slow beyond the screening deadline
+  notes:
+  - dns-resolution and tls-handshake fixtures exercise partition variants on a different code path than
+    an unreachable host (chaos partition breadth)
+  spec_trace:
+  - SPEC §5 (Behavior — fail_closed), SPEC §6 (Error Handling — recovery)
+- id: BDD.01.03.3757
+  name: Reputation source recovers and a resubmission is issued a code
+  type: recovery
+  priority: p1-high
+  ears:
+  - EARS.01.03.50d1
+  given:
+  - the reputation source was degraded and is now restored to "reachable"
+  when:
+  - a Link Submitter resubmits a well-formed public URL
+  then:
+  - the Shorten/Redirect API SHALL screen the destination and issue a short code WITHIN @threshold:PRD.01.perf.screeningdeadline
+  spec_trace:
+  - SPEC §5 (Behavior — recovery), SPEC §6 (Error Handling — recovery)
+- id: BDD.01.03.3322
+  name: Counting outage never blocks redirect
+  type: recovery
+  priority: p1-high
+  ears:
+  - EARS.01.03.9425
+  given:
+  - the visit-counting path is stalled or failing
+  when:
+  - a Link Visitor requests an otherwise-known short code "/abc123"
+  then:
+  - the Shorten/Redirect API SHALL still resolve the redirect to the original URL WITHIN @threshold:PRD.01.perf.redirectp95
+  - the system SHALL emit a "counting_path_degraded" metric increment, or a structured WARN log entry
+    carrying a degradation_type field, marking the degraded-mode entry
+  notes:
+  - the degraded-mode observable makes silent counting degradation detectable by operators (OP-I2-001)
+  spec_trace:
+  - SPEC §5 (Behavior — degraded_mode), SPEC §6 (Error Handling — recovery)
+- id: BDD.01.03.02c1
+  name: Concurrent visits are recorded without loss
+  type: recovery
+  priority: p1-high
+  ears:
+  - EARS.01.03.f766
+  given:
+  - an issued short code "/abc123" with a visit count of 0
+  when:
+  - 50 visits to "/abc123" are processed concurrently
+  then:
+  - the Visit Counter SHALL record every confirmed visit without loss, counting each distinct confirmed
+    visit exactly once, WITHIN @threshold:PRD.01.reliability.countstaleness
+  - the reconciled visit count SHALL equal 50
+  spec_trace:
+  - SPEC §5 (Behavior — concurrency), SPEC §4 (Data Models)
+- id: BDD.01.03.1f90
+  name: Mapping Store degradation during redirect returns a bounded error
+  type: recovery
+  priority: p1-high
+  ears:
+  - EARS.01.03.c4c9
+  - EARS.01.04.5e5b
+  - EARS.01.04.cea3
+  outline: true
+  given:
+  - an issued short code "/abc123" mapping to "https://example.com/page"
+  - the Mapping Store is "<degradation>"
+  when:
+  - a Link Visitor requests "/abc123"
+  then:
+  - the Shorten/Redirect API SHALL return the bounded degraded response "Redirect temporarily unavailable,
+    please retry." WITHIN @threshold:PRD.01.perf.redirectp95
+  - the API SHALL NOT hang beyond @threshold:PRD.01.perf.redirectp95 and SHALL NOT emit an unshed 5xx
+  - the system SHALL emit a "mapping_store_degraded" counter increment labelled with the "<degradation>"
+    degradation_type for the degraded redirect
+  examples:
+    headers:
+    - degradation
+    rows:
+    - - unreachable
+    - - dns resolution failure
+    - - tls handshake failure
+    - - slow beyond the redirect budget
+  notes:
+  - the store-partition (unreachable), dns-resolution, tls-handshake, and slow-read variants exercise
+    distinct client-side timeout/retry code paths (CHAOS-BDD-01 partition breadth, matching BDD.01.03.41c7);
+    the "temporarily unavailable" wording is an author assumption pending a PRD §10 degraded-redirect
+    message; the "mapping_store_degraded" observable makes silent store failure detectable by operators
+    (OP-I2-002); recovery is asserted in BDD.01.03.44fe
+  spec_trace:
+  - SPEC §5 (Behavior — degraded_mode), SPEC §6 (Error Handling — recovery)
+- id: BDD.01.03.44fe
+  name: Mapping Store recovers and redirects resume
+  type: recovery
+  priority: p1-high
+  ears:
+  - EARS.01.04.5e5b
+  - EARS.01.03.c4c9
+  given:
+  - the Mapping Store was unreachable and is now restored to reachable
+  - an issued short code "/abc123" mapping to "https://example.com/page" committed at recovery-point-objective
+    zero
+  when:
+  - a Link Visitor requests "/abc123" after restoration
+  then:
+  - the Shorten/Redirect API SHALL redirect to "https://example.com/page" WITHIN @threshold:PRD.01.perf.redirectp95
+  notes:
+  - restoration counterpart to the degradation outline (BDD.01.03.1f90); RTO ≤ 30 min per EARS.01.04.5e5b
+  spec_trace:
+  - SPEC §5 (Behavior — recovery), SPEC §4 (Data Models — durability)
+- id: BDD.01.03.076f
+  name: A slow visit counter never delays the redirect
+  type: recovery
+  priority: p1-high
+  ears:
+  - EARS.01.03.4425
+  - EARS.01.03.9425
+  given:
+  - an issued short code "/abc123" mapping to "https://example.com/page"
+  - the visit-counting dispatch is lagging beyond @threshold:PRD.01.reliability.countstaleness
+  when:
+  - a Link Visitor requests "/abc123"
+  then:
+  - the Shorten/Redirect API SHALL resolve the redirect to "https://example.com/page" WITHIN @threshold:PRD.01.perf.redirectp95
+  - the increment SHALL be deferred or buffered off the synchronous redirect path
+  notes:
+  - proves the off-path dispatch decouples redirect latency from counter latency (EARS.01.03.4425); slow-but-not-failed
+    counterpart to the counting-outage scenario (BDD.01.03.3322)
+  spec_trace:
+  - SPEC §5 (Behavior — degraded_mode), SPEC §6 (NFR — performance isolation)
+- id: BDD.01.03.976e
+  name: Counting path recovers and reconciles missed visits
+  type: recovery
+  priority: p1-high
+  ears:
+  - EARS.01.03.f766
+  - EARS.01.04.1898
+  - EARS.01.03.4425
+  given:
+  - the visit-counting path was stalled while 12 confirmed visits to "/abc123" occurred
+  - the counting path is now restored
+  when:
+  - the counting path resumes
+  then:
+  - the Visit Counter SHALL reconcile the 12 confirmed visits without loss to the exactly-once outcome
+    WITHIN @threshold:PRD.01.reliability.countstaleness
+  - the reconciled visit count for "/abc123" SHALL include every confirmed visit that occurred during
+    the outage
+  - the system SHALL emit a "counting_path_recovered" event, or a structured INFO log entry carrying a
+    reconciled_count field, when the counting path resumes and reconciliation completes
+  notes:
+  - recovery pair for the counting-outage degraded-mode scenario (BDD.01.03.3322); the recovery observable
+    confirms self-heal in real time, not only via eventual count correctness (OP-I2-003)
+  spec_trace:
+  - SPEC §5 (Behavior — recovery), SPEC §4 (Data Models — count durability)
+- id: BDD.01.03.2a8c
+  name: Code-space capacity is reclaimed and creation resumes
+  type: recovery
+  priority: p1-high
+  ears:
+  - EARS.01.03.5442
+  - EARS.01.03.eca5
+  given:
+  - the short-code space was at @threshold:PRD.01.quota.codespacecapacity and capacity has since been
+    reclaimed
+  when:
+  - a Link Submitter posts a well-formed public URL "https://example.com/page"
+  then:
+  - the Shorten/Redirect API SHALL resume issuing a unique short code that resolves to "https://example.com/page"
+  notes:
+  - recovery pair for the code-space-exhaustion rejection (BDD.01.03.177e); confirms no permanent capacity
+    lockout
+  spec_trace:
+  - SPEC §5 (Behavior — capacity), SPEC §6 (Error Handling — recovery)
+- id: BDD.01.03.e61c
+  name: Concurrent reputation-unreachable and code-space-at-capacity yields the retryable message
+  type: recovery
+  priority: p1-high
+  ears:
+  - EARS.01.03.50d1
+  - EARS.01.03.5442
+  given:
+  - destination-reputation screening is enabled
+  - the reputation source is "unreachable"
+  - the short-code space is at @threshold:PRD.01.quota.codespacecapacity
+  when:
+  - a Link Submitter posts a well-formed public URL
+  then:
+  - the Shorten/Redirect API SHALL reject creation with the retryable "Short links can't be created right
+    now. Existing links still work." message, not the non-retryable at-capacity message
+  - the API SHALL issue no short code
+  notes:
+  - 'exercises the EARS precedence note for simultaneous failure: the retryable fail-closed response (EARS.01.03.50d1)
+    takes precedence over the non-retryable at-capacity response (EARS.01.03.5442) (CHAOS-BDD-02)'
+  spec_trace:
+  - SPEC §5 (Behavior — fail_closed precedence), SPEC §6 (Error Handling — recovery)
+- id: BDD.01.03.588f
+  name: Invalid destination is rejected across all invalid classes
+  type: parameterized
+  priority: p1-high
+  ears:
+  - EARS.01.03.97be
+  outline: true
+  given:
+  - a Link Submitter with the destination "<destination>" of class "<class>"
+  when:
+  - the submitter posts the destination to the Shorten/Redirect API
+  then:
+  - the API SHALL reject it with "That address can't be shortened — only public http/https web addresses
+    are accepted."
+  - the API SHALL return neither a 5xx response nor an issued code
+  examples:
+    headers:
+    - class
+    - destination
+    rows:
+    - - empty
+      - ''
+    - - over max length
+      - https://example.com/<2049-char-path>
+    - - javascript scheme
+      - javascript:alert(1)
+    - - data scheme
+      - data:text/html,<script>1</script>
+    - - file scheme
+      - file:///etc/passwd
+    - - malformed/relative
+      - /relative/path
+  notes:
+  - over-max-length destination exceeds @threshold:PRD.01.quota.urlmaxlen by one character
+  spec_trace:
+  - SPEC §5 (Behavior — input_validation), SPEC §6 (Error Handling)
+- id: BDD.01.03.3708
+  name: Destination screening is enforced when the feature gate is enabled
+  type: optional
+  priority: p2-medium
+  ears:
+  - EARS.01.03.6811
+  given:
+  - destination-reputation screening is enabled as a go-live precondition
+  - a Link Submitter with a destination the reputation source rates "clean"
+  when:
+  - the destination passes URL validation
+  then:
+  - the Shorten/Redirect API SHALL screen the candidate destination at create time before issuing a short
+    code
+  - the reputation-source test double SHALL record exactly one screening call
+  spec_trace:
+  - SPEC §5 (Behavior — feature_gate), SPEC §3 (Interfaces)
 ```
 
 ## 4. Traceability

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -47,10 +47,15 @@
 >    + the `04_BDD/*.md` playbook **bodies** (Gherkin → YAML scenario references;
 >    PR-3 only bumped their version frontmatter, not content). framework/ change →
 >    needs its own PATCH bump (0.29.0 → 0.29.1).
-> 4. **PR-4** corpus + the 7 `BDD-01_golden` acceptance fixtures migration (run
->    the PR-1 transcoder; `missing_section.md` is no-Gherkin/verify-only;
->    `drift_codes.yaml` verify-only). Verify V4 ID-stability + V11 corpus. NOT a
->    framework/ change (examples/ + tests/) → no bump.
+> 4. ✅ **PR-4 (SHIPPED this session) — corpus BDD-01 migrated to YAML.** The
+>    transcoder (hardened: fence-classified placement + doc-control row strip +
+>    empty-subheading collapse) converted `examples/.../04_BDD/BDD-01.md` (31
+>    scenarios, ids verbatim → all 16 downstream `@bdd:` resolve, V4). **Corpus
+>    REFGRAN 7 → 5** (2 BDD edges gone; the 5 SPEC/TDD/IPLAN `@adr`/`@tdd` remain
+>    = `CORPUS-REFGRAN-RECASCADE`). The 7 `BDD-01_golden` fixtures were already
+>    non-Gherkin → no change. New corpus baseline: **1 TH-RES, 5 REFGRAN, 6 STY02**.
+>    290 unit/conformance green; acceptance unchanged (3 pre-existing SPEC `@adr`
+>    failures). Not framework/ → no bump.
 > 5. **PR-5** `doc-bdd*` skills rewrite (keep `test_skill_template_alignment` /
 >    `plm_lint` / `test_autopilot_saga_parity` green).
 > 6. **PR-6** governance docs (GD-03 note, `TAG_SYNTAX.md` BDD row,
@@ -63,7 +68,7 @@
 > **How to resume:** read this banner + `plans/YAML-BDD-SCHEMA-PLAN.md` (D-1…D-6,
 > the schema, the 5-function linter-fork contract, V1–V11). Linter lives in
 > `tools/sdd_doc_lint/__init__.py`; transcoder/emitter go in `tools/`; tests in
-> `tests/unit/`. Corpus baseline for the V11 cross-check: 1× TH-RES-001, 7×
+> `tests/unit/`. Corpus baseline for the V11 cross-check (post-PR-4): 1× TH-RES-001, 5×
 > REFGRAN01, 6× STY02 on `main`.
 >
 > **Note:** YAML-BDD resolves the **2 BDD** REFGRAN edges; the **5

--- a/tests/unit/test_gherkin_to_bdd_yaml.py
+++ b/tests/unit/test_gherkin_to_bdd_yaml.py
@@ -98,6 +98,44 @@ class TranscoderEngine(unittest.TestCase):
         self.assertEqual(reloaded[0]["id"], "BDD.01.03.ccd6")
         self.assertEqual(reloaded[1]["examples"]["headers"], ["input_type", "value"])
 
+    def test_transcode_multifence_placement_and_cleanup(self) -> None:
+        # Realistic corpus shape: feature in one fence (§2), scenarios in a
+        # later fence (§3) under per-category sub-headings; a Document Control
+        # @ears reference row. The transcoder must: put feature yaml in §2,
+        # scenarios yaml in §3, drop the doc-control row, collapse the now-empty
+        # category sub-headings.
+        md = (
+            "---\ndoc_id: BDD-01\nartifact_type: BDD\n---\n\n"
+            "## 1. Document Control\n\n"
+            "| EARS reference | @ears: EARS-01 |\n"
+            "| Status | Draft |\n\n"
+            "## 2. Feature Definition\n\n"
+            "```gherkin\n@ears:EARS-01 @bdd:BDD-01\nFeature: F\n  As a user\n"
+            "  Background:\n    Given ready\n```\n\n"
+            "## 3. Scenario Structure\n\n"
+            "### 3.1 Success scenarios\n\n"
+            "```gherkin\n@scenario-type:success @p0-critical @scenario-id:BDD.01.03.ccd6\n"
+            "@ears:EARS.01.03.5066\nScenario: S1\n  Given g\n  When w\n  Then t\n```\n\n"
+            "### 3.2 Error scenarios\n\n"
+            "```gherkin\n@scenario-type:error @p1-high @scenario-id:BDD.01.03.eeee\n"
+            "@ears:EARS.01.03.bbbb\nScenario: S2\n  Given g\n  When w\n  Then t\n```\n\n"
+            "## 4. Traceability\n\n@bdd: BDD-01\n"
+        )
+        out = transcode_markdown(md)
+        # doc-control @ears row dropped
+        self.assertNotIn("| EARS reference |", out)
+        # both scenario ids present (verbatim), in one consolidated block
+        self.assertIn("id: BDD.01.03.ccd6", out)
+        self.assertIn("id: BDD.01.03.eeee", out)
+        self.assertEqual(out.count("```yaml"), 2)  # feature block + scenarios block
+        self.assertNotIn("```gherkin", out)
+        # empty '### 3.2 Error scenarios' collapsed; the one with content stays
+        self.assertNotIn("### 3.2 Error scenarios", out)
+        self.assertIn("### 3.1 Success scenarios", out)
+        # §3 heading + §4 heading preserved (STRUCT01)
+        self.assertIn("## 3. Scenario Structure", out)
+        self.assertIn("## 4. Traceability", out)
+
     def test_transcode_markdown_replaces_fence(self) -> None:
         md = (
             "---\ndoc_id: BDD-01\nartifact_type: BDD\n---\n\n## 3. Scenarios\n\n```gherkin\n"

--- a/tools/gherkin_to_bdd_yaml.py
+++ b/tools/gherkin_to_bdd_yaml.py
@@ -190,25 +190,63 @@ def render_feature_yaml(feature: dict) -> str:
 
 def transcode_markdown(md_text: str) -> str:
     """Rewrite a BDD doc's ``​```gherkin`` block(s) into ``​```yaml`` feature +
-    scenarios blocks. Non-Gherkin content is preserved verbatim."""
+    scenarios blocks, placing each where it belongs (fence-classified).
+
+    The real corpus splits Gherkin across multiple fences — the `Feature:` block
+    in §2 and scenarios across §3. So: the **feature** YAML replaces the fence
+    that declares `Feature:`; the **scenarios** YAML replaces the FIRST fence that
+    declares a `Scenario`; any further scenario fences are blanked (their content
+    is already folded into the single scenarios block). If a single fence holds
+    both, both YAML blocks land there. Non-Gherkin content is preserved verbatim.
+    """
+    # Drop the §1 Document Control upstream-reference rows — trace now lives on
+    # each scenario's `ears:` list, so a doc-level `@ears/@prd/@brd` here is an
+    # orphan doc-form tag (REFGRAN01). Matches the template, which removed them.
+    md_text = re.sub(
+        r"^\|\s*(?:EARS|PRD|BRD) reference\s*\|[^\n]*\|[ \t]*\n",
+        "",
+        md_text,
+        flags=re.MULTILINE | re.IGNORECASE,
+    )
+
     fence = re.compile(r"```gherkin\n(.*?)\n```", re.DOTALL)
-    blocks = fence.findall(md_text)
+    blocks = [m.group(1) for m in fence.finditer(md_text)]
     if not blocks:
         return md_text
     parsed = parse_gherkin_feature("\n\n".join(blocks))
     feature_yaml = "```yaml\n" + render_feature_yaml(parsed["feature"]) + "```"
     scenarios_yaml = "```yaml\n" + render_scenarios_yaml(parsed["scenarios"]) + "```"
 
-    first = True
+    feature_idx = next((i for i, b in enumerate(blocks) if "Feature:" in b), None)
+    scn_idxs = [i for i, b in enumerate(blocks) if re.search(r"^\s*Scenario", b, re.MULTILINE)]
+    first_scn = scn_idxs[0] if scn_idxs else None
+
+    replacement: dict[int, str] = {}
+    if feature_idx is not None:
+        replacement[feature_idx] = feature_yaml
+    if first_scn is not None:
+        if first_scn == feature_idx:
+            replacement[feature_idx] = feature_yaml + "\n\n" + scenarios_yaml
+        else:
+            replacement[first_scn] = scenarios_yaml
+    elif feature_idx is not None:
+        # No separate scenario fence — fold scenarios into the feature fence.
+        replacement[feature_idx] = feature_yaml + "\n\n" + scenarios_yaml
+
+    counter = {"i": -1}
 
     def _replace(_m: re.Match) -> str:
-        nonlocal first
-        if first:
-            first = False
-            return feature_yaml + "\n\n" + scenarios_yaml
-        return ""  # subsequent gherkin blocks folded into the first
+        counter["i"] += 1
+        return replacement.get(counter["i"], "")  # unlisted fences blanked
 
-    return fence.sub(_replace, md_text)
+    result = fence.sub(_replace, md_text)
+    # Collapse now-empty '### ...' scenario sub-headings: with the flat,
+    # type-discriminated `scenarios:` list, the per-category sub-sections
+    # (Error/Recovery/Parameterized/Optional) whose fences were folded into the
+    # single block are left empty. Drop a '### …' heading followed only by blank
+    # lines up to the next heading.
+    result = re.sub(r"^### [^\n]*\n(?:[ \t]*\n)+(?=#{2,3} )", "", result, flags=re.MULTILINE)
+    return result
 
 
 def main(argv: list[str] | None = None) -> int:


### PR DESCRIPTION
## Summary

The **corpus payoff** of YAML-BDD-SCHEMA — the framework migrates its own showcase artifact end-to-end (machine-produced by the transcoder; **never hand-edited**, per CLAUDE.md).

## Changes

- **`examples/url-shortener/docs/04_BDD/BDD-01.md`** — Gherkin → structured YAML `scenarios:` block. **31 scenarios**; each `@scenario-id` **copied verbatim** so all **16 downstream `@bdd:` citations still resolve** (V4 ID-stability); inline `@threshold:` preserved; `#` comments lifted to `spec_trace:`/`notes:`. **Drops both BDD REFGRAN edges → corpus REFGRAN 7 → 5** (the remaining 5 are SPEC/TDD/IPLAN `@adr`/`@tdd`, tracked by `CORPUS-REFGRAN-RECASCADE`).
- **`tools/gherkin_to_bdd_yaml.py`** — hardened for the real multi-fence corpus: fence-classified placement (feature → §2, scenarios → §3), Document Control reference-row strip, empty category sub-heading collapse. +1 multi-fence test.
- Acceptance `BDD-01_golden` fixtures are already non-Gherkin → **no change**.

## Verification

- **290 unit + conformance** green; transcoder tests now 7.
- **Acceptance unchanged** — the 3 failing cases (`SPEC-01_golden.yaml @adr: ADR-01` doc-form REFGRAN in tdd/iplan/fullpath) are **pre-existing on main** (`CORPUS-REFGRAN-RECASCADE`, not BDD; verified by stash-test).
- **Content faithful** — IDs verbatim, thresholds inline, spec_trace/notes lifted; 13 success / 6 error / 10 recovery / 1 param / 1 optional; 3 outlines with examples.
- New corpus baseline: **1 TH-RES, 5 REFGRAN, 6 STY02**.

## Scope

Not a `framework/` change (examples/ + tools/ + tests/) → **no version bump, not spec-tier**. Next: PR-3b (playbook bodies + QUICK_REFERENCE), PR-5 (doc-bdd skills).

🤖 Generated with [Claude Code](https://claude.com/claude-code)