### PR TITLE
docs: corpus-regen runbook + session wrap (P3 arc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added — Corpus-regeneration runbook (docs; no spec change) (2026-06-30)
+
+`plans/CORPUS-REGEN-RUNBOOK.md` — founder-runnable procedure for the wholesale
+example-corpus regeneration after framework-spec changes (needs a live plugin CLI).
+Leverages `tests/ACCEPTANCE.md` (driver + `--promote`); adds the
+post-framework-change trigger, a G1–G5 verification gate, and the deferred
+corpus-remediation backlog it closes (16 COV02 orphans, `CORPUS-REFGRAN-RECASCADE`,
+`CORPUS-PRD-TH-RES`, `INDEX-UPSTREAM-RESIDUE` corpus-side). `plans/HANDOFF.md`
+updated to the session-wrap state (P3 items 2 & 3 + the STRUCT01-INDEX-EXEMPTION
+bugfix shipped; regen runbook delivered).
+
 ### Added — ENG-BRD-SKETCH-ROADMAP: project-init roadmap in the BRD-00 index + trace-inert sketch sub-form; framework spec 0.32.4 → 0.32.5 (2026-06-30)
 
 Authoring only `BRD-01` plus index one-liners left whole-project scope

--- a/plans/CORPUS-REGEN-RUNBOOK.md
+++ b/plans/CORPUS-REGEN-RUNBOOK.md
@@ -1,0 +1,101 @@
+# Corpus Regeneration Runbook — regenerate the example corpus after framework changes
+
+> **Why this exists.** The example corpus (`examples/url-shortener/docs/` +
+> `.aidoc/`) is a **framework output**, not a hand-maintained artifact. After a
+> run of framework-spec changes that alter templates, lint rules, playbooks, or
+> the trace contract, the committed corpus drifts from what the current framework
+> would produce — so a set of corpus-remediation findings are deliberately
+> **deferred to a wholesale regen** rather than hand-patched (hand-editing example
+> artifacts is forbidden — see `CLAUDE.md` "Never hand-edit example artifacts").
+> This runbook is the procedure for that regen. It **must run in a live Claude
+> Code plugin session** (the cascade dispatches the `doc-*-autopilot` skills); it
+> cannot run in a framework-dev container.
+
+## When to run
+
+Run a wholesale regen when framework-spec changes since the corpus was last
+produced have changed any of: layer
+**templates**, **lint rules** (`sdd_doc_lint`), **playbooks**, the **trace
+contract**, or **`@`-tag semantics**. As of this writing the corpus lags the spec
+by the `0.29.x → 0.32.5` arc (YAML-BDD, element-level coverage, provisional IDs,
+reuse, advisory scores, the sketch roadmap), so a regen is due.
+
+## What a regen clears (the deferred backlog)
+
+These `FRAMEWORK-TODO.md` items are **closed by the regen**, not by hand:
+
+- **16 COV02 orphans** — BDD scenarios with no downstream SPEC/TDD at element
+  level (surfaced by ELEMENT-COVERAGE-001; a fresh cascade authors the coverage).
+- **`CORPUS-REFGRAN-RECASCADE`** — the 5 remaining SPEC/TDD/IPLAN doc-level
+  `@adr`/`@tdd` tags re-cascaded to element granularity (GD-03/REFGRAN01).
+- **`CORPUS-PRD-TH-RES`** — PRD-01's missing `component_decomposition` thresholds
+  (11 unresolvable `@threshold:` citations).
+- **`INDEX-UPSTREAM-RESIDUE`** (corpus side) — stale cumulative `Upstream:`
+  enumerations in the corpus's layer index docs.
+
+After a clean regen these drop out of the corpus baseline; close each TODO entry
+with the regen commit ref.
+
+## Procedure
+
+All commands run from the framework repo root, in a live plugin session with the
+`aidoc-flow` plugin installed (see `plans/PLUGIN-P2-DEPLOY-RUNBOOK.md` for install).
+The driver and all its modes are documented in
+[`tests/ACCEPTANCE.md`](../tests/ACCEPTANCE.md) §3 — this runbook sequences them for
+a regen.
+
+1. **Record the starting baseline** (for the diff at the end):
+
+   ```bash
+   PYTHONPATH=tools python -m sdd_doc_lint examples/url-shortener/docs/ \
+     | grep -oE 'COV0[12]|REFGRAN01|STY02|TH-RES-001|STRUCT01|ID02|PROV01|REUSE0[12]' \
+     | sort | uniq -c | tee /tmp/corpus-baseline-before.txt
+   ```
+
+2. **Cleanup-then-cascade** (the deterministic-start pattern — `ACCEPTANCE.md`
+   §4 "Cleanup-then-cascade"): remove the layers being regenerated + their
+   per-layer saga/audit state, then run the cascade with `--force`. For a
+   *wholesale* regen, clear the whole produced chain:
+
+   ```bash
+   rm -rf examples/url-shortener/docs examples/url-shortener/.aidoc
+   bash tests/scripts/test-acceptance.sh url-shortener --live --force
+   ```
+
+   (To regenerate only some layers, use `--from <LAYER>` / single-layer mode per
+   `ACCEPTANCE.md` §3 Usage instead of the full `rm -rf`.)
+
+3. **Verify — the gate.** A regen is accepted only when ALL hold:
+
+   | # | Check | Expected |
+   |---|-------|----------|
+   | G1 | `bash tests/scripts/test-acceptance.sh url-shortener --dry-run` | green deterministic smoke (Phase 0, negative fixtures, hook) |
+   | G2 | `python -m pytest tests/conformance -q` | green |
+   | G3 | `PYTHONPATH=tools python -m sdd_doc_lint examples/url-shortener/docs/` | **no `STRUCT01`/`ID02`/`TRACE-RES-001` errors**; COV02 orphans resolved (or each explicitly `deferred:`); REFGRAN01 at element granularity; compare to `/tmp/corpus-baseline-before.txt` and account for every delta |
+   | G4 | the chain's recorded version (`docs/.version`, per `ACCEPTANCE.md` §3 layout — established/updated by `--promote`) | matches the current plugin version |
+   | G5 | the produced chain's `@`-tag chain resolves end-to-end (no dangling refs) | `python tools/trace_walk.py examples/url-shortener/docs/` clean |
+
+4. **Promote** (commit the regenerated corpus):
+
+   ```bash
+   bash tests/scripts/test-acceptance.sh url-shortener --live --promote
+   ```
+
+   This stages + commits `docs/` + `.aidoc/` (see `ACCEPTANCE.md` §3.2 `--promote`).
+
+5. **Close the backlog.** In `plans/FRAMEWORK-TODO.md`, move the four
+   corpus-remediation items above to Closed with the regen commit ref; update
+   `plans/HANDOFF.md`.
+
+## Notes
+
+- **Determinism:** element IDs are LLM-generated stable strings, **not** content
+  hashes (see auto-memory `project-element-ids-not-deterministic`), so a regen will
+  not reproduce byte-identical IDs — that is expected. The gate is *structural*
+  (G2/G3/G5), not a byte-diff.
+- **Cost:** a full live cascade exercises all active plugin elements; see
+  `ACCEPTANCE.md` §3 for the cost ballpark.
+- **Never hand-edit** a corpus artifact to "fix" a G3 finding — if a class of
+  finding survives a clean cascade, that is a **framework/playbook gap**: fix the
+  skill or template and re-cascade (`CLAUDE.md` "Never hand-edit example
+  artifacts").

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -1,39 +1,50 @@
 # Session Handoff
 
-> **🟡 IN PROGRESS (2026-06-30) — P3 cleanup arc: items 2 → 3 → 4.** Completing
-> the three deferred ▶ RESUME-HERE items in order, each as a full plan→review→
-> plan-PR→impl-PR cycle (founder direction).
+> **🟢 P3 CLEANUP ARC — items 2 & 3 SHIPPED + prerequisite bugfix SHIPPED + regen
+> runbook delivered (2026-06-30).** `main` clean at framework spec **0.32.5**,
+> plugin `0.23.0`. Six PRs merged this session (all admin-merged — composition-CI
+> gap forces `--admin`; founder standing OK).
 >
-> - **Item 2 — `BL-READY-SCORE-ADVISORY`: plan MERGED (#221), impl IN FLIGHT.**
->   Marks the 14 `*_ready_score` / `target_score` fields advisory across the 7
->   layer templates (BRD…TDD) — inline `#` comment + one `health_score` `_note:`
->   each (D-0042). Framework spec **0.32.3 → 0.32.4** (PATCH). The "52" headline
->   was BeeLocal's per-artifact tally; the template fix is 14 lines. Plan 2-cycle
->   reviewed (independent pass 0 load-bearing findings). Note: the
->   `test_plugin_release_metadata.py` hard-pin now **auto-updates** via
->   `sync-version-refs.sh` (no longer the manual tripwire PLANSTD-001 hit).
-> - **STRUCT01-INDEX-EXEMPTION (prerequisite bugfix, item-3-blocker): plan MERGED
->   (#223), impl IN FLIGHT.** ENG-BRD-SKETCH-ROADMAP's independent review found a
->   pre-existing bug: the linter's `*-INDEX` STRUCT01/trace exemption read top-level
->   `artifact_type`, but the 8 index templates nest it under `custom_fields` (6 bare;
->   IPLAN-00 `.yaml` has no `---` frontmatter) → a consumer's index threw STRUCT01
->   (BRD-00: 17). Fix is a **pure linter change** (filename-based `_is_index_doc` +
->   ID02 `-INDEX` skip) — no template/spec change, no bump. 3 review passes (Pass 2
->   caught that the original docs-only fix would self-trip ID02 → pivoted). D-0043.
-> - **Item 3 — `ENG-BRD-SKETCH-ROADMAP`: plan MERGED (#225), impl IN FLIGHT.**
->   Re-scoped onto the now-STRUCT01-clean BRD-00 index (4 review passes, 3
->   independent). Spec **0.32.4 → 0.32.5** (PATCH, docs-only): BRD-00 index "Planned
->   BRDs" table is the roadmap home (cycle/PROD/`@depends:`/status columns);
->   `01_BRD/README.md` documents project-init + the trace-inert Sketch concept;
->   `BRD-TEMPLATE.yaml` cross-ref. D-0044. Standalone Sketch-*file* support +
->   `_DOC_ID` header false-positive both deferred + logged in FRAMEWORK-TODO.
-> - **Item 4 — P3 stragglers + corpus regen:** doc-only stragglers to be cleared;
->   **wholesale corpus regen needs a live plugin CLI** (not runnable here) → I'll
->   deliver a regen runbook for the founder to run.
+> - **Item 2 — `BL-READY-SCORE-ADVISORY` ✅ SHIPPED** (#221 plan + #222 impl, spec
+>   `0.32.3 → 0.32.4`, D-0042). Marked the 14 `*_ready_score`/`target_score` fields
+>   advisory across the 7 layer templates + reworded 15 contradicting `_guidance`
+>   prose lines (ai-review caught the "required"/"quality gate" contradiction the
+>   2-cycle plan review missed → plan Pass 3).
+> - **`STRUCT01-INDEX-EXEMPTION` ✅ SHIPPED** (#223 plan + #224 impl, pure linter
+>   fix, no spec bump, D-0043). Prerequisite bug surfaced by item-3's review: the
+>   `*-INDEX` STRUCT01/trace exemption read top-level `artifact_type` but the 8
+>   index templates nest it under `custom_fields` → consumers' indexes threw
+>   STRUCT01. Fix: filename-based `_is_index_doc` + ID02 `-INDEX` skip. 3 passes
+>   (Pass 2 caught the original docs-only fix would self-trip ID02 → pivoted).
+> - **Item 3 — `ENG-BRD-SKETCH-ROADMAP` ✅ SHIPPED** (#225 plan + #226 impl, spec
+>   `0.32.4 → 0.32.5`, D-0044). BRD-00 index "Planned BRDs" table = roadmap home
+>   (cycle/PROD/`@depends:`/status); `01_BRD/README.md` project-init + trace-inert
+>   Sketch; `BRD-TEMPLATE.yaml` cross-ref. 4 passes, 3 independent.
+> - **Item 4 — regen runbook delivered; P3 content-stragglers remain.**
+>   `plans/CORPUS-REGEN-RUNBOOK.md` is the founder-runnable procedure for the
+>   **wholesale corpus regen** (needs a live plugin CLI; not runnable in this
+>   container) — it closes the deferred corpus-remediation backlog (16 COV02
+>   orphans, CORPUS-REFGRAN-RECASCADE, CORPUS-PRD-TH-RES, INDEX-UPSTREAM-RESIDUE
+>   corpus-side). **Doc-only P3 stragglers NOT yet cleared** (deferred to a focused
+>   session — see ▶ below).
 >
-> **Merge-flow:** founder gave a standing OK to admin-merge the green
-> governance-tier PRs in this arc (composition-CI gap forces `--admin` on every
-> PR here regardless).
+> **▶ RESUME HERE — next session:**
+>
+> 1. **Run the corpus regen** (`plans/CORPUS-REGEN-RUNBOOK.md`) on a live plugin
+>    CLI — the corpus lags spec `0.29.x → 0.32.5`. Closes the 4 corpus-remediation
+>    TODO items.
+> 2. **Doc-only P3 stragglers** (one themed sweep, à la #217): `D54-F12`
+>    (agentic antipatterns in BRD/PRD), `ENG-PLATFORM-ADR-TIMING` (ADR-timing
+>    wording in BRD+PRD templates), `INDEX-UPSTREAM-RESIDUE` (stale `Upstream:`
+>    enumerations in the 8 layer index templates/READMEs), `D54-F04` (EARS-Ready
+>    non-latency rubric — bigger, playbook work).
+> 3. **New follow-ons logged this session:** `SKETCH-FILE-STANDALONE` (standalone
+>    Sketch-file lint support), `LINT-DOCID-HEADER-FALSE-POSITIVE` (`_DOC_ID`
+>    flags `<TYPE>-<word>` header/link tokens).
+> 4. **Hermes parity** — still the one large outstanding arc (`HERMES-BACKLOG.md`).
+>
+> **Merge-flow:** every PR here needs `--admin` (composition-CI gap,
+> `AIDOC-CI-COMPOSITION-CHECK-PRHEAD`) — founder standing OK for this arc.
 >
 > ---
 >


### PR DESCRIPTION
## Session-wrap docs PR

Adds **`plans/CORPUS-REGEN-RUNBOOK.md`** — the founder-runnable procedure for the
wholesale example-corpus regeneration (needs a live plugin CLI; not runnable in a
framework-dev container). It leverages `tests/ACCEPTANCE.md` (driver + `--promote`)
and adds: the post-framework-change trigger, a G1–G5 verification gate, and the
deferred corpus-remediation backlog the regen closes (16 COV02 orphans,
`CORPUS-REFGRAN-RECASCADE`, `CORPUS-PRD-TH-RES`, `INDEX-UPSTREAM-RESIDUE`).

Updates `plans/HANDOFF.md` to the session-wrap state.

### This session shipped (already merged)
- **Item 2 — BL-READY-SCORE-ADVISORY** (#221/#222, spec 0.32.4, D-0042)
- **STRUCT01-INDEX-EXEMPTION** prerequisite bugfix (#223/#224, D-0043, no bump)
- **Item 3 — ENG-BRD-SKETCH-ROADMAP** (#225/#226, spec 0.32.5, D-0044)

### ▶ Remaining (next session)
Run the corpus regen on a CLI; doc-only P3 stragglers (D54-F12, ENG-PLATFORM-ADR-TIMING,
INDEX-UPSTREAM-RESIDUE, D54-F04); Hermes parity.

No `framework/` change → no spec bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)