### PR TITLE
docs: session wrap — YAML-BDD arc core complete; next-session resume state

### DIFF
--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -35,6 +35,17 @@
 > the element-level `COV01`/`COV02` upgrade (catches the 15 orphaned BDD
 > scenarios), `BL-STATUS-SCOPE` (PR-3b), sub-PRs 2c (phase reconciliation) + 2d
 > (BDD roll-up), and the D54/ENG/BL items for the later waves.
+>
+> **YAML-BDD-SCHEMA arc — CORE COMPLETE (2026-06-28):** migrated BDD off
+> Gherkin-in-markdown to structured YAML `scenarios:` blocks. Plan #197 (D-0038,
+> 3-pass). **Shipped:** PR-1 transcoder + `_THRESHOLD` fix (#198); PR-2
+> `sdd_doc_lint` dual-mode parse path + `BDD-SCHEMA-001` (#200); PR-3 template +
+> schema + GD-03/TAG_SYNTAX (framework `0.29.0`, #201); PR-4 corpus BDD-01
+> migration (REFGRAN 7→5, #202); PR-5 `doc-bdd*` skills (plugin `0.23.0`, #203).
+> **Remaining:** (a) **PR-3b** — `04_BDD/*.md` playbook bodies + `QUICK_REFERENCE.md`
+> Gherkin→YAML prose (PATCH `0.29.1`); (b) **element-level COV01/COV02 upgrade**
+> — the deferred payoff, now unblocked (catches the 15 orphaned BDD scenarios);
+> (c) `CORPUS-REFGRAN-RECASCADE` (below) — now just the 5 SPEC/TDD/IPLAN edges.
 
 ### `[sync]` `BUMP-SKILL-AUTHORING-CHECKLIST-STRAGGLER` — `bump_version.py` misses the SKILL_AUTHORING acceptance-checklist line
 
@@ -73,21 +84,22 @@
   (framework spec …)` line specifically) so future bumps stop rewriting
   provenance. Restored the two lines by hand in `a0cb426f`.
 
-### `[example-corpus]` `CORPUS-REFGRAN-RECASCADE` — 7 doc-level trace tags need element-level re-cascade (REFGRAN01)
+### `[example-corpus]` `CORPUS-REFGRAN-RECASCADE` — 5 SPEC/TDD/IPLAN doc-level `@adr`/`@tdd` tags need element-level re-cascade (REFGRAN01)
 
-- *Context:* CFB-PR-3 shipped `REFGRAN01` (GD-03 enforcement). The corpus carries
-  **7 doc-level trace tags to element-declaring layers** (warnings in `build`,
-  errors in `gate-code`): `BDD-01:31,55`, `SPEC-01:31,67,469`, `TDD-01:204`,
-  `IPLAN-01:43`. 5 are redundant (drop — element-level sibling present); 2 need
-  conversion (`BDD-01:55` feature `@ears` → fan-out the union of its 26 scenarios'
-  elements per GD-03; `SPEC-01:67` prose → element-level).
-- *Fix shape:* re-cascade via the `doc-<layer>-fixer` skills (never hand-edit) —
-  **blocked in framework-dev sessions** (the plugin skills aren't invocable
-  here). Either run the fixers in a live plugin session, OR add a REFGRAN
-  `--fix` mechanical auto-fixer (drop-redundant + fan-out are deterministic;
-  aligns with PR-4's `rehash` subcommand direction). Until then `REFGRAN01` is
-  warnings-only in `build` mode (does not raise the exit code); gate-code-clean
-  (plan V7) lands with the re-cascade.
+- *Context:* CFB-PR-3 shipped `REFGRAN01` (GD-03 enforcement). Originally **7**
+  doc-level trace tags; **YAML-BDD-SCHEMA PR-4 (#202) resolved the 2 BDD edges**
+  (`BDD-01:31,55`) by migrating BDD-01 to YAML `ears:` lists. **5 remain** (all
+  non-BDD, warnings in `build` / errors in `gate-code`): `SPEC-01:31,67,469`,
+  `TDD-01:204`, `IPLAN-01:43` — doc-form `@adr: ADR-01` / `@tdd: TDD-01`. 3 are
+  same-line redundant drops (`SPEC-01:31,469`, `TDD-01:204`); 1 table-cell drop
+  (`IPLAN-01:43`); 1 prose convert/drop (`SPEC-01:67`). Same 3 cases also fail
+  the acceptance suite (pre-existing) on the `SPEC-01_golden` fixtures.
+- *Fix shape:* re-cascade via the `doc-<layer>-fixer` skills in a live plugin
+  session (now rewritten for YAML BDD but the SPEC/TDD/IPLAN fixers handle
+  markdown `@`-tags), OR a `REFGRAN --fix` mechanical auto-fixer (the 3 same-line
+  drops are deterministic; `SPEC-01:67` prose needs a judgment call). Until then
+  `REFGRAN01` is warnings-only in `build`; gate-code-clean lands with the
+  re-cascade. The Gherkin complexity that originally blocked this is gone.
 
 ### `[example-corpus]` `CORPUS-PRD-TH-RES` — PRD-01 missing `component_decomposition` → 11 unresolvable `@threshold:` citations
 

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -1,18 +1,51 @@
 # Session Handoff
 
-> **🟢 YAML-BDD-SCHEMA plan MERGED — implementation starting (2026-06-28). `main`
-> at `dfb57309`.**
+> **🟢 YAML-BDD-SCHEMA arc — CORE COMPLETE (PR-1…PR-5 merged, 2026-06-28).
+> `main` at `1407f445`; framework spec `0.29.0`, plugin `0.23.0`.**
 >
-> A new design-of-record landed: **`plans/YAML-BDD-SCHEMA-PLAN.md`** (PR #197,
-> `dfb57309`) — migrate BDD scenarios from Gherkin-in-markdown to a structured
-> **YAML scenarios block inside `BDD-NN.md`** + an on-demand YAML→Gherkin
-> emitter. Converged over 3 independent gap-review passes; decision logged as
-> **D-0038** (plan D-1…D-6). This supersedes the BDD portion of
-> CFB-PR-3's REFGRAN fan-out — the Gherkin/GD-03 tag collision is dissolved at
-> the root (typed `ears` lists, no delimiter), feature coverage = union of
-> scenario `ears` (no fan-out), and it sets up the element-level COV02 upgrade.
+> Design-of-record **`plans/YAML-BDD-SCHEMA-PLAN.md`** (PR #197, D-0038, 3-pass
+> converged) → migrate BDD off Gherkin-in-markdown to a structured **YAML
+> `scenarios:` block inside `BDD-NN.md`**. The whole loop is now closed: spec
+> describes it (PR-3 template+GD-03+TAG_SYNTAX), linter reads it (PR-2 dual-mode),
+> transcoder + `doc-bdd*` skills produce it (PR-1/PR-5), corpus is it (PR-4
+> BDD-01). The Gherkin/GD-03 tag collision (the CFB-PR-3 26-element fan-out) is
+> dissolved at the root; IDs stable (16 downstream `@bdd:` resolve); coverage now
+> element-precise. **Merged:** #198 (PR-1) · #200 (PR-2) · #201 (PR-3, spec-tier
+> 0.29.0) · #202 (PR-4) · #203 (PR-5, plugin 0.23.0). (Note: GD-04 #199 landed
+> 0.28.0 mid-arc → PR-3 re-bumped to 0.29.0.)
 >
-> **▶ RESUME HERE — implementation is a ~7 PR sequence:**
+> **▶ RESUME HERE — next session, priority order:**
+>
+> 1. **PR-3b** (PATCH framework `0.29.0 → 0.29.1`) — the deferred governance
+>    polish: `framework/playbooks/04_BDD/*.md` **bodies** (qa_lead, auditor,
+>    chaos_engineer, security_engineer, tech_lead, operator — Gherkin→YAML
+>    scenario prose) + `framework/QUICK_REFERENCE.md`. PR-3 bumped their version
+>    frontmatter but NOT their content. framework/ change → carries the PATCH bump
+>    (GATE-SPEC). Spec-tier → human sign-off.
+> 2. **Element-level COV01/COV02 upgrade** — the deferred PAYOFF, now unblocked by
+>    element-precise YAML BDD: upgrade the coverage gates from doc-level to
+>    element-level so they catch the **15 orphaned BDD scenarios** (31 declared −
+>    16 cited downstream). New plan → 2-cycle review → impl. Design-of-record:
+>    `CFB-PR-2-COVERAGE-ENGINE-PLAN.md` DD-5/DD-6 + the BDD `ears:` lists are now
+>    the element-level signal the upgrade needs.
+> 3. **`CORPUS-REFGRAN-RECASCADE`** (`FRAMEWORK-TODO.md`) — now just the **5
+>    SPEC/TDD/IPLAN `@adr`/`@tdd` doc-form edges** (PR-4 resolved the 2 BDD ones).
+>    3 same-line drops + 1 table-cell (IPLAN-01:43) + 1 prose (SPEC-01:67). Run
+>    the `doc-<layer>-fixer` skills in a plugin session, OR a `REFGRAN --fix`.
+> 4. Tooling/backlog (`FRAMEWORK-TODO.md`): `RELEASE-CHANGELOG-TEST-CONVENTION-GAP`
+>    (keeps biting — we add `[Unreleased]` entries it doesn't recognize),
+>    `BUMP-SKILL-AUTHORING-CHECKLIST-STRAGGLER`, `CORPUS-PRD-TH-RES`,
+>    `INDEX-UPSTREAM-RESIDUE`.
+>
+> **How to resume:** read this banner + `plans/YAML-BDD-SCHEMA-PLAN.md`. The
+> transcoder is `tools/gherkin_to_bdd_yaml.py`; the linter BDD fork lives in
+> `tools/sdd_doc_lint/__init__.py` (`_bdd_yaml_scenarios` / `_check_bdd_schema` /
+> the `build_edge_graph` BDD synthetic-edge block). Corpus baseline (post-PR-4):
+> **1× TH-RES-001, 5× REFGRAN01, 6× STY02** on `main`.
+>
+> ---
+>
+> **Per-PR detail of the shipped arc (PR-1…PR-5) — historical:**
 >
 > 1. ✅ **PR-1 (SHIPPED this session) — `_THRESHOLD` fix + transcoder.** The two
 >    self-contained, fully-verified pieces:


### PR DESCRIPTION
## Summary

Continuity-doc wrap for the YAML-BDD-SCHEMA arc (PR-1…PR-5 merged this session). Doc-only — no code/spec change.

- **`plans/HANDOFF.md`** — banner → **arc CORE COMPLETE** (`main` 1407f445, framework `0.29.0`, plugin `0.23.0`); crisp ▶ RESUME HERE list for next session: **PR-3b** (playbook bodies + QUICK_REFERENCE, PATCH `0.29.1`), the **element-level COV01/COV02 upgrade** (the deferred payoff — catches the 15 orphaned BDD scenarios), **CORPUS-REFGRAN-RECASCADE** (now 5 SPEC/TDD/IPLAN edges), + tooling backlog. Per-PR detail collapsed to a historical subsection. Corpus baseline noted (1 TH-RES / 5 REFGRAN / 6 STY02).
- **`plans/FRAMEWORK-TODO.md`** — YAML-BDD arc status banner; `CORPUS-REFGRAN-RECASCADE` updated **7 → 5** (PR-4 resolved the 2 BDD edges via the YAML migration).
- `CHANGELOG.md` already current on `main` (the PR-1…PR-5 entries landed with their respective PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)