### PR TITLE
docs(todo): defer D54-F08 (--skeleton emit) as build-on-demand (D-0058) — clears the framework-core backlog

### DIFF
--- a/plans/DECISIONS.md
+++ b/plans/DECISIONS.md
@@ -10,6 +10,35 @@ graduation.
 
 ---
 
+## D-0058 — Defer D54-F08 (`--skeleton` template emit) as build-on-demand — a speculative DX convenience with real hazards, not built now
+
+**2026-07-06.** D54-F08 asked for a `--skeleton` emit that strips a template's authoring keys
+(`_guidance`/`_example`/`_antipatterns`) leaving the content keys, as plugin tooling. Grounding
+found no existing internal "context-strip" to reuse (the TODO's premise), and the feature is a
+speculative convenience with real hazards, so per the minimal-and-realistic / no-speculative-
+features convention it is **deferred (build-on-demand)**, not built.
+
+**Reasons.** (1) **Anti-aligned with the framework's own design** — templates are deliberately
+`_guidance`-dense (127 `_guidance` blocks in BRD alone) because the framework bets guidance-
+dense templates author *better*; the `doc-*` skills inject the **full** template. A guidance-
+stripped skeleton produces lower-quality authoring, working against that thesis. (2) **Comment-
+fidelity hazard** — a YAML `safe_load`→`safe_dump` strip destroys all inline `#` enum hints and
+reformats, so the skeleton would not resemble the template; faithful output needs a
+`ruamel.yaml` round-trip (a new dependency). (3) **Divergence risk** — the underscore keys are
+NOT uniformly strippable: `_authored_form` (the BRD FR-coverage contract COV01 depends on),
+`_required_when_subtype` (IPLAN sub-type gating), and `_required` are **normative**; a naive
+strip drops required structure and misleads authors, and the preserve-list must stay in sync as
+templates evolve. (4) **No demand signal** — no consumer requests it.
+
+**Revive criterion.** Build only if a consumer actually asks. The safe form is then a `tools/`
+script with a **curated strip denylist** (`_guidance`/`_size_target`/`_note`/`_antipatterns`/
+`_example`) that preserves the normative keys, plus a test asserting they survive — ideally
+`ruamel.yaml` round-trip for comment fidelity. Tracked as DEFERRED in FRAMEWORK-TODO
+`D54-F08`. This closes out the framework-core backlog sweep: the remaining P2/P3 items were
+either shipped or (this one) deferred with rationale.
+
+---
+
 ## D-0057 — EARS quantification is dimension-appropriate: latency → percentiles, non-latency → a concrete numeric bound (reconcile the template rubric to the already-correct playbooks)
 
 **2026-07-06.** D54-F04 (framework spec `0.34.0 → 0.34.1`, PATCH). The EARS quality-attribute

--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -485,7 +485,24 @@
 - *Fix shape:* a `--skeleton` emit (strip `_guidance`/`_example`/
   `_antipatterns`, leave content keys) — land as plugin tooling, not a
   new CLI.
-- *Status:* OPEN — P3.
+- *Status:* ⏸️ **DEFERRED — build-on-demand (2026-07-06, D-0058).** Grounding found this a
+  speculative DX convenience with real hazards, so it is not built now (per the
+  minimal-and-realistic convention). Reasons: (1) **anti-aligned with the framework's own
+  design** — templates are deliberately `_guidance`-dense because the framework bets that
+  guidance-dense templates author *better* (the `doc-*` skills inject the full template); a
+  guidance-stripped skeleton produces lower-quality authoring. (2) **Comment-fidelity hazard**
+  — a YAML `safe_load`→`safe_dump` strip destroys all `#` inline enum hints
+  (`value: feature  # platform | feature`) and reorders/reformats, so the skeleton would not
+  resemble the template; faithful output needs a `ruamel.yaml` round-trip (a new dependency).
+  (3) **Divergence risk** — not all underscore keys are strippable: `_authored_form` (the BRD
+  FR-coverage contract COV01 depends on), `_required_when_subtype` (IPLAN sub-type gating), and
+  `_required` are **normative** and must be preserved; a naive "strip all `_`" would drop
+  required structure and mislead authors, and the preserve-list must stay in sync as templates
+  evolve. (4) **No demand signal** — no consumer log requests a skeleton; the `doc-*` skills
+  already own authoring. **Revive only if a consumer actually asks** — at which point the safe
+  form is a `tools/` script with a curated strip denylist (`_guidance`/`_size_target`/`_note`/
+  `_antipatterns`/`_example`) that preserves the normative keys, plus a test asserting they
+  survive.
 
 ### Engramory consumer feedback (SDD authoring against v0.23.0) — triaged 2026-06-26
 

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -105,14 +105,21 @@
 > 0.34.1`): reworded the EARS-Ready rubric so a **non-latency** quantified bound (cycles /
 > iterations / event-window / `*.count`) counts as quantified — percentiles stay required for
 > **latency** only. Template-only (the playbook lenses were already correct); no new syntax;
-> deterministic lint byte-identical (rubric is LLM-auditor scoring). **▶ Remaining
-> genuinely-open framework-core (spec-tier, P3):** just `D54-F08` `--skeleton` template emit —
-> impl merge needs founder ratification.
-> **Note:** IPLAN-LANG-001 (#255) + D54-F13/COV03 (#257) merged (founder-ratified); D54-F04
-> (#261) impl OPEN awaiting ratification. **CI FIX:** the v1.5.1 `aidoc-flow-ci` bump (#254)
-> FIXED the composition-check-on-PR-head gap (`AIDOC-CI-COMPOSITION-CHECK-PRHEAD`) — plan/docs
-> PRs now merge via the **normal green path** (no `--admin` needed); #258/#260 merged cleanly
-> without admin.
+> deterministic lint byte-identical (rubric is LLM-auditor scoring). Then **`D54-F08`
+> DEFERRED** (build-on-demand, D-0058): the `--skeleton` template emit is a speculative DX
+> convenience with real hazards (anti-aligned with the guidance-dense design; comment-fidelity
+> loss on a YAML strip; normative underscore keys `_authored_form`/`_required_when_subtype`
+> can't be naively stripped; no demand signal) — deferred with rationale, not built (founder
+> chose defer). **✅ FRAMEWORK-CORE BACKLOG CLEARED** — every P2/P3 item is shipped or
+> deferred-with-rationale; nothing genuinely-open remains.
+> **Note:** IPLAN-LANG-001 (#255) + D54-F13/COV03 (#257) + D54-F04 (#261) all merged
+> (founder-ratified). **CI FIX:** the v1.5.1 `aidoc-flow-ci` bump (#254) FIXED the
+> composition-check-on-PR-head gap (`AIDOC-CI-COMPOSITION-CHECK-PRHEAD`) — plan/docs PRs now
+> merge via the **normal green path** (no `--admin` needed); #258/#260 merged cleanly without
+> admin. **KNOWN CI FALSE-POSITIVE:** the v1.5.1 `ai-review` is diff-scoped — it flags a plan
+> cross-reference as a "broken xref" on every impl PR that cites its separately-merged plan
+> (e.g. #261). Verify the file is on `main` and `--admin` past it; the real fix is upstream in
+> `aidoc-flow-ci` (resolve referenced paths against the repo, not just the PR diff).
 >
 > ---
 >


### PR DESCRIPTION
Reconciles `D54-F08` to **DEFERRED (build-on-demand)** with a documented rationale. **Docs-only** — no `framework/` change, no version bump, auto-mergeable. Founder-directed (chose defer over building).

## Why deferred (not built)

Grounding found `D54-F08` (a `--skeleton` emit stripping a template's authoring keys) to be a speculative DX convenience with real hazards — per the minimal-and-realistic / no-speculative-features convention, it is not built now:

1. **Anti-aligned with the framework's design** — templates are deliberately `_guidance`-dense (127 `_guidance` blocks in BRD alone) because the framework bets guidance-dense templates author *better*; the `doc-*` skills inject the **full** template. A stripped skeleton authors worse.
2. **Comment-fidelity hazard** — a YAML `safe_load`→`safe_dump` strip destroys inline `#` enum hints + reformats; faithful output needs a `ruamel.yaml` round-trip (new dependency).
3. **Divergence risk** — not all underscore keys are strippable: `_authored_form` (the BRD FR-coverage contract COV01 depends on), `_required_when_subtype` (IPLAN sub-typing), and `_required` (section-required marker) are **normative** and must be preserved; a naive strip misleads authors.
4. **No demand signal** — no consumer requests it.

**Revive criterion** (documented in D-0058 + the TODO): build only if a consumer asks — then a `tools/` script with a curated strip denylist that preserves the normative keys + a test, ideally `ruamel.yaml` for comment fidelity.

## Result

**The framework-core backlog is cleared** — every P2/P3 item is now shipped or deferred-with-rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)