### PR TITLE
docs(hermes): log H-12 saga-journal conformance finding; live CHG saga disproven

### DIFF
--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -24,13 +24,17 @@
 > the `chg` review crew to `persona_mappings.yaml` + removed the deferred-whitelist
 > so the crew-coverage test enforces CHG. Crew-map parity only. 497 Hermes + 157
 > conformance green.
-> **▶ Next (Hermes follow-ons, each its own plan):** **live/sanctioned CHG saga**
-> (add `09_CHG` to `saga.schema.json` + a dispatch path — the review found no runtime
-> schema wall, so an explicit `doc_type=chg` review is dispatchable-but-unsanctioned);
-> **H-6/H-2 calibration deltas** (no-findings rationale / author-self-claim strip /
-> fixer-regression); **Phase 1b** (saga break-circuit exercise +
-> `quality_loop_max_iterations`); **`prompt_only` playbook injection**. Also H-11
-> (agent-skill v3.2 modernization) + the broader items in `HERMES-BACKLOG.md`.
+> **▶ Next (Hermes follow-ons, each its own plan):**
+> **(1) `H-12` — real saga-journal schema conformance** (NEW, highest value — found
+> 2026-07-03): Hermes's *real* saga journals miss 4 `saga.schema.json`-required
+> fields (`artifact_id`/`layer`/`iteration`/`transitions`); the Phase-1 conformance
+> only validates hand-authored *fixtures*, masking it. Fix `SagaRunState` +
+> serialization + a real-journal conformance test. **NOTE: "live CHG saga" was
+> disproven — CHG review already works end-to-end (verified); fold its residue into
+> H-12.** **(2)** `H-6`/`H-2` calibration deltas (no-findings rationale /
+> author-self-claim strip / fixer-regression). **(3)** Phase 1b (saga break-circuit
+> exercise + `quality_loop_max_iterations`). **(4)** `prompt_only` playbook injection;
+> `H-11` agent-skill modernization. See `HERMES-BACKLOG.md`.
 >
 > ---
 >

--- a/plans/HERMES-BACKLOG.md
+++ b/plans/HERMES-BACKLOG.md
@@ -54,6 +54,41 @@ the plugin has been the testbed for are batched here.
 
 ## Hermes-deferred items
 
+### H-12 — Hermes real saga journals don't conform to `saga.schema.json` (fixtures mask it)
+
+**Source:** discovered 2026-07-03 while grounding the "live CHG saga" follow-on
+after HERMES-PARITY-PHASE-3 (#234).
+
+**Finding (evidence-backed):** a **real** Hermes saga journal (serialized from
+`SagaRunState`, `platforms/hermes/src/mcp_server/review/saga_models.py`) is
+**missing 4 `saga.schema.json`-required fields**: `artifact_id`, `layer`,
+`iteration`, `transitions`. Verified by running `run_project_review_build_saga`
+end-to-end and dumping `journal_path` — keys were
+`{review_run_id, document_path, document_fingerprint, personas_requested, status,
+created_at, updated_at, retry_count, branches, compensation_actions}`. The
+`tests/conformance/test_saga_lifecycle_parity.py` guard (HERMES-PARITY-PHASE-1)
+only validates **hand-authored fixtures** (`fixtures/saga/hermes_BRD-01_saga.json`,
+which were written *with* those fields) — so the "both platforms' saga journals
+conform to the shared schema" parity claim is **aspirational for Hermes**, not
+enforced against real output.
+
+**Fix shape:** add `artifact_id` / `layer` / `iteration` to `SagaRunState` (populate
+from the saga call's `layer` + extracted doc id) and serialize the accumulated
+`transitions` into the journal; add a conformance/integration test that validates a
+**real** Hermes journal (not a fixture) against `saga.schema.json`. This also
+naturally sanctions CHG (a real CHG journal would carry `layer: "09_CHG"`, which
+then needs `09_CHG` added to the schema enum — a `framework/` change). Moderate
+(Hermes engine + a framework schema addition).
+
+**Related — "live CHG saga" is a NEAR-NO-OP:** CHG review already runs end-to-end
+today (verified: `saga_status=CLOSED`, uncited findings discarded, `playbook_coverage
+{C1:1}`) because the injection path is layer-agnostic (Phase 2) and CHG crew parity
+landed in Phase 3 (#234). The only thing "live CHG" adds beyond H-12 is documenting
+`sdd_review doc_type=chg` as a sanctioned target. Fold into H-12.
+
+**Dependency:** none. Independent of the other H-items. Higher value than the
+originally-planned "live CHG saga" (which grounding showed unnecessary).
+
 ### H-1 — SAGA-PARITY-001 Phase 3: G-R1 invariant alignment
 
 **Source:** [`docs/PARITY.md`](../docs/PARITY.md) §Enforcement parity;


### PR DESCRIPTION
## Docs-only — capture a grounding finding

While grounding the recommended "live CHG saga" follow-on (post HERMES-PARITY-PHASE-3
#234), two things surfaced:

1. **"Live CHG saga" is a near-no-op.** CHG review already runs end-to-end today —
   verified: `saga_status=CLOSED`, uncited findings discarded (citation floor works
   for CHG), `playbook_coverage {C1:1}`. The injection path is layer-agnostic (Phase
   2) and CHG crew parity landed in Phase 3. It was never blocked.

2. **Real, higher-value gap found → logged as `H-12`.** Hermes's *actual* saga
   journals (serialized from `SagaRunState`) are **missing 4 `saga.schema.json`-required
   fields** (`artifact_id`, `layer`, `iteration`, `transitions`). The Phase-1
   conformance test only validates hand-authored *fixtures* (written *with* those
   fields), so the "both platforms' saga journals conform" parity claim is aspirational
   for Hermes, not enforced against real output.

This PR logs `H-12` in `HERMES-BACKLOG.md` (with the fix shape + the CHG residue folded
in) and refreshes the `HANDOFF.md` next-steps. **Docs only; no code/spec change.**

Rationale for logging vs. building: this is a fresh, moderate item (Hermes engine + a
framework schema addition) surfaced late in a 16-PR session; capturing it durably
(only committed work survives) is the right move before picking it up deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)