### PR TITLE
fix(lint): LINT-DOCID-HEADER-FALSE-POSITIVE — narrow ID02 to digit-leading doc-id tokens

### DIFF
--- a/plans/DECISIONS.md
+++ b/plans/DECISIONS.md
@@ -10,6 +10,35 @@ graduation.
 
 ---
 
+## D-0056 — The ID02 malformed-doc-id scan flags only digit-leading `TYPE-<n>` tokens (generalizes D-0043's `-INDEX` exemption); no version bump
+
+**2026-07-06.** LINT-DOCID-HEADER-FALSE-POSITIVE. The `sdd_doc_lint` ID02 check
+(`_DOC_ID` = `\b(TYPE)-([A-Za-z0-9]+)\b`) flagged **any** `TYPE-<token>` that wasn't
+`TYPE-<digits>` (or `-INDEX`) as a malformed document id — so prose like `PRD-Ready` (a
+readiness-gate name), `BRD-TEMPLATE` (a quick-link), and `BRD-NN` (a placeholder) tripped it
+on the BRD-00 index template and on any consumer's filled-in index.
+
+**Decision.** A valid doc-id's post-hyphen segment is **always all-digits** (`doc_re` =
+`^[A-Z]+-\d{2,}$`), so a `TYPE-<letter-leading>` token can never be a malformed instance of
+that form — it is a compound word/marker. ID02 now fires **only when the second segment is
+digit-leading** (`m.group(2)[0].isdigit()`) and fails `doc_re`. This removes the prose
+false-positives while keeping every real malformed id flagged (`BRD-2`, `BRD-007x`), and
+**generalizes** [[D-0043]]'s special-cased `-INDEX` exemption to any non-id-like token (the
+explicit `-INDEX` clause is subsumed and removed). Accepted tradeoff: a letter-in-digit-slot
+typo (`BRD-O1`) is no longer flagged — rare, and a future `≥1-digit` heuristic could recover
+it without reintroducing the FPs.
+
+**No version bump.** ID02 is not documented normatively in `framework/`; the rule's contract
+("malformed doc-ids are flagged") is unchanged — only the FP scope narrows. The lint code
+lives in `tools/sdd_doc_lint/` (vendored byte-identical to both platform mirrors via
+`sync-vendored.sh`); no `framework/**` path is touched → GATE-SPEC does not fire, matching the
+D-0043 (STRUCT01-INDEX-EXEMPTION) linter-bugfix-no-bump precedent. New unit cases guard the FP
+removal (via the valid fixture) + the kept true-positive; 166 conformance green; zero ID02 on
+the example corpus. Reviewed: 3 passes (Pass 2 independent). Closes FRAMEWORK-TODO
+`LINT-DOCID-HEADER-FALSE-POSITIVE`.
+
+---
+
 ## D-0055 — COV03 phase-leak advisory (deferred-band over-realization); no new phase tag — the band + BRD-00 roadmap already encode both phase axes
 
 **2026-07-06.** D54-F13 (phase-leak leg; framework spec `0.33.1 → 0.34.0`, MINOR). The

--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -600,7 +600,14 @@
 - *Fix shape:* narrow the `_DOC_ID` malformed-id check — skip tokens inside
   inline-code / link targets / known header words, or require the doc-id to be a
   standalone token in a trace context. Needs care not to mask real malformed ids.
-- *Status:* OPEN — P3.
+- *Status:* ✅ **CLOSED (2026-07-06, `LINT-DOCID-HEADER-FALSE-POSITIVE-PLAN.md`, D-0056).**
+  ID02 now fires **only on a digit-leading second segment** (a valid doc-id is
+  `TYPE-<digits>`, always digit-leading; a letter-leading `TYPE-<word>` is prose). Removes
+  `PRD-Ready`/`BRD-TEMPLATE`/`BRD-NN` while keeping real malformed ids (`BRD-2`, `BRD-007x`);
+  generalizes D-0043's `-INDEX` exemption. Pure `tools/sdd_doc_lint` bugfix (vendored to both
+  mirrors) — **no `framework/` change, no version bump** (D-0043 precedent). New unit guard +
+  166 conformance green. *(Chosen over the inline-code/link-context parse — that would miss
+  the bare table-cell `PRD-Ready`.)*
 
 ### `[template]` `ENG-PLATFORM-ADR-TIMING` — "ADRs created BEFORE PRD" wording conflicts with cumulative-tag chain
 

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -96,12 +96,18 @@
 > BRD-00 `Cycle` roadmap already encode both phase axes (cross-cycle leaks are structurally
 > prevented by trace-inert future BRDs). Canonical `tools/sdd_doc_lint` + both mirrors;
 > TRACEABILITY.md §Coverage gates; 6 tests; zero example-corpus findings; verified
-> end-to-end. Closes `D54-F13`. **▶ Remaining genuinely-open framework-core:** `D54-F04`
-> EARS rubric (P3), `LINT-DOCID-HEADER-FALSE-POSITIVE` (P3), `D54-F08` skeleton-emit (P3).
-> Each is a `framework/` spec-tier PR → **impl merge needs founder ratification.**
-> **Note:** IPLAN-LANG-001 (#255) merged (founder-ratified); the D54-F13/COV03 impl PR is
-> OPEN awaiting founder ratification (spec-tier; AI must not auto-merge framework-spec
-> changes).
+> end-to-end. Closes `D54-F13`. Then shipped **`LINT-DOCID-HEADER-FALSE-POSITIVE`** (PR #258
+> plan; impl D-0056): the ID02 malformed-doc-id scan now fires **only on digit-leading
+> `TYPE-<n>` tokens** (a valid id is `TYPE-<digits>`; a letter-leading `TYPE-<word>` like
+> `PRD-Ready`/`BRD-TEMPLATE` is prose) — generalizes D-0043's `-INDEX` exemption. **Pure
+> `tools/sdd_doc_lint` bugfix — no `framework/` change, no version bump, auto-mergeable**
+> (D-0043 precedent). **▶ Remaining genuinely-open framework-core (both spec-tier, P3):**
+> `D54-F04` EARS-Ready rubric broadening, `D54-F08` `--skeleton` template emit — impl merge
+> needs founder ratification.
+> **Note:** IPLAN-LANG-001 (#255) + D54-F13/COV03 (#257) merged (founder-ratified). **CI
+> FIX:** the v1.5.1 `aidoc-flow-ci` bump (#254) FIXED the composition-check-on-PR-head gap
+> (`AIDOC-CI-COMPOSITION-CHECK-PRHEAD`) — plan/docs PRs now merge via the **normal green
+> path** (no `--admin` needed); #258 was the first to merge cleanly without admin.
 >
 > ---
 >

--- a/platforms/claude-code-plugin/sdd_doc_lint/__init__.py
+++ b/platforms/claude-code-plugin/sdd_doc_lint/__init__.py
@@ -551,7 +551,12 @@ def lint_text(
         # Inline document IDs (TYPE-NN) of known artifacts must match the doc form.
         for m in _DOC_ID.finditer(line):
             tok = m.group(0)
-            if not doc_re.match(tok) and not tok.upper().endswith("-INDEX"):
+            # Only a DIGIT-leading second segment is a plausible doc-id attempt
+            # (a valid id is TYPE-<digits>). A letter-leading token — PRD-Ready,
+            # BRD-TEMPLATE, BRD-NN, <X>-INDEX — is a compound word/marker, never a
+            # malformed id, so it must not draw ID02 (LINT-DOCID-HEADER-FALSE-POSITIVE;
+            # generalizes D-0043's `-INDEX` exemption to any non-id-like token).
+            if m.group(2)[0].isdigit() and not doc_re.match(tok):
                 findings.append(Finding(rel, i, "ID02", f"malformed document id '{tok}'"))
         # Inline element IDs (TYPE.a.b.c…) of known artifacts must match the element form.
         for m in _ELEM_ID.finditer(line):

--- a/platforms/hermes/sdd_doc_lint/__init__.py
+++ b/platforms/hermes/sdd_doc_lint/__init__.py
@@ -551,7 +551,12 @@ def lint_text(
         # Inline document IDs (TYPE-NN) of known artifacts must match the doc form.
         for m in _DOC_ID.finditer(line):
             tok = m.group(0)
-            if not doc_re.match(tok) and not tok.upper().endswith("-INDEX"):
+            # Only a DIGIT-leading second segment is a plausible doc-id attempt
+            # (a valid id is TYPE-<digits>). A letter-leading token — PRD-Ready,
+            # BRD-TEMPLATE, BRD-NN, <X>-INDEX — is a compound word/marker, never a
+            # malformed id, so it must not draw ID02 (LINT-DOCID-HEADER-FALSE-POSITIVE;
+            # generalizes D-0043's `-INDEX` exemption to any non-id-like token).
+            if m.group(2)[0].isdigit() and not doc_re.match(tok):
                 findings.append(Finding(rel, i, "ID02", f"malformed document id '{tok}'"))
         # Inline element IDs (TYPE.a.b.c…) of known artifacts must match the element form.
         for m in _ELEM_ID.finditer(line):

--- a/tools/sdd_doc_lint/__init__.py
+++ b/tools/sdd_doc_lint/__init__.py
@@ -551,7 +551,12 @@ def lint_text(
         # Inline document IDs (TYPE-NN) of known artifacts must match the doc form.
         for m in _DOC_ID.finditer(line):
             tok = m.group(0)
-            if not doc_re.match(tok) and not tok.upper().endswith("-INDEX"):
+            # Only a DIGIT-leading second segment is a plausible doc-id attempt
+            # (a valid id is TYPE-<digits>). A letter-leading token — PRD-Ready,
+            # BRD-TEMPLATE, BRD-NN, <X>-INDEX — is a compound word/marker, never a
+            # malformed id, so it must not draw ID02 (LINT-DOCID-HEADER-FALSE-POSITIVE;
+            # generalizes D-0043's `-INDEX` exemption to any non-id-like token).
+            if m.group(2)[0].isdigit() and not doc_re.match(tok):
                 findings.append(Finding(rel, i, "ID02", f"malformed document id '{tok}'"))
         # Inline element IDs (TYPE.a.b.c…) of known artifacts must match the element form.
         for m in _ELEM_ID.finditer(line):

--- a/tools/sdd_doc_lint/fixtures/valid/docs/01_BRD/BRD-01_login.md
+++ b/tools/sdd_doc_lint/fixtures/valid/docs/01_BRD/BRD-01_login.md
@@ -40,6 +40,10 @@ intro
 ## Business Objectives
 
 Stub BRD with element id BRD.01.07.a7f3 referenced from EARS-01 + PRD-01.
+The PRD-Ready gate, the BRD-TEMPLATE quick-link, the BRD-NN placeholder, and a
+SPEC-Final note are prose tokens, NOT malformed doc-ids — they must draw no ID02
+(LINT-DOCID-HEADER-FALSE-POSITIVE: only digit-leading TYPE-<n> tokens are doc-id
+attempts).
 
 ## Project Scope
 

--- a/tools/sdd_doc_lint/tests/test_lint.py
+++ b/tools/sdd_doc_lint/tests/test_lint.py
@@ -57,6 +57,21 @@ class DocLint(unittest.TestCase):
         findings = lint_path(Path(__file__))
         self.assertEqual(findings, [])
 
+    def test_id02_skips_letter_leading_prose_but_flags_digit_leading(self):
+        # LINT-DOCID-HEADER-FALSE-POSITIVE: a valid doc-id is TYPE-<digits>, so a
+        # letter-leading TYPE-<word> token (PRD-Ready / BRD-TEMPLATE / BRD-NN /
+        # SPEC-Final) is prose, not a malformed id — it must NOT draw ID02. The
+        # valid fixture carries those four tokens; a digit-leading malformed id
+        # (BRD-2 in the broken fixture) must STILL draw ID02.
+        valid_id02 = [f for f in lint_path(FIXTURES / "valid") if f.code == "ID02"]
+        self.assertEqual(
+            valid_id02, [], f"letter-leading prose must not draw ID02; got {valid_id02}"
+        )
+        broken_id02 = {
+            f.message.split("'")[1] for f in lint_path(FIXTURES / "broken") if f.code == "ID02"
+        }
+        self.assertIn("BRD-2", broken_id02, "digit-leading malformed id must still draw ID02")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Implements the merged plan `plans/LINT-DOCID-HEADER-FALSE-POSITIVE-PLAN.md` (**D-0056**). Closes FRAMEWORK-TODO `LINT-DOCID-HEADER-FALSE-POSITIVE`. **Pure `sdd_doc_lint` bugfix — no `framework/` change, no version bump** (D-0043 precedent), auto-mergeable.

## What changed

The ID02 malformed-doc-id scan (`_DOC_ID` = `\b(TYPE)-([A-Za-z0-9]+)\b`) flagged **any** `TYPE-<token>` that wasn't `TYPE-<digits>` or `-INDEX` — so prose like `PRD-Ready`, `BRD-TEMPLATE`, `BRD-NN` tripped it on the BRD-00 index template and any consumer's filled-in index.

A valid doc-id's post-hyphen segment is **always all-digits** (`doc_re` = `^[A-Z]+-\d{2,}$`), so a letter-leading `TYPE-<word>` can never be a malformed instance — it's a compound word. ID02 now fires **only when the second segment is digit-leading**. This **generalizes** D-0043's `-INDEX` exemption.

- **Removes:** `PRD-Ready`, `BRD-TEMPLATE`, `BRD-NN`, `SPEC-Final`.
- **Keeps:** `BRD-2`, `BRD-007x` (real malformed ids, incl. the broken-fixture case).

## Verification

- `5 unit tests + 166 conformance` green; canonical + both mirrors byte-identical; zero ID02 on the example corpus.
- New unit guard: the valid fixture carries the 4 FP tokens (must stay ID02-clean) + a digit-leading true-positive assertion.
- No `framework/**` touched (grep-confirmed ID02 isn't documented in the spec) → no GATE-SPEC, no version bump.
- **Pre-push independent adversarial review: 0 findings across all 6 checks.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)