### PR TITLE
docs: FRWK-REVIEW-002 PR-F — docs-of-record currency + sync hazard fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Together they handle: mechanical sync is invisible (just commit; the right files
 
 | Change category | Mandatory updates (same PR) | Mechanical (auto-synced) | Semantic (you author) |
 |---|---|---|---|
-| **Framework spec** (`framework/**`) | `framework/VERSION` bump if structural; `framework/governance/DECISIONS.md` if a decision is recorded; repo-root `CHANGELOG.md` `[Unreleased]`; `ROADMAP.md` "Post-v1.0 — Shipped" if user-visible | CLAUDE.md current-state line; README.md Status block; docs/PARITY.md row | DECISIONS entry; CHANGELOG entry; ROADMAP bullet |
+| **Framework spec** (`framework/**`) | `framework/VERSION` bump if structural; `framework/governance/DECISIONS.md` if a decision is recorded; repo-root `CHANGELOG.md` `[Unreleased]`; `ROADMAP.md` "Recently shipped" if user-visible | CLAUDE.md current-state line; README.md Status block; docs/PARITY.md row | DECISIONS entry; CHANGELOG entry; ROADMAP bullet |
 | **Platform change** (`platforms/<name>/**`) | `platforms/<name>/CHANGELOG.md` `[Unreleased]`; `platforms/<name>/VERSION` if bumping; `docs/PARITY.md` (release only); `docs/TAGGING.md` (release only) | plugin.json; marketplace.json; 52 × SKILL.md frontmatter; READMEs; PARITY current-state | CHANGELOG entry; new TAGGING row (on release) |
 | **User-visible policy/rule** | `CLAUDE.md` §"Durable conventions"; auto-memory entry; `README.md` if status-line affected | — | rule prose; memory note |
 | **Hermes follow-on created** | `plans/HERMES-BACKLOG.md` new `H-N` entry in the same PR | — | backlog entry (Source / Plugin status / Substantive work / Dependency) |

--- a/DESC.md
+++ b/DESC.md
@@ -287,10 +287,10 @@ and keep a system alive — with its responsibilities drawn honestly.*
 The framework spec is engine-agnostic; two independent platforms implement it, each
 versioned independently. Both pass the same shared conformance suite.
 
-| Platform | Engine | Release |
+| Platform | Engine | Version |
 |----------|--------|---------|
-| **Hermes AI** | MCP server | `hermes/v0.3.0` (`platforms/hermes/`) |
-| **Claude Code plugin** | Native Claude Code (skills / agents / commands) | `claude-code-plugin/v0.17.1` (`platforms/claude-code-plugin/`) |
+| **Hermes AI** | MCP server | `0.7.3` (`platforms/hermes/`) |
+| **Claude Code plugin** | Native Claude Code (skills / agents / commands) | `0.23.4` (`platforms/claude-code-plugin/`) |
 
 See [`docs/PARITY.md`](docs/PARITY.md) for the capability comparison and a
 "which platform should I use?" guide.
@@ -309,9 +309,13 @@ From Claude Code:
 
 The migration is complete (cutover shipped as `v1.0.0`); the project is now in
 **post-cutover development** (latest project release `v1.1.0`), tracking
-framework spec `0.20.1`. The Claude Code plugin is a **pre-1.0 preview** — APIs
-and surfaces may change before 1.0. Platform release versions are in the
+framework spec `0.35.1`. The Claude Code plugin is a **pre-1.0 preview** — APIs
+and surfaces may change before 1.0. Platform versions are in the
 [Platforms](#platforms) table above.
+
+> *This overview is a point-in-time snapshot (as of 2026-07-09); it is not
+> wired into the version-sync hook. For live version state see the per-package
+> `VERSION` files and [`docs/PARITY.md`](docs/PARITY.md).*
 
 Post-v1.0 development — delivered and planned — is tracked in
 [`ROADMAP.md`](ROADMAP.md); per-release detail is in

--- a/README.md
+++ b/README.md
@@ -287,10 +287,13 @@ and keep a system alive — with its responsibilities drawn honestly.*
 The framework spec is engine-agnostic; two independent platforms implement it, each
 versioned independently. Both pass the same shared conformance suite.
 
-| Platform | Engine | Release |
+| Platform | Engine | Version |
 |----------|--------|---------|
 | **Hermes AI** | MCP server | `hermes/v0.7.3` (`platforms/hermes/`) |
 | **Claude Code plugin** | Native Claude Code (skills / agents / commands) | `claude-code-plugin/v0.23.4` (`platforms/claude-code-plugin/`) |
+
+*Versions are the per-package `VERSION`-file values (namespaced as they would be
+tagged); the git tag itself may not be cut yet — see `docs/TAGGING.md`.*
 
 See [`docs/PARITY.md`](docs/PARITY.md) for the capability comparison and a
 "which platform should I use?" guide.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,17 +31,17 @@ permanent asymmetry.
 Near-term, in-flight work.
 
 - **Hermes parity catch-up** — bring Hermes up to the plugin's current spec surface
-  (framework `0.35.0`). Hermes already has team-mode + 8-layer playbook injection +
+  (framework `0.35.1`). Hermes already has team-mode + 8-layer playbook injection +
   saga conformance (D-0045…D-0053; the whole 0.32.x arc is auto-satisfied via its
   vendored `sdd_doc_lint` + shared templates). The residual items are small doc/skill
   deltas — **H-11c** (SHA-256 residue, now unblocked by PROVISIONAL-IDS-002) + the
   cosmetic H-11a sweep — and the architecturally-deferred saga gate (H-1). Tracked in
   [`plans/HERMES-BACKLOG.md`](plans/HERMES-BACKLOG.md).
 
-- **PROVISIONAL-IDS-002 Phase 1 (2026-07-08, framework `0.34.2 → 0.35.0`):** the Model-2
-  element-ID drift verifier — formalized hash-input contract + opt-in `rehash --check`
-  (`IDDRIFT01`). Phase 2+ (`rehash --fix`, all-layer extraction, corpus reconciliation)
-  is founder-decided. See [`plans/PROVISIONAL-IDS-002-PLAN.md`](plans/PROVISIONAL-IDS-002-PLAN.md).
+- **FRWK-REVIEW-002 (in flight, 2026-07-09):** fixing 46 findings from the 2026-07-09
+  plugin + core-docs review across 7 tier-scoped PRs. Plugin PRs (A/B) + docs-of-record
+  (F) landed; spec-tier (C/D), engine-agnosticism (E), and CLAUDE.md (G) held for the
+  founder. See [`plans/FRWK-REVIEW-002-PLAN.md`](plans/FRWK-REVIEW-002-PLAN.md).
 
 ---
 
@@ -96,6 +96,30 @@ Strategic direction.
 
 Headline capabilities now in the framework (full detail in
 [`CHANGELOG.md`](CHANGELOG.md)):
+
+- **PROVISIONAL-IDS-002 Phase 1 (2026-07-08, framework `0.34.2 → 0.35.0`).** The
+  Model-2 element-ID drift verifier — formalized hash-input contract + opt-in
+  `rehash --check` (`IDDRIFT01`, advisory, not in the default lint). Phase 2+
+  (`rehash --fix`, all-layer extraction, corpus reconciliation) is
+  founder-decided. See
+  [`plans/PROVISIONAL-IDS-002-PLAN.md`](plans/PROVISIONAL-IDS-002-PLAN.md).
+- **Governance-decision ratifications (framework `0.34.2`).** GD-02…GD-05 spec
+  governance decisions ratified.
+- **COV03 phase-leak advisory (framework `0.34.0`).** The inverse of COV01's
+  escape — flags a `Future`-banded element that a downstream layer already
+  realizes.
+- **GD-05 author self-claim strip (framework `0.33.0`).** The review lens
+  disregards any author-supplied readiness score before scoring.
+- **Provisional IDs + first-class reuse (D-0040 / D-0041).** Manual-mode
+  provisional IDs (`id_state`/`PROV01`) with the normative SHA-256 algorithm,
+  and satisfied-by-reference reuse (`reuse:` frontmatter, `REUSE01`/`REUSE02`).
+- **YAML-BDD arc (framework `0.28`–`0.29`).** BDD authored as structured
+  `scenarios:` YAML (not Gherkin-in-markdown); `doc-bdd*` skills, template, and
+  layer README moved to the YAML carrier.
+- **Element-level coverage engine (framework `0.24`–`0.27`).** COV01/COV02
+  element-level forward/backward coverage over the `REALIZING_LAYERS` map
+  (D-0039) — catches orphaned requirement/scenario elements a doc-level check
+  misses.
 
 - **Acceptance-fixtures drift fix (ACCEPTANCE-FIXTURES-DRIFT, no
   VERSION change).** Closes 12 long-standing failures in

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ plus two platforms). Security fixes are applied to the latest release line.
 | Component | Supported |
 |-----------|-----------|
 | Latest project release (`v1.x`) | ✅ |
-| `framework/` spec — latest (`0.11.x`) | ✅ |
+| `framework/` spec — latest (`0.35.x`) | ✅ |
 | Platforms — latest tagged release | ✅ |
 | Older / pre-cutover (`< v1.0`, archive branch) | ❌ |
 

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -23,7 +23,7 @@ create→review→revise loop, while keeping their own runtime mechanisms
 (Hermes: Python saga runtime; plugin: SKILL prompts + JSON journal + Bash
 subprocesses). The contract lives in
 [`../framework/governance/REVIEW_SAGA.md`](../framework/governance/REVIEW_SAGA.md)
-(arriving with framework spec `0.23.0` via SAGA-PARITY-001, D-0031, which
+(arriving in the `0.13.0` spec cycle via SAGA-PARITY-001, D-0031, which
 extends D-0005's blackboard contract with an outer-loop journal).
 
 Earlier states of this document described **output-shape parity** —
@@ -204,7 +204,7 @@ deterministic gate, and reduced findings).
 | Blackboard | git-ignored `.aidoc/review/<artifact-id>/<persona>.json` slots | saga journal + branch summaries |
 | Persona names | framework names natively (`chaos_engineer`, `security_engineer`, `synthesizer`, …) | framework names natively (`chaos_engineer`, `security_engineer`, …); single remaining alias `chairperson` → `synthesizer` |
 | Reduce / score | `synthesizer` subagent (rule-driven) | `saga_reducer` + `review_scoring.py` (code) |
-| Saga lifecycle (D-0031 / framework spec `0.23.0`) | `saga.json` written at `.aidoc/review/<NN>_<LAYER>/<id>/saga.json`; same state machine + journal schema as Hermes. **All 8 layers (plugin v0.21.0+)**: preemptive enforcement via `tools/saga_driver.py` invoked by every `doc-<layer>-autopilot` (SAGA-PARITY-001 Phase 4). Outer wall-clock-bounded, multi-iteration loop. | Python saga runtime (`saga_orchestrator.py`, `saga_models.py`, `saga_journal.py`); preemptive enforcement, single-pass in-process |
+| Saga lifecycle (D-0031 / `0.13.0` spec cycle) | `saga.json` written at `.aidoc/review/<NN>_<LAYER>/<id>/saga.json`; same state machine + journal schema as Hermes. **All 8 layers (plugin v0.21.0+)**: preemptive enforcement via `tools/saga_driver.py` invoked by every `doc-<layer>-autopilot` (SAGA-PARITY-001 Phase 4). Outer wall-clock-bounded, multi-iteration loop. | Python saga runtime (`saga_orchestrator.py`, `saga_models.py`, `saga_journal.py`); preemptive enforcement, single-pass in-process |
 | Resilience — partial crew | blackboard slots + coverage/quorum (D-0005 blackboard, authoritative for crew state) + saga.json journal for outer-loop phase state (D-0031) | saga retries/compensation; degrade above quorum, escalate below |
 | Resilience — partial outer loop | `saga.json` PARTIAL_TIMEOUT state via break-circuit; next invocation resumes from checkpoint | saga state machine **accepts** `PARTIAL_TIMEOUT` (spec-conformant table, HERMES-PARITY Phase 1); the orchestrator does not yet *write* it — the break-circuit + resume path is Phase 1b |
 | Report | unified report (`UCR_OUTPUT_UNIFIED` / audit report) | `PERSONA_REVIEW_REPORT` / saga summary |

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -28,7 +28,7 @@ aidoc-flow-framework/
 ├── .pre-commit-config.yaml         Pre-commit hooks (lint / format / security)
 ├── ruff.toml · .markdownlint.json · .markdownlintignore · .yamllint · .secrets.baseline
 ├── .github/
-│   ├── workflows/                  CI: conformance, hermes, plugin, pre-commit, codeql, chg-gate, labeler
+│   ├── workflows/                  CI: ai-review, audit-trail, auto-merge-ai-prs, chg-gate, codeql, composition, conformance, doc-review, hermes, labeler, plugin, pre-commit, standards-drift
 │   ├── CODEOWNERS · dependabot.yml · labeler.yml
 │   └── ISSUE_TEMPLATE/ · PULL_REQUEST_TEMPLATE.md
 ├── docs/
@@ -36,6 +36,7 @@ aidoc-flow-framework/
 │   ├── PROJECT.md                   Versioning, branches, milestones, change management
 │   ├── PARITY.md                    Hermes ↔ plugin capability comparison
 │   ├── TAGGING.md                   Git-tag policy
+│   ├── SUPPORT.md                   Support channels + how to get help
 │   └── STARTUP_HANDOFF.md
 │
 ├── framework/                       SHARED engine-agnostic specification (the contract)

--- a/docs/TAGGING.md
+++ b/docs/TAGGING.md
@@ -90,15 +90,25 @@ git log --oneline v0.1.0..v0.2.0   # commits between two tags
 Slash-namespaced refs (`framework/v0.1.0`, `mark/<slug>`) are valid git tag
 names and make `git tag -l '<prefix>/*'` an effective per-stream filter.
 
-## Current tags
+## Release inventory
 
-| Tag | Commit | Marks |
+> **This is the release/version record, not a list of git tags that all exist.**
+> Each row is a version assigned to a shipped change. A git **tag** is cut
+> separately, and the tag-cut has lagged the version stream (a known backlog —
+> see the HANDOFF). To see which tags are *actually* cut, run `git tag -l` /
+> `git ls-remote --tags origin`; as of 2026-07-09 the cut high-water marks are
+> `v1.1.0` (project), `framework/v0.21.0`, `claude-code-plugin/v0.20.1`, and
+> `hermes/v0.1.1`. Rows above those points are version assignments whose tag has
+> not yet been cut. Do not assume a row here means the tag exists.
+
+| Version / tag | Commit | Marks |
 |-----|--------|-------|
 | `v0.1.0` | Phase 0 baseline | Planning & scaffolding milestone |
 | `v0.2.0` | Phase 1 close | Framework Spec Extraction milestone |
 | `framework/v0.1.0` | Phase 1 close | Framework spec — first independent release |
 | `v0.3.0` | Phase 2 close | Platform A: Hermes Re-homing milestone |
 | `hermes/v0.1.0` | Phase 2 close | Hermes platform — first independent release |
+| `hermes/v0.1.1` | Hermes patch | Hermes platform — patch release (cut tag) |
 | `v0.4.0` | Phase 3 close | Platform B: Claude Code plugin milestone |
 | `claude-code-plugin/v0.1.0` | Phase 3 close | Claude Code plugin — first independent release |
 | `v0.5.0` | Phase 4 close | Conformance & Independence milestone |
@@ -161,21 +171,12 @@ names and make `git tag -l '<prefix>/*'` an effective per-stream filter.
 | `framework/v0.3.1` | CHG-D2 (`3753de2`) | Framework spec — governance decision register, GD-01 |
 | `v1.1.0` | PR #2 merge (`3974daa`) | Post-cutover feature release — skill-set revision + adaptation overlay + CHG GATE-SPEC |
 
-> Phase 1 tags (`v0.1.0`, `v0.2.0`, `framework/v0.1.0`) are published
-> on the remote. Phase 2 tags (`v0.3.0`, `hermes/v0.1.0`), Phase 3
-> tags (`v0.4.0`, `claude-code-plugin/v0.1.0`), and Phase 4 tag
-> (`v0.5.0`) are created locally on the in-container session at the
-> respective close commits and need the local-clone workaround
-> established at P1-T8 — the in-container git proxy continues to
-> refuse tag pushes with HTTP 403. See `plans/P2-T6-PLAN.md`
-> §Approach.5, `plans/P3-T5-PLAN.md` §Approach.5, and
-> `plans/P4-T5-PLAN.md` §Approach.6 for the exact local-clone
-> commands. Verify any tag's publication via
-> `git ls-remote --tags origin`.
->
-> The post-cutover tags (`framework/v0.2.0`, `framework/v0.3.0`,
-> `framework/v0.3.1`, and the project milestone `v1.1.0`) are **published** on
-> the remote, created from a local clone at the PR #2 merge.
+> All Phase 0–5 milestone tags (`v0.1.0`–`v0.5.0`, `v1.0.0`, `v1.1.0`,
+> `framework/v0.1.0`–`v0.3.1`, `framework/v0.21.0`, `hermes/v0.1.0`–`v0.1.1`,
+> `claude-code-plugin/v0.1.0`–`v0.20.1`) are **published on the remote**. The
+> per-package version streams have since moved ahead of the cut tags (the
+> tag-cut backlog noted at the top of this section). Verify any tag's
+> publication via `git ls-remote --tags origin`.
 
 ## In-container push restrictions
 

--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -158,6 +158,13 @@
   current-state row only (drop the `/g`, or match the `claude-code-plugin/vX
   (framework spec …)` line specifically) so future bumps stop rewriting
   provenance. Restored the two lines by hand in `a0cb426f`.
+- **RESOLVED (FRWK-REVIEW-002 PR-F, 2026-07-09).** The prior hand-restore in
+  `a0cb426f` restored them to the wrong value (`0.23.0`, not the authored
+  `0.13.0`). PR-F F1 restored both PARITY lines to `0.13.0` and made them
+  sweep-proof by rephrasing to "`0.13.0` spec cycle" (no `framework spec \`X\``
+  literal for the sed to match), and documented the hazard inline in
+  `scripts/sync-version-refs.sh`. The`/g` behavior is left as-is; the
+  convention (historical mentions avoid the literal) is the guard.
 
 ### `[example-corpus]` `CORPUS-REFGRAN-RECASCADE` — 5 SPEC/TDD/IPLAN doc-level `@adr`/`@tdd` tags need element-level re-cascade (REFGRAN01)
 

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -1,7 +1,8 @@
 # Session Handoff
 
 > **▶ IN FLIGHT (2026-07-09) — FRWK-REVIEW-002** (`plans/FRWK-REVIEW-002-PLAN.md`,
-> plan PR #275 merged). Fixes 46 findings from the 2026-07-09 plugin + core-docs
+> plan PR #275 merged). **Current versions:** framework spec `0.35.1` · plugin
+> `0.23.4` · hermes `0.7.3`. Fixes 46 findings from the 2026-07-09 plugin + core-docs
 > review across 7 tier-scoped PRs. **PR-A shipped** (plugin `0.23.3`): skill-content
 > drift — audit-report path unified across 68 sites, iteration-cap citation
 > corrected + backported, `review_mode` consistency, phantom emitter removed, verdict

--- a/plans/HERMES-BACKLOG.md
+++ b/plans/HERMES-BACKLOG.md
@@ -4,7 +4,7 @@
 |-------|-------|
 | Status     | **ARC UNDERWAY** — Phase 1 shipped (saga conformance); playbook injection is the load-bearing next gap |
 | Owner      | vladm3105 |
-| Last update | 2026-07-02 |
+| Last update | 2026-07-09 |
 | Policy     | **Plugin-first development.** Hermes work is deferred until the corresponding plugin functionality is complete and verified end-to-end. This is the single source of truth for "what Hermes still needs to catch up on." |
 
 > **⚠️ CORRECTED ASSESSMENT (2026-07-02, D-0045) — read before implementing any

--- a/scripts/check-docs-updated.sh
+++ b/scripts/check-docs-updated.sh
@@ -14,7 +14,7 @@
 #
 #   - root CHANGELOG.md entry under [Unreleased] (project-level)
 #   - plugin CHANGELOG entry under [Unreleased]
-#   - ROADMAP.md "Post-v1.0 — Shipped" bullet
+#   - ROADMAP.md "Recently shipped" bullet
 #   - plans/HANDOFF.md current-state header refresh
 #   - plans/HERMES-BACKLOG.md new H-N entry (when the change creates Hermes
 #     follow-on work)
@@ -90,7 +90,7 @@ if (( substantive > 0 && has_doc_change == 0 )); then
 
                        Project-level:
                          - CHANGELOG.md          (entry under [Unreleased])
-                         - ROADMAP.md            ("Post-v1.0 — Shipped" bullet)
+                         - ROADMAP.md            ("Recently shipped" bullet)
                          - README.md             (Status block, if user-visible)
                          - CLAUDE.md             ("Current state" line)
                          - plans/HANDOFF.md      (current-state header)

--- a/scripts/sync-version-refs.sh
+++ b/scripts/sync-version-refs.sh
@@ -177,6 +177,14 @@ fi
 fw_ver="$(read_version framework/VERSION)"
 log "framework VERSION: ${fw_ver:-(missing)}"
 
+# HAZARD (FRWK-REVIEW-002 F1): the replace_in_file calls below do a GLOBAL
+# substitution of the literal "framework spec `<prev>`" — they cannot tell a
+# current-state row from a historical/provenance mention. Any doc line that
+# quotes an OLD spec version in that exact literal form will be swept to the new
+# version on the next bump (this once corrupted the D-0031 provenance lines in
+# docs/PARITY.md, 0.13.0 -> 0.23.0). Rule: historical/provenance version
+# mentions MUST avoid the "framework spec `X.Y.Z`" literal — write them as
+# "`0.13.0` spec cycle" (or similar) so the sed can't match them.
 if [[ -n "$fw_ver" ]]; then
   fw_prev="$(detect_version_in CLAUDE.md \
     'framework spec `[0-9]+\.[0-9]+\.[0-9]+`')"

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -9,8 +9,12 @@ The suite has two halves:
    `framework/` spec is internally coherent: the registry agrees with itself
    and with the files on disk, layer templates match the registry, governance
    files are present, and no engine-specific tokens have leaked in.
-2. **Platform conformance** (Phase 4) — checks that a *platform* implementation
-   honours the spec. Not implemented yet; the contract is documented below.
+2. **Platform conformance** (`tests/conformance/platforms/`) — checks that a
+   *platform* implementation honours the spec. **Implemented and running**: 16
+   modules covering the Claude Code plugin (framework-bundle drift guard,
+   `sdd_doc_lint` vendoring identity, version/spec-version declarations, plugin
+   manifest + release metadata + config schema, autopilot saga parity, model
+   precheck, engine isolation, adaptation surface, skill-template alignment).
 
 ## Running it
 
@@ -35,14 +39,14 @@ prefer that runner.
 |--------|--------|
 | `test_registry.py` | registry structure; 8 dense layers; required keys; `error_prefix` == `artifact`; `downstream` chain; cumulative `required_tags`; `can_reference` consistency; `folder`/`template` resolve; `layer_groups` partition; `c4_mapping` artifacts known; `id_patterns` compile |
 | `test_layers.py` | each layer folder has template + README + index template; templates parse; `metadata.layer` matches the registry; `metadata.document_type` present |
-| `test_governance.py` | the 18 governance + CHG files are present (and only those); `CHG-TEMPLATE.yaml` parses |
+| `test_governance.py` | the governance + CHG files listed in `EXPECTED_FILES` are present (and only those — any new `framework/governance/` file must be registered); `CHG-TEMPLATE.yaml` parses |
 | `test_version.py` | `framework/VERSION` is present and a bare `X.Y.Z` SemVer string |
 | `test_spec_hygiene.py` | no engine tokens (`hermes`, `ucx_`, `.claude/`, `mcp`, `mermaid-gen`, `charts-flow`, engine SDD verbs) and no stale version strings under `framework/` |
 
 `_spec.py` is the shared helper (locates `framework/`, loads the registry); it
 is not a test module.
 
-## Platform-conformance contract (Phase 4)
+## Platform-conformance contract
 
 A platform (Hermes, the Claude Code plugin) conforms to the framework when:
 
@@ -53,6 +57,7 @@ A platform (Hermes, the Claude Code plugin) conforms to the framework when:
   `can_reference`, `downstream`);
 - it carries no expectation of the other platform's engine.
 
-Phase 4 adds platform-specific test modules here that exercise this contract
-against each platform's output. They are intentionally absent now — no platform
-exists yet.
+The `tests/conformance/platforms/` modules exercise this contract against the
+Claude Code plugin (see the second suite half above). The plugin ships a
+byte-identical vendored copy of the spec subtrees it consumes (D-0022); a drift
+guard fails CI if the bundle and the canonical spec diverge.


### PR DESCRIPTION
## What

**PR-F of FRWK-REVIEW-002** (plan #275). Docs-of-record currency sweep + the sync-script historical-line corruption fix. No version bump.

| Item | Fix |
|------|-----|
| **F1** | Restore the two corrupted `docs/PARITY.md` D-0031 provenance lines to `0.13.0`, **sweep-proof** ("`0.13.0` spec cycle" — no `framework spec \`X\`` literal the sed matches); document the global-sed hazard inline in `sync-version-refs.sh`; close the `FRAMEWORK-TODO` `SYNC-VERSION-PROVENANCE-OVERBUMP` entry (the prior hand-restore used the wrong value, `0.23.0`). |
| **F2** | `DESC.md` refreshed to current versions + stamped a dated snapshot (not sync-wired). |
| **F3** | `docs/TAGGING.md` "Current tags" → "Release inventory" with an honest tag-vs-version-assignment note listing the actual cut high-water marks; added the missing `hermes/v0.1.1` row; removed the obsolete local-only footnote (all 5 early tags are on the remote — verified). |
| **F4** | README platform-table header `Release` → `Version` + "tag may not be cut yet" footnote (keeps the conformance-required `claude-code-plugin/vX` string). |
| **F5** | ROADMAP: stale `0.35.0` → `0.35.1`; moved PROVISIONAL-IDS-002 Phase 1 to "Recently shipped"; backfilled the coverage-engine / YAML-BDD / provisional-IDs / GD-05 / COV03 / GD-02…05 arcs. |
| **F6** | `SECURITY.md` supported row `0.11.x` → `0.35.x`; HANDOFF top banner states current versions. |
| **F7** | Dead `"Post-v1.0 — Shipped"` → `"Recently shipped"` (CONTRIBUTING matrix + reminder hook). |
| **F8** | `tests/conformance/README.md` refreshed — platform half is implemented (16 modules), not "Phase 4 / not implemented". |
| **F9** | `REPO_STRUCTURE.md` workflows list completed (13); `SUPPORT.md` added to the docs/ tree. |
| **F10** | `HERMES-BACKLOG.md` Last-update date. |

## Verification

- Conformance **188 green** (README/PARITY/TAGGING release-metadata tests still pass — the conformance-required version strings are preserved).
- Stale-string grep sweep clean (`Post-v1.0 — Shipped`, `0.11.x`, `0.20.1`, `v0.17.1` gone; remaining "Post-v1.0 development" is a legitimate phrase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)