### PR TITLE
feat(ci): add auto-merge-ai-prs.yml caller (workspace canon §17)

### DIFF
--- a/.github/workflows/auto-merge-ai-prs.yml
+++ b/.github/workflows/auto-merge-ai-prs.yml
@@ -1,0 +1,62 @@
+# Caller for vladm3105/aidoc-flow-ci/.github/workflows/auto-merge-ai-prs.yml.
+# PUBLIC consumer variant — uses ubuntu-latest runners.
+# Pinned at @ci/v1.5.1 per IPLAN-0030 P3 rollout.
+#
+# The reusable is the server-side enforcer for AI-opened PRs
+# (OPS-0062 deferred companion). It detects stuck-green PRs
+# (label=ai:review-passed + mergeStateStatus=CLEAN + autoMergeRequest
+# is null + updatedAt > 2 min) + re-arms `gh pr merge --auto --merge`
+# under the reviewer App's token. Narrow scope cases 1+2 per plan §1.
+#
+# Trigger architecture per IPLAN-0030 §2.2 + Pass-2 C1 finding:
+#   - workflow_run on ai-review + composition completion — chains off
+#     the workflows that produce/update the ai:review-passed label +
+#     CLEAN state. NOT check_suite (GHA anti-recursion blocks that
+#     trigger for GHA-created check suites; verified empirically
+#     pre-IPLAN-0030).
+#   - workflow_dispatch for operator manual recovery on stuck-green PRs.
+#
+# App-token requirements:
+#   APP_REVIEWER_1_ID + APP_REVIEWER_1_KEY  (reviewer App credentials —
+#     same secrets as ai-review.yml). If the App isn't installed on
+#     this repo yet, the reusable falls back to GITHUB_TOKEN with a
+#     downgrade warning (workflow_run triggers won't fire from the
+#     merge commit — per GHA anti-recursion — but merges still succeed).
+name: auto-merge-ai-prs
+
+on:
+  workflow_run:
+    workflows: ["ai-review", "composition"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to attempt re-arm on (positive integer required)"
+        type: string
+        required: true
+
+# Caller-level permissions constrain what the reusable can do. The reusable
+# needs contents:write + pull-requests:write + issues:write for `gh pr
+# merge`, label read, and label-set-on-failure respectively.
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  call:
+    # Skip non-success workflow_run fires — the reusable's state-filter
+    # step 3 would exit clean anyway (mergeStateStatus != CLEAN on a
+    # failed ai-review or composition), but this saves the runner slot
+    # entirely (per OPS-0065 security-auditor recommendation).
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/auto-merge-ai-prs.yml@ci/v1.5.1
+    with:
+      # `||` fallback per Workflow-tool expression semantics: returns
+      # the first truthy operand. workflow_run path resolves the LHS;
+      # dispatch path resolves the middle. Fork PRs on workflow_run
+      # have empty `pull_requests[]` so LHS is empty and the reusable's
+      # step 1 exits clean (per the reusable's fork-PR handling).
+      pr_number: ${{ github.event.workflow_run.pull_requests[0].number || inputs.pr_number || '' }}
+      runner_labels: '["ubuntu-latest"]'
+    secrets: inherit  # pragma: allowlist secret

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,25 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added — auto-merge-ai-prs.yml caller (server-side auto-merge for AI-opened PRs) (2026-07-08)
+
+Adopts the canonical `auto-merge-ai-prs.yml` caller from
+`aidoc-flow-ci/install/templates/workflows/auto-merge-ai-prs-public.yml`
+per REPO_STANDARDS §17 workspace canon. Complements OPS-0062 (AI
+agent auto-merge default — in-session `--auto`) with server-side
+recovery for stuck-green PRs.
+
+- **`.github/workflows/auto-merge-ai-prs.yml`** (NEW) — thin caller
+  pinning `aidoc-flow-ci@ci/v1.5.1`. ubuntu-latest runner labels.
+
+Rollout aligned with 5 workspace-canon consumers (operations, business,
+iplanic, iplan-runner, engramory) from prior IPLAN-0030 Phase B.
+Requires reviewer App install + `auto_merge.repos` allowlist entry to
+fully activate; falls back to GITHUB_TOKEN with downgrade warning
+pre-install.
+
+Self-review skipped per founder OK — mechanical template-clone workflow addition; ci/v1.5.1 pin matches sibling consumers
+
 ### Changed — Wave 1 adoption of aidoc-flow-ci PLAN-003 governance-file canon (2026-07-08)
 
 Framework adopts the PLAN-003 flexible-canonical (Option B) project-governance


### PR DESCRIPTION
## Summary

Per REPO_STANDARDS §17 (aidoc-flow-ci) workspace canon: adds canonical `auto-merge-ai-prs.yml` caller for server-side auto-merge recovery on AI-opened PRs. Copied verbatim from the aidoc-flow-ci canonical `-public.yml` template.

Complements OPS-0062 in-session `--auto` default.

## Changes (2 surfaces)

- **`.github/workflows/auto-merge-ai-prs.yml`** (NEW) — thin caller pinning `aidoc-flow-ci@ci/v1.5.1`.
- **`CHANGELOG.md`** — `[Unreleased]` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)