### PR TITLE
docs(governance): Wave 1a adoption of PLAN-003 governance-file canon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,37 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed — Wave 1 adoption of aidoc-flow-ci PLAN-003 governance-file canon (2026-07-08)
+
+Framework adopts the PLAN-003 flexible-canonical (Option B) project-governance
+file canon shipped by `aidoc-flow-ci@ci/v1.6.0` (see PR-V1/V2/V3/V4 —
+`aidoc-flow-ci#73`, `#74`, `aidoc-flow-operations#217`, `aidoc-flow-ci#75`
+— design at `aidoc-flow-ci/plans/PLAN-003_project-governance-canon.md`).
+Governance drift check (`bash ../aidoc-flow-ci/install/apply-standards.sh
+--check`) now reports `CLAUDE.md#per-repo-governance: OK`.
+
+- **`CLAUDE.md`** — `## Per-repo governance` table updated:
+  - Fixed `Plans` row: cell was `plans/<NAME>-PLAN.md` (a naming pattern
+    that doesn't resolve on disk) → `plans/` (the actual directory).
+  - Added required `Roadmap | ROADMAP.md` row (was absent per PLAN-003
+    §4.5 required-row check).
+  - Added 3 repo-specific additional rows below the required 6 per
+    §4.2: `Spec governance decisions | framework/governance/DECISIONS.md`
+    (second DECISIONS surface — spec-governance — distinct from
+    `plans/DECISIONS.md` which tracks migration decisions),
+    `Hermes per-package changelog | platforms/hermes/CHANGELOG.md`, and
+    `Plugin per-package changelog | platforms/claude-code-plugin/CHANGELOG.md`.
+
+**3 surfaces** (CLAUDE.md + FRAMEWORK-TODO.md tracking entry + this
+CHANGELOG entry) — at the OPS-0061 Rule 1 ≤3 boundary. Retrofit of the
+workspace-standards blocks (per
+PLAN-003 §5.4c framework row link-summary-format retrofit) DEFERRED to
+follow-up PR — tracked in `plans/FRAMEWORK-TODO.md` § Open under
+`[docs] PLAN-003 §5.4c framework link-summary retrofit`. Orthogonal to
+the `--check` governance-drift gate this PR closes.
+
+Multi-agent self-review per OPS-0065 (code-reviewer + documentation-specialist parallel dispatch): approved after 1 fold cycle addressing 2 HIGH (CHANGELOG TBD placeholder → filled; PR reference undercount PR-V1/V2 → PR-V1/V2/V3/V4 with per-PR #s) + 2 MEDIUM (deferred retrofit had no forward pointer → tracked in FRAMEWORK-TODO.md per feedback_framework_todo_list rule; scope-imprecision on plans/DECISIONS.md label wording → clarified as "migration decisions") + 5 LOW (dual-DECISIONS phrasing; italic separator note; explanatory prose deferred; PLAN-003 path cited inline; jargon reduced)
+
 ### Added — governance-doc addition triggers framework spec 0.35.0 → 0.35.1 patch bump (2026-07-08)
 
 - **`framework/VERSION`** — patch bump `0.35.0 → 0.35.1`. Prior Wave 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,8 +222,13 @@ surfaces for **this** repo:
 | Live HANDOFF | `plans/HANDOFF.md` |
 | TODO / backlog | `plans/FRAMEWORK-TODO.md` |
 | Decisions log | `plans/DECISIONS.md` |
-| Plans | `plans/<NAME>-PLAN.md` |
+| Plans | `plans/` (per-initiative `PLAN-NNN-<slug>.md` files) |
 | Changelog | `CHANGELOG.md` |
+| Roadmap | `ROADMAP.md` |
+| *(repo-specific rows below — same table, optional)* | |
+| Spec governance decisions | `framework/governance/DECISIONS.md` |
+| Hermes per-package changelog | `platforms/hermes/CHANGELOG.md` |
+| Plugin per-package changelog | `platforms/claude-code-plugin/CHANGELOG.md` |
 
 **Never put any of these in `tmp/`** — `tmp/` is for transient working
 files; nothing in it survives a context-clear or new session.

--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -24,6 +24,20 @@
 
 ## Open
 
+**[docs] PLAN-003 §5.4c framework link-summary retrofit — deferred from Wave 1a**
+
+- Context: Wave 1 PR (2026-07-08) closed the parser-gate `--check-governance`
+  drift in `CLAUDE.md ## Per-repo governance` (added missing Roadmap required
+  row + 3 additional rows + fixed Plans path). PLAN-003 §5.4c framework row
+  also mandates the "path-with-summary" retrofit of the workspace-standards
+  blocks (`## Governance PR discipline` / `## AI agent auto-merge default`
+  / `## Multi-agent automated review`) per §4.2 H5 mechanism — replacing the
+  ~150 lines of duplicated OPS-NNNN body content with concise pointer format.
+- Fix shape: rewrite framework's 3 workspace-standards sections to match the
+  path-with-summary format shown in `aidoc-flow-ci/CLAUDE.md` line 76-105
+  (one-sentence summary + `→ ../operations/CLAUDE.md — search "OPS-NNNN"`).
+  Follow-up PR; kept separate from Wave 1a to preserve Rule 1 ≤3 surfaces.
+
 > **CONSUMER-FEEDBACK-001 progress (2026-06-27):** 3 consumer logs triaged → 22
 > items (the 3 dated banners below), orchestrated by
 > `plans/CONSUMER-FEEDBACK-001-PLAN.md`. **Closed:** `BL-TAG-CHAIN-GATE-SYNC`


### PR DESCRIPTION
## Summary

Framework Wave 1a rollout of the PLAN-003 project-governance file canon (design merged as `aidoc-flow-ci#72`; canon shipped as PR-V1/V2/V3/V4 = `aidoc-flow-ci#73`, `#74`, `aidoc-flow-operations#217`, `aidoc-flow-ci#75` on 2026-07-08). Per PLAN-003 §5.5 / operations `docs/CROSS_REPO_PLAYBOOKS.md` §T-D: Wave 1 = framework + iplan-standard; this is Wave 1a (framework); iplan-standard is Wave 1b.

Closes governance drift on `CLAUDE.md#per-repo-governance` — `bash ../aidoc-flow-ci/install/apply-standards.sh --check` now reports **OK** on this surface.

## Changes (3 surfaces)

- **`CLAUDE.md`** — `## Per-repo governance` table:
  - Fixed `Plans` row: cell was `plans/<NAME>-PLAN.md` (naming pattern that doesn't resolve on disk) → `plans/` (directory).
  - Added required `Roadmap | ROADMAP.md` row (was absent).
  - Added 3 additional rows below required 6 per §4.2: `framework/governance/DECISIONS.md` (spec-governance surface distinct from `plans/DECISIONS.md` migration-decisions surface), `platforms/hermes/CHANGELOG.md`, `platforms/claude-code-plugin/CHANGELOG.md`.
- **`plans/FRAMEWORK-TODO.md`** — new `[docs]` tracking entry for deferred PLAN-003 §5.4c workspace-standards link-summary retrofit (per `feedback_framework_todo_list` rule).
- **`CHANGELOG.md`** — `[Unreleased]` entry.

**3 surfaces at OPS-0061 Rule 1 ≤3 boundary.** Retrofit of workspace-standards blocks (per §5.4c framework row) deferred to follow-up PR — kept separate to preserve Rule 1; tracked in FRAMEWORK-TODO.md.

## Review

Multi-agent self-review per OPS-0065 (code-reviewer + documentation-specialist parallel dispatch): approved after 1 fold cycle addressing:
- **2 HIGH** — CHANGELOG "TBD" placeholder → filled; PR reference undercount PR-V1/V2 → full PR-V1/V2/V3/V4 with per-repo PR #s.
- **2 MEDIUM** — deferred-retrofit had no forward pointer → tracked in FRAMEWORK-TODO.md; `plans/DECISIONS.md` scope wording clarified as "migration decisions" per file's own preface.
- **5 LOW** — dual-DECISIONS phrasing; italic separator note (parser-tolerated); explanatory-prose deferred; PLAN-003 path cited inline; jargon reduced.

## Test plan

- [x] `bash ../aidoc-flow-ci/install/apply-standards.sh --check` → `CLAUDE.md#per-repo-governance: OK`
- [x] All 5 new/edited path cells verified on disk: `plans/`, `ROADMAP.md`, `CHANGELOG.md`, `framework/governance/DECISIONS.md`, `platforms/hermes/CHANGELOG.md`, `platforms/claude-code-plugin/CHANGELOG.md`
- [x] 3 pre-existing unchanged rows (`plans/HANDOFF.md`, `plans/FRAMEWORK-TODO.md`, `plans/DECISIONS.md`) still resolve
- [x] Rule 1 compliance verified (3 surfaces)

## Rollout gate

Wave 1a complete when this merges. Wave 1b = iplan-standard (biggest scope, all 4 governance files NEW; likely needs founder OK for surface count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)