### PR TITLE
fix(tooling): changelog-test convention + SKILL_AUTHORING bump straggler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — tooling backlog: changelog-entry test convention + SKILL_AUTHORING bump straggler (2026-06-29)
+
+Two recurring tooling papercuts (no version impact):
+
+- **`tests/release/test_changelog_entry.py`** (`RELEASE-CHANGELOG-TEST-CONVENTION-GAP`)
+  — was asserting a top-level `## [X.Y.Z]` heading while the repo nests the
+  current version under `## [Unreleased]` as a `### … framework spec X → Y`
+  subsection, so it was latently RED at HEAD (invisible only because CI doesn't
+  run `tests/release/`). Now accepts the version in either a released top-level
+  heading or an Unreleased subsection heading.
+- **`tools/bump_version.py`** (`BUMP-SKILL-AUTHORING-CHECKLIST-STRAGGLER`) — now
+  sweeps the backtick-wrapped `framework_spec_version: "X"` in
+  `SKILL_AUTHORING.md`'s §6 checklist that the column-anchored `bump_fsv` regex
+  missed every bump (left stale at `0.27.0`, 3 bumps behind); corrected to
+  `0.30.0` and auto-maintained henceforth.
+
 ### Added — ELEMENT-COVERAGE-001: element-level COV01/COV02 coverage; framework spec 0.29.1 → 0.30.0 (2026-06-29)
 
 Upgrades the coverage lint gates from **document-level** to **element-level**

--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -48,8 +48,12 @@
 > payoff — catches the 16 orphaned BDD scenarios);
 > (c) `CORPUS-REFGRAN-RECASCADE` (below) — now just the 5 SPEC/TDD/IPLAN edges.
 
-### `[sync]` `BUMP-SKILL-AUTHORING-CHECKLIST-STRAGGLER` — `bump_version.py` misses the SKILL_AUTHORING acceptance-checklist line
+### `[sync]` `BUMP-SKILL-AUTHORING-CHECKLIST-STRAGGLER` — ✅ CLOSED (2026-06-29) — `bump_version.py` misses the SKILL_AUTHORING acceptance-checklist line
 
+- ✅ **Fixed:** `bump_version.py` now sweeps any unanchored
+  `framework_spec_version: "X"` in `SKILL_AUTHORING.md` (idempotent), catching
+  the backtick-wrapped §6 checklist line; the current stale `0.27.0` value
+  corrected to `0.30.0`.
 - *Context:* recurred in CFB-PR-2 2a-core step 6 (0.23.1→0.24.0) AND 2b step 3
   (0.24.0→0.25.0). `SKILL_AUTHORING.md:112` (`- [ ] … framework_spec_version:
   "X" present.`) is a backtick-wrapped checklist line, not the `^…
@@ -60,8 +64,12 @@
   rewrite for the SKILL_AUTHORING checklist line), or add a conformance guard
   asserting the checklist version == `framework/VERSION`.
 
-### `[harness]` `RELEASE-CHANGELOG-TEST-CONVENTION-GAP` — `tests/release/test_changelog_entry.py` doesn't match the `[Unreleased]` convention
+### `[harness]` `RELEASE-CHANGELOG-TEST-CONVENTION-GAP` — ✅ CLOSED (2026-06-29) — `tests/release/test_changelog_entry.py` doesn't match the `[Unreleased]` convention
 
+- ✅ **Fixed:** the test now accepts the current version in EITHER a released
+  `## [X.Y.Z]` heading OR an `[Unreleased]` `### … <version>` subsection heading
+  (matches the version in any level-2/3 heading, trailing-boundary guarded).
+  3/3 release tests green.
 - *Context:* surfaced in CFB-PR-2b self-review. The test requires a top-level
   `## [<version>]` heading, but the repo nests releases under `## [Unreleased]`
   with `### Added — Framework Spec X → Y`. It is RED at HEAD for `0.25.0` (and on

--- a/platforms/claude-code-plugin/docs/SKILL_AUTHORING.md
+++ b/platforms/claude-code-plugin/docs/SKILL_AUTHORING.md
@@ -109,7 +109,7 @@ Format · Related Resources`
 ## 6. Acceptance checklist (per skill)
 
 - [ ] `name` equals the directory name.
-- [ ] `version: "0.23.0"`, `framework_spec_version: "0.27.0"` present.
+- [ ] `version: "0.23.0"`, `framework_spec_version: "0.30.0"` present.
 - [ ] No `## Version History`; no `mermaid-gen`; no `-reviewer`/`-validator`
       references; no removed-family references.
 - [ ] Template/README/governance links use `${CLAUDE_PLUGIN_ROOT}/framework/layers/NN_X/`.

--- a/tests/release/test_changelog_entry.py
+++ b/tests/release/test_changelog_entry.py
@@ -21,11 +21,20 @@ class ChangelogEntryTests(unittest.TestCase):
             self.skipTest("CHANGELOG.md not present")
         version = (FRAMEWORK / "VERSION").read_text(encoding="utf-8").strip()
         changelog = CHANGELOG.read_text(encoding="utf-8")
-        pattern = rf"^##\s*\[?{re.escape(version)}\]?"
+        # The current version's entry may appear in either form (RELEASE-CHANGELOG-
+        # TEST-CONVENTION-GAP):
+        #   * a released top-level heading — ``## [0.30.0]`` / ``## 0.30.0``; or
+        #   * an ``## [Unreleased]`` subsection heading naming the version, the
+        #     convention this repo uses — ``### Added — … framework spec X → 0.30.0``.
+        # Match the version in any level-2/3 heading line, not just a bracketed
+        # top-level one. The trailing lookahead avoids a prefix match (0.30.0 in
+        # 0.30.01).
+        pattern = rf"^#{{2,3}}\s+.*{re.escape(version)}(?![\d.])"
         self.assertRegex(
             changelog,
             re.compile(pattern, re.MULTILINE),
-            f"CHANGELOG.md has no '## {version}' section",
+            f"CHANGELOG.md has no heading naming the current version {version} "
+            f"(neither a released '## [{version}]' nor an '[Unreleased]' '### … {version}' entry)",
         )
 
     def test_no_placeholder_orphans(self):

--- a/tools/bump_version.py
+++ b/tools/bump_version.py
@@ -109,6 +109,20 @@ def main(argv: list[str]) -> int:
     skill_authoring = BUNDLE / "docs" / "SKILL_AUTHORING.md"
     if skill_authoring.exists():
         n += bump_fsv([skill_authoring], new)
+        # BUMP-SKILL-AUTHORING-CHECKLIST-STRAGGLER: the §6 checklist line carries
+        # `framework_spec_version: "X"` INSIDE a backtick-wrapped list item, not
+        # the column-anchored frontmatter form `bump_fsv` matches — so it was
+        # missed every bump and went stale. Sweep any remaining occurrence with an
+        # unanchored rewrite (idempotent). Only touches `framework_spec_version`
+        # strings — never the plugin `version:` (independent stream).
+        sa = skill_authoring.read_text(encoding="utf-8")
+        patched = re.sub(
+            r'framework_spec_version:\s*"\d+\.\d+\.\d+"',
+            f'framework_spec_version: "{new}"',
+            sa,
+        )
+        if patched != sa:
+            skill_authoring.write_text(patched, encoding="utf-8")
     print(f"Updated {n} framework_spec_version declaration(s)")
 
     # Plugin README framework-spec strings (conformance-checked; must be fixed


### PR DESCRIPTION
Clears two recurring tooling papercuts from the backlog. **No version impact**; not spec-tier, not governance.

### `RELEASE-CHANGELOG-TEST-CONVENTION-GAP`
`tests/release/test_changelog_entry.py` asserted a top-level `## [X.Y.Z]` heading, but this repo nests the current version under `## [Unreleased]` as a `### … framework spec X → Y` subsection — so it was **latently RED at HEAD** (invisible only because CI runs `tests/conformance`/`platforms/hermes`, not `tests/release/`). The test now accepts the version in **either** a released top-level heading **or** an `[Unreleased]` `###` subsection heading (matches the version in any level-2/3 heading; trailing-boundary guarded against prefix matches). 3/3 release tests green.

### `BUMP-SKILL-AUTHORING-CHECKLIST-STRAGGLER`
`tools/bump_version.py` missed the backtick-wrapped `framework_spec_version: "X"` in `SKILL_AUTHORING.md`'s §6 checklist (the `bump_fsv` regex is column-anchored to frontmatter), so it went stale every bump — found **3 bumps behind at `0.27.0`**. The bump now does an unanchored sweep of that string (idempotent; only touches `framework_spec_version`, never the independent plugin `version:`). Current value corrected to `0.30.0`; auto-maintained henceforth.

### Verification
- 156 release + conformance tests green; bump sweep verified idempotent at `0.30.0`.
- FRAMEWORK-TODO entries marked ✅ CLOSED; CHANGELOG `[Unreleased]` noted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)