### PR TITLE
fix(tools): sdd_doc_lint recognizes index/registry docs so they lint clean (STRUCT01-INDEX-EXEMPTION)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — STRUCT01-INDEX-EXEMPTION: `sdd_doc_lint` recognizes index/registry docs so they lint clean (tooling; no spec change) (2026-06-30)
+
+`sdd_doc_lint`'s index exemption (STRUCT01 required-sections + the trace-resolution
+skip) read a **top-level** `artifact_type` ending in `-INDEX`, but the 8 layer index
+templates declare `artifact_type` under `custom_fields` (6 with a bare value) and the
+IPLAN-00 registry is a `.yaml` with no `---` frontmatter — so the exemption never
+fired and a consumer's copied index threw STRUCT01 errors (BRD-00: 17). The `-INDEX`
+marker also self-tripped the ID02 doc-id scan. Fixed in the linter: a filename-based
+`_is_index_doc(rel, fm)` (`<TYPE>-00_index`, reliable for all 8 incl. the `.yaml`) used
+in both exemptions, plus the ID02 scan skips `-INDEX` tokens. No template/`framework/`
+change → no spec bump (precedent: #198/#200). Vendored copies re-synced byte-identical;
+new conformance guard `test_index_template_lint.py` (lints the 8 real templates → 0
+STRUCT01 / 0 `-INDEX` ID02); 316 conformance+unit green; example-corpus lint unchanged.
+D-0043.
+
 ### Changed — BL-READY-SCORE-ADVISORY: mark `*_ready_score` / `target_score` advisory in the 7 layer templates; framework spec 0.32.3 → 0.32.4 (2026-06-30)
 
 The `<next>_ready_score` (`document_control`) and `target_score` (`health_score`)

--- a/plans/DECISIONS.md
+++ b/plans/DECISIONS.md
@@ -10,6 +10,23 @@ graduation.
 
 ---
 
+## D-0043 — `sdd_doc_lint` detects index/registry docs by filename (STRUCT01-INDEX-EXEMPTION)
+
+**2026-06-30.** Index/registry docs (`<TYPE>-00_index`) are exempted from the
+instance-doc structural checks (STRUCT01 required-sections, trace-resolution skip)
+via a `_is_index_doc(rel, fm)` helper keyed primarily on the **`<TYPE>-00_index`
+filename**, not on a top-level `artifact_type: <X>-INDEX`. Rationale: the filename
+is the one signal reliably present on all 8 layer index templates and a consumer's
+copies regardless of frontmatter shape — the `.md` templates nest `artifact_type`
+under `custom_fields` (6 with a bare value) and the IPLAN-00 registry is a `.yaml`
+with no `---` frontmatter (so `_extract_frontmatter` returns `None`). A top-level
+`artifact_type` ending in `-INDEX` is still honored for back-compat. Separately, the
+ID02 doc-id scan now skips `-INDEX` tokens (an index artifact-type marker is not a
+malformed doc-id) — chosen over adding a top-level `artifact_type: <X>-INDEX` to the
+templates, which would have self-tripped ID02 (the original docs-only plan; rejected
+at independent review Pass 2). Pure linter fix; no `framework/` change, no spec bump.
+Unblocks [[ENG-BRD-SKETCH-ROADMAP]] (BRD-00 index as a lint-clean roadmap home).
+
 ## D-0042 — readiness scores are advisory: marked in-template, no rubric (BL-READY-SCORE-ADVISORY)
 
 **2026-06-30.** The `<next>_ready_score` (in `document_control`) and `target_score`

--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -80,6 +80,21 @@
   library + operations auto-merge enforcer backlog); track the fix upstream.
   Logged here for next-session merge-flow awareness.
 
+### `[lint]` `STRUCT01-INDEX-EXEMPTION-NESTED` — ✅ CLOSED (2026-06-30) — index/registry templates never hit the STRUCT01/trace `-INDEX` exemption
+
+- *Discovered:* 2026-06-30 by the ENG-BRD-SKETCH-ROADMAP plan's independent review.
+  The STRUCT01 required-section exemption + the trace-resolution INDEX skip both read
+  a **top-level** `artifact_type` ending in `-INDEX`, but the 7 `.md` layer index
+  templates nest `artifact_type` under `custom_fields` (6 with a bare value) and the
+  IPLAN-00 registry is a `.yaml` with no `---` frontmatter — so the exemption never
+  fired and a consumer's copied index threw STRUCT01 errors (BRD-00: 17). The
+  `-INDEX` token also self-tripped the ID02 doc-id scan.
+- ✅ **Fixed** (STRUCT01-INDEX-EXEMPTION, D-0043): filename-based `_is_index_doc`
+  (`<TYPE>-00_index`) used in both exemptions + ID02 skips `-INDEX` tokens; all 8
+  index templates (incl. the `.yaml`) lint clean; new conformance guard
+  `test_index_template_lint.py`. Pure linter fix, no spec bump.
+  Plan: `plans/STRUCT01-INDEX-EXEMPTION-PLAN.md`.
+
 ### `[sync]` `BUMP-SKILL-AUTHORING-CHECKLIST-STRAGGLER` — ✅ CLOSED (2026-06-29) — `bump_version.py` misses the SKILL_AUTHORING acceptance-checklist line
 
 - ✅ **Fixed:** `bump_version.py` now sweeps any unanchored

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -12,11 +12,18 @@
 >   reviewed (independent pass 0 load-bearing findings). Note: the
 >   `test_plugin_release_metadata.py` hard-pin now **auto-updates** via
 >   `sync-version-refs.sh` (no longer the manual tripwire PLANSTD-001 hit).
-> - **Item 3 — `ENG-BRD-SKETCH-ROADMAP`:** grounded; next after item 2. Design
->   tension resolved-in-principle: roadmap lives as rows in the lint-exempt
->   **BRD-00 index** table; standalone `status: Sketch` BRD-file lint support
->   (STRUCT01 under-authoring exemption + the deferred SKETCH-001 over-authoring
->   guard) is **out of scope** (docs-only, author-scoped).
+> - **STRUCT01-INDEX-EXEMPTION (prerequisite bugfix, item-3-blocker): plan MERGED
+>   (#223), impl IN FLIGHT.** ENG-BRD-SKETCH-ROADMAP's independent review found a
+>   pre-existing bug: the linter's `*-INDEX` STRUCT01/trace exemption read top-level
+>   `artifact_type`, but the 8 index templates nest it under `custom_fields` (6 bare;
+>   IPLAN-00 `.yaml` has no `---` frontmatter) → a consumer's index threw STRUCT01
+>   (BRD-00: 17). Fix is a **pure linter change** (filename-based `_is_index_doc` +
+>   ID02 `-INDEX` skip) — no template/spec change, no bump. 3 review passes (Pass 2
+>   caught that the original docs-only fix would self-trip ID02 → pivoted). D-0043.
+> - **Item 3 — `ENG-BRD-SKETCH-ROADMAP`:** parked (plan preserved with the Pass-2
+>   finding) until the STRUCT01 bugfix lands, then re-scoped onto the now-lint-clean
+>   BRD-00 index as the roadmap home (docs-only; standalone `status: Sketch` BRD-file
+>   support stays deferred — STRUCT01 still enforces sections on instance BRDs).
 > - **Item 4 — P3 stragglers + corpus regen:** doc-only stragglers to be cleared;
 >   **wholesale corpus regen needs a live plugin CLI** (not runnable here) → I'll
 >   deliver a regen runbook for the founder to run.

--- a/platforms/claude-code-plugin/sdd_doc_lint/__init__.py
+++ b/platforms/claude-code-plugin/sdd_doc_lint/__init__.py
@@ -551,7 +551,7 @@ def lint_text(
         # Inline document IDs (TYPE-NN) of known artifacts must match the doc form.
         for m in _DOC_ID.finditer(line):
             tok = m.group(0)
-            if not doc_re.match(tok):
+            if not doc_re.match(tok) and not tok.upper().endswith("-INDEX"):
                 findings.append(Finding(rel, i, "ID02", f"malformed document id '{tok}'"))
         # Inline element IDs (TYPE.a.b.c…) of known artifacts must match the element form.
         for m in _ELEM_ID.finditer(line):
@@ -1055,6 +1055,24 @@ def _check_cascade(corpus: list[tuple[str, str]]) -> list[Finding]:
     return findings
 
 
+_INDEX_FILENAME = re.compile(r"(?:^|/)[A-Z]+-00_index")
+
+
+def _is_index_doc(rel: str, fm: dict | None) -> bool:
+    """An index/registry doc, exempt from instance-doc structural checks.
+
+    Recognized by the ``<TYPE>-00_index`` filename (the registry naming
+    convention — reliable even for ``.yaml`` registries whose body does not
+    parse as ``---`` frontmatter), OR a top-level ``artifact_type`` ending in
+    ``-INDEX`` (kept for back-compat with docs that declare it that way).
+    """
+    if _INDEX_FILENAME.search(rel or ""):
+        return True
+    if fm and str(fm.get("artifact_type") or "").strip().endswith("-INDEX"):
+        return True
+    return False
+
+
 def _check_required_template_sections(
     rel: str,
     text: str,
@@ -1075,10 +1093,8 @@ def _check_required_template_sections(
     if not artifact:
         return findings
     fm = _extract_frontmatter(text)
-    if fm:
-        declared = str(fm.get("artifact_type") or "").strip()
-        if declared.endswith("-INDEX"):
-            return findings
+    if _is_index_doc(rel, fm):
+        return findings
     targets = _load_section_targets(artifact, registry)
     if not targets:
         return findings
@@ -1450,7 +1466,7 @@ def _check_trace_resolution(
     findings: list[Finding] = []
     for rel, text in corpus:
         fm = _extract_frontmatter(text)
-        if fm and str(fm.get("artifact_type") or "").strip().endswith("-INDEX"):
+        if _is_index_doc(rel, fm):
             continue
         # Derive artifact's own layer-number for downstream-skip comparison.
         artifact_code = ""

--- a/platforms/hermes/sdd_doc_lint/__init__.py
+++ b/platforms/hermes/sdd_doc_lint/__init__.py
@@ -551,7 +551,7 @@ def lint_text(
         # Inline document IDs (TYPE-NN) of known artifacts must match the doc form.
         for m in _DOC_ID.finditer(line):
             tok = m.group(0)
-            if not doc_re.match(tok):
+            if not doc_re.match(tok) and not tok.upper().endswith("-INDEX"):
                 findings.append(Finding(rel, i, "ID02", f"malformed document id '{tok}'"))
         # Inline element IDs (TYPE.a.b.c…) of known artifacts must match the element form.
         for m in _ELEM_ID.finditer(line):
@@ -1055,6 +1055,24 @@ def _check_cascade(corpus: list[tuple[str, str]]) -> list[Finding]:
     return findings
 
 
+_INDEX_FILENAME = re.compile(r"(?:^|/)[A-Z]+-00_index")
+
+
+def _is_index_doc(rel: str, fm: dict | None) -> bool:
+    """An index/registry doc, exempt from instance-doc structural checks.
+
+    Recognized by the ``<TYPE>-00_index`` filename (the registry naming
+    convention — reliable even for ``.yaml`` registries whose body does not
+    parse as ``---`` frontmatter), OR a top-level ``artifact_type`` ending in
+    ``-INDEX`` (kept for back-compat with docs that declare it that way).
+    """
+    if _INDEX_FILENAME.search(rel or ""):
+        return True
+    if fm and str(fm.get("artifact_type") or "").strip().endswith("-INDEX"):
+        return True
+    return False
+
+
 def _check_required_template_sections(
     rel: str,
     text: str,
@@ -1075,10 +1093,8 @@ def _check_required_template_sections(
     if not artifact:
         return findings
     fm = _extract_frontmatter(text)
-    if fm:
-        declared = str(fm.get("artifact_type") or "").strip()
-        if declared.endswith("-INDEX"):
-            return findings
+    if _is_index_doc(rel, fm):
+        return findings
     targets = _load_section_targets(artifact, registry)
     if not targets:
         return findings
@@ -1450,7 +1466,7 @@ def _check_trace_resolution(
     findings: list[Finding] = []
     for rel, text in corpus:
         fm = _extract_frontmatter(text)
-        if fm and str(fm.get("artifact_type") or "").strip().endswith("-INDEX"):
+        if _is_index_doc(rel, fm):
             continue
         # Derive artifact's own layer-number for downstream-skip comparison.
         artifact_code = ""

--- a/tests/conformance/test_index_template_lint.py
+++ b/tests/conformance/test_index_template_lint.py
@@ -1,0 +1,70 @@
+"""Conformance: the 8 layer index/registry templates lint clean of structural errors.
+
+`sdd_doc_lint` exempts index/registry docs (`<TYPE>-00_index`) from the
+instance-doc structural checks — STRUCT01 (required sections) and the
+trace-resolution skip. That exemption must fire for the *real* templates, not just
+a synthetic fixture: the templates declare `artifact_type` under `custom_fields`
+(some with a bare value) and the IPLAN registry is a `.yaml` with no `---`
+frontmatter, so an exemption keyed only on top-level `artifact_type` silently
+missed all 8 — a consumer copying a template into `docs/` then hit STRUCT01 errors.
+
+This guard lints each real index template and asserts:
+  * zero STRUCT01 (the exemption fires), and
+  * zero `-INDEX`-token ID02 (the `<X>-INDEX` artifact-type marker is not itself
+    reported as a malformed document id).
+
+Regression for STRUCT01-INDEX-EXEMPTION (D-0043). It would FAIL on `main` before
+the fix (STRUCT01 nonzero on every template).
+"""
+
+import sys
+import unittest
+
+from _spec import FRAMEWORK, REPO_ROOT
+
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+from sdd_doc_lint import find_registry, lint_path  # noqa: E402
+
+_REGISTRY = FRAMEWORK / "registry" / "LAYER_REGISTRY.yaml"
+
+
+def _index_templates():
+    """The 8 layer index/registry templates (`<TYPE>-00_index.TEMPLATE.{md,yaml}`)."""
+    found = sorted(FRAMEWORK.glob("layers/0*/[A-Z]*-00_index.TEMPLATE.*"))
+    return found
+
+
+class IndexTemplateLint(unittest.TestCase):
+    def test_all_eight_index_templates_present(self):
+        templates = _index_templates()
+        self.assertEqual(
+            len(templates),
+            8,
+            f"expected 8 layer index templates, found {[p.name for p in templates]}",
+        )
+
+    def test_index_templates_emit_no_struct01_or_index_id02(self):
+        registry = _REGISTRY if _REGISTRY.is_file() else find_registry()
+        for template in _index_templates():
+            with self.subTest(template=template.name):
+                findings = lint_path(template, registry=registry)
+                struct01 = [f for f in findings if f.code == "STRUCT01"]
+                self.assertEqual(
+                    struct01,
+                    [],
+                    f"{template.name}: index doc must be STRUCT01-exempt; got "
+                    f"{[f.message for f in struct01]}",
+                )
+                index_id02 = [f for f in findings if f.code == "ID02" and "-INDEX'" in f.message]
+                self.assertEqual(
+                    index_id02,
+                    [],
+                    f"{template.name}: the -INDEX artifact-type marker must not be "
+                    f"flagged as a malformed document id; got "
+                    f"{[f.message for f in index_id02]}",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/sdd_doc_lint/__init__.py
+++ b/tools/sdd_doc_lint/__init__.py
@@ -551,7 +551,7 @@ def lint_text(
         # Inline document IDs (TYPE-NN) of known artifacts must match the doc form.
         for m in _DOC_ID.finditer(line):
             tok = m.group(0)
-            if not doc_re.match(tok):
+            if not doc_re.match(tok) and not tok.upper().endswith("-INDEX"):
                 findings.append(Finding(rel, i, "ID02", f"malformed document id '{tok}'"))
         # Inline element IDs (TYPE.a.b.c…) of known artifacts must match the element form.
         for m in _ELEM_ID.finditer(line):
@@ -1055,6 +1055,24 @@ def _check_cascade(corpus: list[tuple[str, str]]) -> list[Finding]:
     return findings
 
 
+_INDEX_FILENAME = re.compile(r"(?:^|/)[A-Z]+-00_index")
+
+
+def _is_index_doc(rel: str, fm: dict | None) -> bool:
+    """An index/registry doc, exempt from instance-doc structural checks.
+
+    Recognized by the ``<TYPE>-00_index`` filename (the registry naming
+    convention — reliable even for ``.yaml`` registries whose body does not
+    parse as ``---`` frontmatter), OR a top-level ``artifact_type`` ending in
+    ``-INDEX`` (kept for back-compat with docs that declare it that way).
+    """
+    if _INDEX_FILENAME.search(rel or ""):
+        return True
+    if fm and str(fm.get("artifact_type") or "").strip().endswith("-INDEX"):
+        return True
+    return False
+
+
 def _check_required_template_sections(
     rel: str,
     text: str,
@@ -1075,10 +1093,8 @@ def _check_required_template_sections(
     if not artifact:
         return findings
     fm = _extract_frontmatter(text)
-    if fm:
-        declared = str(fm.get("artifact_type") or "").strip()
-        if declared.endswith("-INDEX"):
-            return findings
+    if _is_index_doc(rel, fm):
+        return findings
     targets = _load_section_targets(artifact, registry)
     if not targets:
         return findings
@@ -1450,7 +1466,7 @@ def _check_trace_resolution(
     findings: list[Finding] = []
     for rel, text in corpus:
         fm = _extract_frontmatter(text)
-        if fm and str(fm.get("artifact_type") or "").strip().endswith("-INDEX"):
+        if _is_index_doc(rel, fm):
             continue
         # Derive artifact's own layer-number for downstream-skip comparison.
         artifact_code = ""


### PR DESCRIPTION
## Impl PR — STRUCT01-INDEX-EXEMPTION (plan #223)

Implements `plans/STRUCT01-INDEX-EXEMPTION-PLAN.md` (merged #223). Prerequisite
bugfix that unblocks ENG-BRD-SKETCH-ROADMAP.

### Bug
`sdd_doc_lint`'s index exemption (STRUCT01 required-sections + trace-resolution
skip) read a **top-level** `artifact_type` ending in `-INDEX`, but the 8 layer
index templates declare `artifact_type` under `custom_fields` (6 with bare values)
and IPLAN-00 is a `.yaml` with no `---` frontmatter → the exemption never fired, so
a consumer's copied index threw STRUCT01 errors (BRD-00: 17). The `-INDEX` marker
also self-tripped the ID02 doc-id scan.

### Fix — pure linter, no template/spec change
- `_is_index_doc(rel, fm)` keyed on the `<TYPE>-00_index` **filename** (reliable for
  all 8 incl. the `.yaml` registry) + back-compat top-level `artifact_type` `-INDEX`;
  used in the STRUCT01 + trace-resolution exemptions.
- ID02 scan skips `-INDEX` tokens (index markers, not malformed doc-ids).
- Vendored copies re-synced byte-identical. **No `framework/` change → no spec bump**
  (precedent: #198/#200).

### Verification
- V1 new test **fails on the unfixed linter** (8 templates, STRUCT01 present) — proves it catches the bug.
- V2 `pytest tests/conformance tests/unit` → **316 passed, 855 subtests** (incl. vendoring + sync-idempotency guards).
- V3 all 8 `<TYPE>-00_index.TEMPLATE.*` → 0 STRUCT01 / 0 `-INDEX` ID02.
- V4 corpus lint **unchanged** (16 COV02 / 5 REFGRAN01 / 6 STY02 / 1 TH-RES-001).
- V5 vendored copies byte-identical to canonical.

### Review
Plan 3-cycle reviewed (Pass 2 independent caught the ID02 self-trip in the original
docs-only approach → pivoted; Pass 3 independent re-implemented + validated, 0
load-bearing findings). New guard `test_index_template_lint.py` lints the **real**
templates (the existing unit test used a synthetic fixture that masked the drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)