### PR TITLE
docs(handoff): retire resolved loose-end (cfb-pr-1a branch deleted, superseded by #180)

### DIFF
--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -73,10 +73,14 @@
 >    retires the deferred corpus-remediation items (16 COV02 orphans,
 >    CORPUS-REFGRAN-RECASCADE, CORPUS-PRD-TH-RES, INDEX-UPSTREAM-RESIDUE).
 >
-> **Loose end:** local branch `feat/cfb-pr-1a-trace-contract` has **1 unmerged
-> commit** (`git cherry` confirmed not in `main`) — a `docs(governance)` trace-
-> contract correction that may be superseded by NECESSARY-UPSTREAM-001. Decide:
-> revive or `git branch -D`.
+> **Loose end RESOLVED (2026-06-29):** branch `feat/cfb-pr-1a-trace-contract`
+> (commit `a770c4fb`) reviewed and **deleted (local + origin)** — fully
+> superseded. Every correction it carried (TRACEABILITY.md necessary-upstream
+> heading/per-layer list/validation table, GATE-08-E003 resolution,
+> governance/README.md wording) already lives on `main` via #180's
+> cumulative→necessary-upstream reconciliation, and `main` goes further
+> (CFB-PR-2 coverage-matrix paragraph; richer GATE-08-E003 transitive-reach
+> note). Reviving it would have regressed the docs.
 >
 > **Coverage engine map** (the session's core surface — for the Hermes port +
 > any coverage follow-on): `tools/sdd_doc_lint/__init__.py` —


### PR DESCRIPTION
## What

Retires the "Loose end" note in `plans/HANDOFF.md` for the dangling branch
`feat/cfb-pr-1a-trace-contract`, now reviewed and **deleted** (local + origin).

## Why

The branch carried commit `a770c4fb` — three trace-contract doc corrections
(TRACEABILITY.md, GATE-08_IPLAN.md, governance/README.md). Review confirmed
**all three are already on `main`** via #180's cumulative→necessary-upstream
reconciliation, and `main` is strictly more complete:

- TRACEABILITY.md — necessary-upstream heading, per-layer list
  (`IPLAN: @spec @tdd`), and validation table all present; plus the CFB-PR-2
  coverage-matrix paragraph the branch lacked.
- GATE-08-E003 — `main` has the necessary-upstream resolution with the richer
  transitive-reach explanation.
- governance/README.md — already "necessary-upstream tagging".

Reviving the branch would have **regressed** the docs, so it was deleted.

## Scope

Doc-of-record housekeeping only. No `framework/` content change → no version
bump. Pre-commit conformance suite passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)