### PR TITLE
feat(hermes): saga state-machine conformance + enforced parity test (HERMES-PARITY-PHASE-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — HERMES-PARITY-PHASE-1: Hermes saga state-machine conformance + enforced parity test (no version change) (2026-07-02)
+
+Hermes's saga `_ALLOWED_TRANSITIONS` was missing the spec's `PARTIAL_TIMEOUT`
+break-circuit state; added it so Hermes's table equals `REVIEW_SAGA.md` and the
+plugin's `saga_driver.py`. New shared conformance test
+`tests/conformance/test_saga_lifecycle_parity.py` (+ `fixtures/saga/`) enforces
+**both** platforms' transition tables against the spec and validates a sample
+journal from each runner against `saga.schema.json` — a test `docs/PARITY.md`
+previously over-claimed already existed. No framework spec change and no Hermes
+version bump (Phase 1 makes the state machine *accept* the transition; the
+orchestrator break-circuit *exercise* + resume is Phase 1b). Corrected the stale
+`HERMES-BACKLOG.md` premise (Hermes already has team-mode; the 0.32.x arc is
+auto-satisfied). D-0045.
+
 ### Changed — P3 docs sweep: INDEX-UPSTREAM-RESIDUE + ENG-PLATFORM-ADR-TIMING + D54-F12-AGENTIC-ANTIPATTERNS; framework spec 0.32.5 → 0.32.6 (2026-06-30)
 
 Three template clarifications, batched (no behavior change):

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -179,7 +179,7 @@ deterministic gate, and reduced findings).
 | Reduce / score | `synthesizer` subagent (rule-driven) | `saga_reducer` + `review_scoring.py` (code) |
 | Saga lifecycle (D-0031 / framework spec `0.23.0`) | `saga.json` written at `.aidoc/review/<NN>_<LAYER>/<id>/saga.json`; same state machine + journal schema as Hermes. **BRD layer (plugin v0.6.1)**: preemptive enforcement via `tools/saga_driver.py` invoked by `doc-brd-autopilot/SKILL.md`. **PRD..IPLAN (plugin v0.6.0)**: cooperative enforcement via SKILL prompts (Phase 4 migrates these to preemptive). | Python saga runtime (`saga_orchestrator.py`, `saga_models.py`, `saga_journal.py`); preemptive enforcement |
 | Resilience — partial crew | blackboard slots + coverage/quorum (D-0005 blackboard, authoritative for crew state) + saga.json journal for outer-loop phase state (D-0031) | saga retries/compensation; degrade above quorum, escalate below |
-| Resilience — partial outer loop | `saga.json` PARTIAL_TIMEOUT state via break-circuit; next invocation resumes from checkpoint | same — saga PARTIAL_TIMEOUT state; preemptive transition |
+| Resilience — partial outer loop | `saga.json` PARTIAL_TIMEOUT state via break-circuit; next invocation resumes from checkpoint | saga state machine **accepts** `PARTIAL_TIMEOUT` (spec-conformant table, HERMES-PARITY Phase 1); the orchestrator does not yet *write* it — the break-circuit + resume path is Phase 1b |
 | Report | unified report (`UCR_OUTPUT_UNIFIED` / audit report) | `PERSONA_REVIEW_REPORT` / saga summary |
 | Layer Playbooks (all 8 layers) | ✅ active — 45 playbooks (BRD 5 / PRD 6 / EARS 5 / BDD 6 / ADR 6 / SPEC 5 / TDD 6 / IPLAN 6) | ⏳ deferred (HERMES-BACKLOG H-4) |
 
@@ -203,11 +203,12 @@ Lifecycle-behavior parity is enforced at two layers; both must pass on CI.
   `tests/conformance/test_saga_lifecycle_parity.py` validates committed
   sample saga journals from both runners
   (`tests/conformance/fixtures/saga/{hermes,plugin}_BRD-01_saga.json`)
-  against the shared `framework/governance/saga.schema.json`, asserts the
-  state machine + transition table in `REVIEW_SAGA.md` matches Hermes'
-  `_ALLOWED_TRANSITIONS` exactly, and asserts the `## Break-circuit
-  policy` section is present in every plugin orchestrator SKILL.md (28
-  orchestrator skills per BRD-RT-004's name-match).
+  against the shared `framework/governance/saga.schema.json`, and asserts
+  **both** platforms' `_ALLOWED_TRANSITIONS` equal the `REVIEW_SAGA.md`
+  transition table exactly — including the `PARTIAL_TIMEOUT` break-circuit
+  state. (The `## Break-circuit policy` SKILL-prose is a separate
+  plugin-side concern — it lives in the ~18 `doc-*-audit` / `doc-*-fixer`
+  skills, not the autopilots — and is not asserted by this parity test.)
 - **Manual end-to-end (live run):** the "same artifact → identical
   lifecycle and report" check is manual, since live LLM output is not
   CI-deterministic. Procedure:

--- a/plans/DECISIONS.md
+++ b/plans/DECISIONS.md
@@ -10,6 +10,26 @@ graduation.
 
 ---
 
+## D-0045 — Hermes parity is engine debt (playbook injection + saga completeness), not the 0.32.x arc; phased, starting with saga conformance (HERMES-PARITY-PHASE-1)
+
+**2026-07-02.** An evidence-backed assessment corrected the stale
+`HERMES-BACKLOG.md` premise: **Hermes already has team-mode** (a working saga
+orchestrator with parallel per-persona fan-out + crew reconciliation to
+`REVIEW_CREWS.yaml`), and **the entire 0.32.x arc (D-0038…D-0044) is
+auto-satisfied** for Hermes via its byte-identical vendored `sdd_doc_lint` +
+shared `framework/layers/` templates — none of it needs Hermes-native code. The
+real gap is older engine debt: **playbook injection** (Hermes injects persona
+files, not the per-`(layer,lens)` `framework/playbooks/`) + **saga completeness**.
+Sequenced into phases (playbook plumbing gates the layer/CHG/calibration work);
+each phase gets its own minimal plan. **Phase 1** (this decision's shipped slice):
+add the spec-required `PARTIAL_TIMEOUT` state to Hermes `_ALLOWED_TRANSITIONS`
+(was missing) and ship `test_saga_lifecycle_parity.py` — which `docs/PARITY.md`
+over-claimed already existed — so *both* platforms' tables are enforced against
+`REVIEW_SAGA.md`. **No Hermes version bump:** Phase 1 makes the state machine
+*accept* `PARTIAL_TIMEOUT` (the parity contract); the orchestrator does not yet
+*write* it (break-circuit exercise + resume = Phase 1b). Plan:
+`plans/HERMES-PARITY-PHASE-1-PLAN.md`.
+
 ## D-0044 — the project roadmap lives in the BRD-00 index "Planned BRDs" table; a sketch is a trace-inert planned row (ENG-BRD-SKETCH-ROADMAP)
 
 **2026-06-30.** Whole-project scope is captured at project init by enumerating

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -1,5 +1,21 @@
 # Session Handoff
 
+> **🟢 HERMES-PARITY ARC STARTED — Phase 1 SHIPPED (2026-07-02).** The big
+> outstanding arc is underway. An evidence-backed assessment **corrected the stale
+> `HERMES-BACKLOG.md` premise**: Hermes already HAS team-mode (working saga
+> orchestrator + crew reconciliation), and the whole 0.32.x arc (D-0038…D-0044) is
+> **auto-satisfied** via vendored `sdd_doc_lint` + shared templates. The real gap is
+> older engine debt: **playbook injection + saga completeness**. **Phase 1 shipped**
+> (#229 plan + impl): added the spec-required `PARTIAL_TIMEOUT` state to Hermes's
+> saga table (was missing) + `test_saga_lifecycle_parity.py` enforcing both
+> platforms against `REVIEW_SAGA.md` (a test `PARITY.md` over-claimed existed). No
+> framework/Hermes version bump. D-0045; 4-phase roadmap in
+> `plans/HERMES-PARITY-PHASE-1-PLAN.md` + the refreshed `HERMES-BACKLOG.md`.
+> **▶ Next: Phase 1b** (orchestrator break-circuit exercise + `quality_loop_max_iterations`),
+> then **Phase 2 — playbook injection** (the load-bearing gap). Each is its own plan.
+>
+> ---
+>
 > **🟢 P3 CLEANUP ARC — items 2 & 3 SHIPPED + prerequisite bugfix + regen runbook +
 > P3 docs sweep (2026-06-30).** `main` clean at framework spec **0.32.6**, plugin
 > `0.23.0`. Eight PRs merged this session (all admin-merged — composition-CI gap

--- a/plans/HERMES-BACKLOG.md
+++ b/plans/HERMES-BACKLOG.md
@@ -2,10 +2,34 @@
 
 | Field | Value |
 |-------|-------|
-| Status     | **DEFERRED** — pending completion of plugin-side work |
+| Status     | **ARC UNDERWAY** — Phase 1 shipped (saga conformance); playbook injection is the load-bearing next gap |
 | Owner      | vladm3105 |
-| Last update | 2026-06-11 |
+| Last update | 2026-07-02 |
 | Policy     | **Plugin-first development.** Hermes work is deferred until the corresponding plugin functionality is complete and verified end-to-end. This is the single source of truth for "what Hermes still needs to catch up on." |
+
+> **⚠️ CORRECTED ASSESSMENT (2026-07-02, D-0045) — read before implementing any
+> H-item below.** An evidence-backed re-assessment found this backlog's central
+> premise **wrong**: **Hermes already has team-mode** (a working saga orchestrator
+> with parallel per-persona fan-out — `saga_orchestrator.py:526`; crews reconciled to
+> `REVIEW_CREWS.yaml` — `review_scoring.py:54`; MCP-wired `sdd_review` `saga_parallel`
+> mode). H-4's "team-mode not implemented" is **FALSE**. And the **entire 0.32.x arc
+> (D-0038…D-0044) is AUTO-SATISFIED** for Hermes via its byte-identical vendored
+> `sdd_doc_lint` + shared `framework/layers/` templates — none needs Hermes-native
+> code. The **real gap is older engine debt: playbook injection + saga completeness.**
+> Re-sequenced (see `plans/HERMES-PARITY-PHASE-1-PLAN.md`):
+>
+> | Phase | Scope | Status |
+> |-------|-------|--------|
+> | 1 | saga state-machine conformance (`PARTIAL_TIMEOUT`) + enforced `test_saga_lifecycle_parity.py` | **✅ shipped** — partial H-1 (table); no Hermes bump |
+> | 1b | orchestrator break-circuit *exercise* + resume (rest of H-1); `quality_loop_max_iterations` (H-7 knob) | pending |
+> | 2 | **playbook injection** for BRD+PRD (H-4) + fold H-6 + H-2 — the load-bearing gap everything else needs | pending |
+> | 3 | playbook fan-out to 6 more layers (H-5) + CHG crew (H-10) | pending |
+> | 4 (opt) | `sdd-orchestrator` agent-skill v3.2 modernization (H-11) | pending |
+>
+> **Auto-satisfied (no action):** H-3 (dormant), H-7 lint rows / H-8 / H-9 lint+template
+> rows, and all of D-0038…D-0044 — Hermes gets these via vendored lint + shared
+> templates. The H-N entries below are retained as historical detail; the phase table
+> above is the live sequencing.
 
 ## Why this exists
 

--- a/platforms/hermes/CHANGELOG.md
+++ b/platforms/hermes/CHANGELOG.md
@@ -14,6 +14,20 @@ this platform adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+
+- **Saga state-machine conformance (HERMES-PARITY-PHASE-1, D-0045).** Hermes's
+  `saga_models._ALLOWED_TRANSITIONS` was missing the spec's `PARTIAL_TIMEOUT`
+  break-circuit state (`REVIEW_SAGA.md` requires it reachable from `PREPARED`,
+  `FANOUT_STARTED`, `BRANCH_RUNNING`, `BRANCH_COMPLETED`, `FANIN_REDUCED`, terminal).
+  Added it so Hermes's table equals the spec and the plugin's `tools/saga_driver.py`.
+  New shared conformance test `tests/conformance/test_saga_lifecycle_parity.py` now
+  enforces both platforms' tables against `REVIEW_SAGA.md` and validates a sample
+  journal from each runner against `saga.schema.json` (the test `docs/PARITY.md`
+  previously over-claimed already existed). **No version bump** — Phase 1 makes the
+  state machine *accept* the transition (parity contract); the orchestrator does not
+  yet *write* it (break-circuit exercise + resume is Phase 1b).
+
 ### Removed
 
 - **Legacy SYS/REQ/CTR/TSPEC layers** (PLATFORM-ALIGN Part B3, `0.2.0 → 0.3.0`).

--- a/platforms/hermes/src/mcp_server/review/saga_models.py
+++ b/platforms/hermes/src/mcp_server/review/saga_models.py
@@ -35,17 +35,26 @@ class SagaRunState:
     compensation_actions: list[dict[str, object]] = field(default_factory=list)
 
 
+# Transition table — authority: framework/governance/REVIEW_SAGA.md.
+# `PARTIAL_TIMEOUT` is the break-circuit (or hard-timeout) terminal-this-process
+# state, reachable from every non-terminal run/branch state per the spec; a future
+# invocation resumes by re-entering an allowed source state (never `from:
+# PARTIAL_TIMEOUT` — G-R1). Matches the plugin reference tools/saga_driver.py.
+# NOTE: Phase 1 (HERMES-PARITY-PHASE-1) makes the state machine *accept* the
+# transition for spec conformance; the orchestrator does not yet *write* it —
+# wiring the break-circuit path + resume is Phase 1b.
 _ALLOWED_TRANSITIONS: dict[str, set[str]] = {
-    "PREPARED": {"FANOUT_STARTED"},
-    "FANOUT_STARTED": {"BRANCH_RUNNING"},
-    "BRANCH_RUNNING": {"BRANCH_COMPLETED", "BRANCH_FAILED"},
+    "PREPARED": {"FANOUT_STARTED", "PARTIAL_TIMEOUT"},
+    "FANOUT_STARTED": {"BRANCH_RUNNING", "PARTIAL_TIMEOUT"},
+    "BRANCH_RUNNING": {"BRANCH_COMPLETED", "BRANCH_FAILED", "PARTIAL_TIMEOUT"},
     "BRANCH_FAILED": {"BRANCH_COMPENSATING", "ESCALATED", "BRANCH_COMPLETED"},
     "BRANCH_COMPENSATING": {"BRANCH_RUNNING", "ESCALATED"},
-    "BRANCH_COMPLETED": {"FANIN_REDUCED"},
-    "FANIN_REDUCED": {"SYNTHESIZED"},
+    "BRANCH_COMPLETED": {"FANIN_REDUCED", "PARTIAL_TIMEOUT"},
+    "FANIN_REDUCED": {"SYNTHESIZED", "PARTIAL_TIMEOUT"},
     "SYNTHESIZED": {"CLOSED"},
     "ESCALATED": set(),
     "CLOSED": set(),
+    "PARTIAL_TIMEOUT": set(),
 }
 
 

--- a/tests/conformance/fixtures/saga/hermes_BRD-01_saga.json
+++ b/tests/conformance/fixtures/saga/hermes_BRD-01_saga.json
@@ -1,0 +1,34 @@
+{
+  "review_run_id": "hermes-brd01-9f8e7d6c",
+  "artifact_id": "BRD-01",
+  "layer": "01_BRD",
+  "personas_requested": [
+    "business_analyst",
+    "architect",
+    "chaos_engineer",
+    "security_engineer",
+    "auditor"
+  ],
+  "status": "CLOSED",
+  "iteration": 1,
+  "current_phase": "synthesize",
+  "created_at": "2026-06-11T09:00:00.000000+00:00",
+  "updated_at": "2026-06-11T09:12:30.000000+00:00",
+  "branches": {
+    "business_analyst": {"branch_id": "hba011223344", "status": "BRANCH_COMPLETED", "attempt": 0, "started_at": "2026-06-11T09:01:00.000000+00:00", "ended_at": "2026-06-11T09:03:00.000000+00:00"},
+    "architect": {"branch_id": "har011223344", "status": "BRANCH_COMPLETED", "attempt": 0, "started_at": "2026-06-11T09:01:00.000000+00:00", "ended_at": "2026-06-11T09:03:10.000000+00:00"},
+    "chaos_engineer": {"branch_id": "hch011223344", "status": "BRANCH_COMPLETED", "attempt": 0, "started_at": "2026-06-11T09:01:00.000000+00:00", "ended_at": "2026-06-11T09:03:20.000000+00:00"},
+    "security_engineer": {"branch_id": "hse011223344", "status": "BRANCH_COMPLETED", "attempt": 0, "started_at": "2026-06-11T09:01:00.000000+00:00", "ended_at": "2026-06-11T09:03:30.000000+00:00"},
+    "auditor": {"branch_id": "hau011223344", "status": "BRANCH_COMPLETED", "attempt": 0, "started_at": "2026-06-11T09:01:00.000000+00:00", "ended_at": "2026-06-11T09:03:40.000000+00:00"}
+  },
+  "transitions": [
+    {"ts": "2026-06-11T09:00:00.000000+00:00", "from": null, "to": "PREPARED", "scope": "run"},
+    {"ts": "2026-06-11T09:00:30.000000+00:00", "from": "PREPARED", "to": "FANOUT_STARTED", "scope": "run"},
+    {"ts": "2026-06-11T09:01:00.000000+00:00", "from": "FANOUT_STARTED", "to": "BRANCH_RUNNING", "scope": "branch:business_analyst"},
+    {"ts": "2026-06-11T09:03:00.000000+00:00", "from": "BRANCH_RUNNING", "to": "BRANCH_COMPLETED", "scope": "branch:business_analyst"},
+    {"ts": "2026-06-11T09:10:00.000000+00:00", "from": "BRANCH_COMPLETED", "to": "FANIN_REDUCED", "scope": "run"},
+    {"ts": "2026-06-11T09:11:00.000000+00:00", "from": "FANIN_REDUCED", "to": "SYNTHESIZED", "scope": "run"},
+    {"ts": "2026-06-11T09:12:30.000000+00:00", "from": "SYNTHESIZED", "to": "CLOSED", "scope": "run"}
+  ],
+  "compensation_actions": []
+}

--- a/tests/conformance/fixtures/saga/plugin_BRD-01_saga.json
+++ b/tests/conformance/fixtures/saga/plugin_BRD-01_saga.json
@@ -1,0 +1,34 @@
+{
+  "review_run_id": "plugin-brd01-1a2b3c4d",
+  "artifact_id": "BRD-01",
+  "layer": "01_BRD",
+  "personas_requested": [
+    "business_analyst",
+    "architect",
+    "chaos_engineer",
+    "security_engineer",
+    "auditor"
+  ],
+  "status": "CLOSED",
+  "iteration": 1,
+  "current_phase": "synthesize",
+  "created_at": "2026-06-10T17:09:08.829368+00:00",
+  "updated_at": "2026-06-10T17:50:28.203332+00:00",
+  "branches": {
+    "business_analyst": {"branch_id": "ba0011223344", "status": "BRANCH_COMPLETED", "attempt": 0, "started_at": "2026-06-10T17:21:31.522057+00:00", "ended_at": "2026-06-10T17:21:41.522057+00:00"},
+    "architect": {"branch_id": "ar0011223344", "status": "BRANCH_COMPLETED", "attempt": 0, "started_at": "2026-06-10T17:22:04.798059+00:00", "ended_at": "2026-06-10T17:22:14.798059+00:00"},
+    "chaos_engineer": {"branch_id": "ch0011223344", "status": "BRANCH_COMPLETED", "attempt": 0, "started_at": "2026-06-10T17:22:16.306059+00:00", "ended_at": "2026-06-10T17:22:26.306059+00:00"},
+    "security_engineer": {"branch_id": "se0011223344", "status": "BRANCH_COMPLETED", "attempt": 0, "started_at": "2026-06-10T17:22:28.100000+00:00", "ended_at": "2026-06-10T17:22:38.100000+00:00"},
+    "auditor": {"branch_id": "au0011223344", "status": "BRANCH_COMPLETED", "attempt": 0, "started_at": "2026-06-10T17:22:40.100000+00:00", "ended_at": "2026-06-10T17:22:50.100000+00:00"}
+  },
+  "transitions": [
+    {"ts": "2026-06-10T17:09:08.829381+00:00", "from": null, "to": "PREPARED", "scope": "run"},
+    {"ts": "2026-06-10T17:18:33.271544+00:00", "from": "PREPARED", "to": "FANOUT_STARTED", "scope": "run"},
+    {"ts": "2026-06-10T17:21:31.522057+00:00", "from": "FANOUT_STARTED", "to": "BRANCH_RUNNING", "scope": "branch:business_analyst"},
+    {"ts": "2026-06-10T17:21:41.522057+00:00", "from": "BRANCH_RUNNING", "to": "BRANCH_COMPLETED", "scope": "branch:business_analyst"},
+    {"ts": "2026-06-10T17:45:00.000000+00:00", "from": "BRANCH_COMPLETED", "to": "FANIN_REDUCED", "scope": "run"},
+    {"ts": "2026-06-10T17:48:00.000000+00:00", "from": "FANIN_REDUCED", "to": "SYNTHESIZED", "scope": "run"},
+    {"ts": "2026-06-10T17:50:28.203332+00:00", "from": "SYNTHESIZED", "to": "CLOSED", "scope": "run"}
+  ],
+  "compensation_actions": []
+}

--- a/tests/conformance/test_saga_lifecycle_parity.py
+++ b/tests/conformance/test_saga_lifecycle_parity.py
@@ -1,0 +1,188 @@
+"""Parity: both runners' review sagas conform to the one spec state machine.
+
+`framework/governance/REVIEW_SAGA.md` is the transition-table authority and
+`framework/governance/saga.schema.json` is the journal schema. This test enforces
+what `docs/PARITY.md` describes (previously an over-claim — the test + fixtures did
+not exist):
+
+  * both platforms' `_ALLOWED_TRANSITIONS` equal the spec transition table
+    (incl. the `PARTIAL_TIMEOUT` break-circuit state), and
+  * a committed sample journal from each runner validates against the shared
+    `saga.schema.json`.
+
+The spec transition table is markdown prose (terminal rows read `(terminal)`), so
+it is HARD-CODED here as `SPEC_TRANSITIONS` — a deliberate second source of truth,
+exactly as `test_saga_driver_invariants.py` already does for the plugin. That
+sibling test carries the detailed plugin-driver invariants; this test's net-new job
+is the *Hermes* table + the cross-platform fixture parity.
+
+HERMES-PARITY-PHASE-1 (D-0045).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import unittest
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_FIXTURES = Path(__file__).resolve().parent / "fixtures" / "saga"
+_SCHEMA_PATH = _REPO_ROOT / "framework" / "governance" / "saga.schema.json"
+
+# --- import both platforms' transition tables (module-level constants) ---
+sys.path.insert(0, str(_REPO_ROOT / "tools"))
+sys.path.insert(0, str(_REPO_ROOT / "platforms" / "hermes" / "src" / "mcp_server" / "review"))
+import saga_driver  # noqa: E402  (plugin reference; path injection intentional)
+import saga_models  # noqa: E402  (Hermes; imports only stdlib)
+
+# The REVIEW_SAGA.md transition table, hard-coded (the markdown is prose, not
+# machine-parseable). Source authority: framework/governance/REVIEW_SAGA.md.
+SPEC_TRANSITIONS: dict[str, set[str]] = {
+    "PREPARED": {"FANOUT_STARTED", "PARTIAL_TIMEOUT"},
+    "FANOUT_STARTED": {"BRANCH_RUNNING", "PARTIAL_TIMEOUT"},
+    "BRANCH_RUNNING": {"BRANCH_COMPLETED", "BRANCH_FAILED", "PARTIAL_TIMEOUT"},
+    "BRANCH_FAILED": {"BRANCH_COMPENSATING", "ESCALATED", "BRANCH_COMPLETED"},
+    "BRANCH_COMPENSATING": {"BRANCH_RUNNING", "ESCALATED"},
+    "BRANCH_COMPLETED": {"FANIN_REDUCED", "PARTIAL_TIMEOUT"},
+    "FANIN_REDUCED": {"SYNTHESIZED", "PARTIAL_TIMEOUT"},
+    "SYNTHESIZED": {"CLOSED"},
+    "ESCALATED": set(),
+    "CLOSED": set(),
+    "PARTIAL_TIMEOUT": set(),
+}
+
+
+def _type_ok(value: object, t: str) -> bool:
+    if t == "object":
+        return isinstance(value, dict)
+    if t == "array":
+        return isinstance(value, list)
+    if t == "string":
+        return isinstance(value, str)
+    if t == "boolean":
+        return isinstance(value, bool)
+    if t == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if t == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if t == "null":
+        return value is None
+    return True
+
+
+def validate(instance: object, schema: dict, path: str = "$") -> list[str]:
+    """Dependency-free check of the JSON-Schema subset this contract uses
+    (type incl. union lists, required, properties, items, enum, minimum,
+    maximum, minLength, minItems, pattern)."""
+    errors: list[str] = []
+    t = schema.get("type")
+    if t is not None:
+        types = t if isinstance(t, list) else [t]
+        if not any(_type_ok(instance, one) for one in types):
+            return [f"{path}: expected {t}, got {type(instance).__name__}"]
+    if "enum" in schema and instance not in schema["enum"]:
+        errors.append(f"{path}: {instance!r} not in enum {schema['enum']}")
+    if isinstance(instance, str):
+        if "minLength" in schema and len(instance) < schema["minLength"]:
+            errors.append(f"{path}: len {len(instance)} < minLength {schema['minLength']}")
+        pat = schema.get("pattern")
+        if pat and not re.search(pat, instance):
+            errors.append(f"{path}: {instance!r} does not match pattern {pat!r}")
+    if isinstance(instance, int) and not isinstance(instance, bool):
+        if "minimum" in schema and instance < schema["minimum"]:
+            errors.append(f"{path}: {instance} < minimum {schema['minimum']}")
+        if "maximum" in schema and instance > schema["maximum"]:
+            errors.append(f"{path}: {instance} > maximum {schema['maximum']}")
+    if isinstance(instance, dict):
+        for req in schema.get("required", []):
+            if req not in instance:
+                errors.append(f"{path}: missing required '{req}'")
+        for key, subschema in schema.get("properties", {}).items():
+            if key in instance:
+                errors.extend(validate(instance[key], subschema, f"{path}.{key}"))
+        extra = schema.get("additionalProperties")
+        if isinstance(extra, dict):
+            declared = set(schema.get("properties", {}))
+            for key, val in instance.items():
+                if key not in declared:
+                    errors.extend(validate(val, extra, f"{path}.{key}"))
+    if isinstance(instance, list):
+        if "minItems" in schema and len(instance) < schema["minItems"]:
+            errors.append(f"{path}: {len(instance)} items < minItems {schema['minItems']}")
+        item_schema = schema.get("items")
+        if item_schema:
+            for i, item in enumerate(instance):
+                errors.extend(validate(item, item_schema, f"{path}[{i}]"))
+    return errors
+
+
+class SagaTransitionTableParity(unittest.TestCase):
+    """Both platforms' `_ALLOWED_TRANSITIONS` must equal the spec table."""
+
+    def test_hermes_table_matches_spec(self):
+        self.assertEqual(
+            saga_models._ALLOWED_TRANSITIONS,
+            SPEC_TRANSITIONS,
+            "Hermes saga_models._ALLOWED_TRANSITIONS diverges from REVIEW_SAGA.md "
+            "(missing PARTIAL_TIMEOUT?).",
+        )
+
+    def test_plugin_table_matches_spec(self):
+        self.assertEqual(
+            saga_driver._ALLOWED_TRANSITIONS,
+            SPEC_TRANSITIONS,
+            "plugin saga_driver._ALLOWED_TRANSITIONS diverges from REVIEW_SAGA.md.",
+        )
+
+    def test_both_platforms_agree(self):
+        self.assertEqual(
+            saga_models._ALLOWED_TRANSITIONS,
+            saga_driver._ALLOWED_TRANSITIONS,
+            "Hermes and plugin saga transition tables disagree.",
+        )
+
+    def test_partial_timeout_terminal_both(self):
+        # G-R1: PARTIAL_TIMEOUT is terminal-this-process on both platforms.
+        self.assertEqual(saga_models._ALLOWED_TRANSITIONS.get("PARTIAL_TIMEOUT"), set())
+        self.assertEqual(saga_driver._ALLOWED_TRANSITIONS.get("PARTIAL_TIMEOUT"), set())
+
+
+class SagaJournalFixtureParity(unittest.TestCase):
+    """A sample journal from each runner validates against the shared schema."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    def _validate_fixture(self, name: str):
+        data = json.loads((_FIXTURES / name).read_text(encoding="utf-8"))
+        errors = validate(data, self.schema)
+        self.assertEqual(errors, [], f"{name} fails saga.schema.json: {errors}")
+        # every recorded `to`/`from` state is a known saga status
+        states = set(self.schema["properties"]["status"]["enum"])
+        for tr in data["transitions"]:
+            self.assertIn(tr["to"], states, f"{name}: unknown transition target {tr['to']!r}")
+            if tr.get("from") is not None:
+                self.assertIn(
+                    tr["from"], states, f"{name}: unknown transition source {tr['from']!r}"
+                )
+
+    def test_plugin_fixture_validates(self):
+        self._validate_fixture("plugin_BRD-01_saga.json")
+
+    def test_hermes_fixture_validates(self):
+        self._validate_fixture("hermes_BRD-01_saga.json")
+
+    def test_fixtures_share_shape(self):
+        plugin = json.loads((_FIXTURES / "plugin_BRD-01_saga.json").read_text(encoding="utf-8"))
+        hermes = json.loads((_FIXTURES / "hermes_BRD-01_saga.json").read_text(encoding="utf-8"))
+        required = set(self.schema["required"])
+        self.assertTrue(required <= plugin.keys() and required <= hermes.keys())
+        self.assertEqual(plugin["layer"], hermes["layer"])
+        self.assertEqual(plugin["artifact_id"], hermes["artifact_id"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Impl PR — HERMES-PARITY-PHASE-1 (plan #229)

Implements `plans/HERMES-PARITY-PHASE-1-PLAN.md` (merged #229) — the first slice of
the Hermes-parity arc.

### Change
- **Hermes saga table:** `saga_models._ALLOWED_TRANSITIONS` was **missing** the
  spec's `PARTIAL_TIMEOUT` break-circuit state (`REVIEW_SAGA.md` requires it from 5
  source states, terminal). Added it → Hermes's table now equals the spec and the
  plugin's `tools/saga_driver.py`.
- **New enforced parity test** `tests/conformance/test_saga_lifecycle_parity.py` (+
  `fixtures/saga/{hermes,plugin}_BRD-01_saga.json`): asserts **both** platforms'
  `_ALLOWED_TRANSITIONS` equal the `REVIEW_SAGA.md` table (incl. `PARTIAL_TIMEOUT`)
  and validates a sample journal from each runner against `saga.schema.json` — a
  test `docs/PARITY.md` **over-claimed already existed** (it didn't). Stdlib-only
  validator (mirrors `test_review_report_parity.py`).
- **Honest `PARITY.md` reconciliation:** the Resilience row now says Hermes
  *accepts* but does not yet *write* `PARTIAL_TIMEOUT` (Phase 1b); the parity-test
  bullet drops the false "28 SKILLs" claim (real: ~18 audit/fixer skills, not
  asserted by this test).
- **Corrected the stale `HERMES-BACKLOG.md`** (team-mode already exists; the 0.32.x
  arc is auto-satisfied) + a 4-phase roadmap. D-0045.

### No version change
No `framework/**` change (GATE-SPEC no-op); **no Hermes bump** — Phase 1 makes the
state machine *accept* the transition (parity contract); the orchestrator
break-circuit *exercise* + resume is Phase 1b (per `PARITY.md`'s capability-based
bump policy).

### Verification
- V1 test **failed on the unfixed Hermes table** (3 table tests red) — proves it catches the gap.
- V2 `pytest tests/conformance` → **157 passed, 644 subtests** (+7 new).
- V3 full Hermes suite → **476 passed** (no regression from the table change).
- V6 no `framework/` diff; Hermes `VERSION` 0.3.0 + `FRAMEWORK_SPEC_VERSION` 0.32.6 unchanged.

Plan was 2-cycle reviewed (1 independent; 3 load-bearing findings folded incl. the "28→18 SKILLs" + Resilience-row corrections implemented here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)