### PR TITLE
ci: bump aidoc-flow-ci pin @ci/v1.4.1 → @ci/v1.4.2 (ai-review review-event skip)

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -87,7 +87,7 @@ permissions:
   issues: write          # labels
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/ai-review.yml@ci/v1.4.1
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/ai-review.yml@ci/v1.4.2
     with:
       reviewer: claude
       runner_labels_routine: '"ubuntu-latest"'

--- a/.github/workflows/composition.yml
+++ b/.github/workflows/composition.yml
@@ -35,7 +35,7 @@ permissions:
   contents: read
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/composition.yml@ci/v1.4.1
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/composition.yml@ci/v1.4.2
     with:
       runner_labels: '"ubuntu-latest"'
     secrets: inherit  # pragma: allowlist secret


### PR DESCRIPTION
## Bump `aidoc-flow-ci` pin `@ci/v1.4.1` → `@ci/v1.4.2`

Activates the durable fix shipped in **aidoc-flow-ci [#46](https://github.com/vladm3105/aidoc-flow-ci/pull/46) / `ci/v1.4.2`**: `ai-review` now skips the heavy reviewer on `pull_request_review` events. A review never changes code, so the verdict at HEAD already stands and `composition` recomputes the gate — the redundant re-fire no longer runs the reviewer and can no longer paint a **false-red `call / ai-review`** check.

This is the false positive we hit on **#206** (a spec-tier PR): the comment-review that fired the composition gate also re-fired `ai-review`, which died at the private-config asset-fetch step and showed red even though the authoritative review for that commit had passed.

### Changes
- `.github/workflows/ai-review.yml` — `uses: …/ai-review.yml@ci/v1.4.1` → `@ci/v1.4.2`
- `.github/workflows/composition.yml` — `uses: …/composition.yml@ci/v1.4.1` → `@ci/v1.4.2` (lockstep; `composition.yml` is unchanged at the source — the `v1.4.2` tag carries the same file)

### Notes
- Governance PR (touches `ai-review.yml`) → human sign-off, not auto-merged.
- `ci/v1.4.2` tag confirmed on the remote (`refs/tags/ci/v1.4.2` → `cbe5c710`).
- This PR's own `ai-review` still runs under the base branch's `v1.4.1` (chicken-and-egg); the fix applies to PRs opened after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
