### PR TITLE
docs(governance): FRWK-REVIEW-002 PR-G — CLAUDE.md anchor + stale current-state fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ The platforms share the `framework/` spec and nothing else. Both pass the same
 shared conformance suite (`tests/conformance/`). The `framework/` spec defines
 the 8-layer SDD flow (BRD → PRD → EARS → BDD → ADR → SPEC → TDD → IPLAN → Code).
 
-**Current state (as of 2026-07-08):** framework spec `0.36.0`, Claude Code plugin `0.23.2` (pre-1.0 preview, 52 skills = 50 active + 2 deprecated stubs), Hermes `0.7.3`. **YAML-BDD arc complete** (BDD authored as structured `scenarios:` YAML, not Gherkin-in-markdown) and the **CONSUMER-FEEDBACK P1 wave shipped**: element-level COV01/COV02 coverage (D-0039 — `REALIZING_LAYERS` map; catches orphaned requirement elements), manual-mode provisional IDs + normative SHA-256 algorithm (D-0040 — `id_state`/`PROV01`; element IDs are LLM-generated stable strings, NOT verified content-hashes), and first-class reuse / satisfied-by-reference (D-0041 — `reuse:` frontmatter; `REUSE01`/`REUSE02`). **PROVISIONAL-IDS-002 Phase 1 shipped** (D-0061/D-0062, spec `0.35.0`): the element-ID hash-input contract (normalization transform + BRD §7 extraction boundary) is formalized in `ID_NAMING_STANDARDS.md`, and `python -m sdd_doc_lint.rehash --check` verifies a canonical BRD's §7 FR IDs against it on demand (`IDDRIFT01` — advisory, opt-in, NOT in the default lint). Scoped "verifiable on demand," not "verified"; `rehash --fix` + all-layer extraction + corpus reconciliation are founder-decided Phase 2+. Plugin also ships full 8-layer playbook injection + preemptive saga driver across all 8 autopilots (SAGA-PARITY-001) + per-layer model-recommendation precheck (MODEL-PRECHECK-ROLLOUT) + review-quality calibration + necessary-upstream contract (NECESSARY-UPSTREAM-001) + threshold-resolution gate (TH-RES-001) + per-PR doc-of-record discipline (DOC_GOVERNANCE_CORE.md Principle 8). 8-layer development sequence complete. **Next major arc: Hermes parity** (Hermes lags the plugin on the recent spec) — plugin-first sequencing, tracked in [`plans/HERMES-BACKLOG.md`](plans/HERMES-BACKLOG.md). The example corpus is regenerated wholesale after framework changes (so corpus-remediation findings are deferred to that regen). IPLAN ↔ iplanic integration deferred — see `plans/IPLAN-IPLANIC-DEFERRED.md`.
+**Current state (as of 2026-07-09):** framework spec `0.36.0`, Claude Code plugin `0.23.4` (pre-1.0 preview, 52 skills = 50 active + 2 deprecated stubs), Hermes `0.7.3`. **YAML-BDD arc complete** (BDD authored as structured `scenarios:` YAML, not Gherkin-in-markdown) and the **CONSUMER-FEEDBACK P1 wave shipped**: element-level COV01/COV02 coverage (D-0039 — `REALIZING_LAYERS` map; catches orphaned requirement elements), manual-mode provisional IDs + normative SHA-256 algorithm (D-0040 — `id_state`/`PROV01`; element IDs are LLM-generated stable strings, NOT verified content-hashes), and first-class reuse / satisfied-by-reference (D-0041 — `reuse:` frontmatter; `REUSE01`/`REUSE02`). **PROVISIONAL-IDS-002 Phase 1 shipped** (D-0061/D-0062, spec `0.35.0`): the element-ID hash-input contract (normalization transform + BRD §7 extraction boundary) is formalized in `ID_NAMING_STANDARDS.md`, and `python -m sdd_doc_lint.rehash --check` verifies a canonical BRD's §7 FR IDs against it on demand (`IDDRIFT01` — advisory, opt-in, NOT in the default lint). Scoped "verifiable on demand," not "verified"; `rehash --fix` + all-layer extraction + corpus reconciliation are founder-decided Phase 2+. Plugin also ships full 8-layer playbook injection + preemptive saga driver across all 8 autopilots (SAGA-PARITY-001) + per-layer model-recommendation precheck (MODEL-PRECHECK-ROLLOUT) + review-quality calibration + necessary-upstream contract (NECESSARY-UPSTREAM-001) + threshold-resolution gate (TH-RES-001) + per-PR doc-of-record discipline (DOC_GOVERNANCE_CORE.md Principle 8). 8-layer development sequence complete. **Next major arc: Hermes parity** (Hermes lags the plugin on the recent spec) — plugin-first sequencing, tracked in [`plans/HERMES-BACKLOG.md`](plans/HERMES-BACKLOG.md). The example corpus is regenerated wholesale after framework changes (so corpus-remediation findings are deferred to that regen). IPLAN ↔ iplanic integration deferred — see `plans/IPLAN-IPLANIC-DEFERRED.md`.
 
 ## Durable conventions
 
@@ -55,7 +55,7 @@ the 8-layer SDD flow (BRD → PRD → EARS → BDD → ADR → SPEC → TDD → 
   documents-of-record in sync with the change it ships — do not let a
   separate "doc-refresh" PR be the catch-up mechanism. The matrix of
   which docs to touch lives in
-  [`CONTRIBUTING.md`](CONTRIBUTING.md#documentation-discipline-update-docs-of-record-per-pr).
+  [`CONTRIBUTING.md`](CONTRIBUTING.md#documentation-discipline--update-docs-of-record-per-pr).
 
   The discipline is enforced by **two pre-commit hooks** (no manual
   step required; both run automatically on `git commit`):
@@ -222,7 +222,7 @@ surfaces for **this** repo:
 | Live HANDOFF | `plans/HANDOFF.md` |
 | TODO / backlog | `plans/FRAMEWORK-TODO.md` |
 | Decisions log | `plans/DECISIONS.md` |
-| Plans | `plans/` (per-initiative `PLAN-NNN-<slug>.md` files) |
+| Plans | `plans/` (per-initiative `<NAME>-PLAN.md` files) |
 | Changelog | `CHANGELOG.md` |
 | Roadmap | `ROADMAP.md` |
 | *(repo-specific rows below — same table, optional)* | |
@@ -250,13 +250,13 @@ never relocates their state.
 - `platforms/claude-code-plugin/` — Platform B (Claude Code plugin).
 - `tests/conformance/` — the shared conformance suite (framework + platform
   checks).
-- `ROADMAP.md` — phased delivery plan (Phase 0 → cutover `v1.0.0`).
+- `ROADMAP.md` — post-cutover Now/Next/Later roadmap (recently-shipped log + planned work).
 - `CHANGELOG.md` — project-level changelog.
 - `docs/PROJECT.md` — versioning, branching, conformance, change management.
 - `docs/REPO_STRUCTURE.md` — repository layout (as-built).
 - `docs/TAGGING.md` — git-tag policy. `docs/PARITY.md` — platform comparison.
-- `plans/` — the migration record (per-task plans, audits, verify records,
-  `DECISIONS.md`, `HANDOFF.md`, `MIGRATION_TODO.md`).
+- `plans/` — the active planning surface (per-initiative plans, audits, verify
+  records, `DECISIONS.md`, `HANDOFF.md`, `FRAMEWORK-TODO.md`).
 
 ## Pre-migration history
 


### PR DESCRIPTION
## What

**PR-G of FRWK-REVIEW-002** (plan #275). CLAUDE.md corrections only. No version bump.

> ⚠️ **Governance PR (touches CLAUDE.md) — held for founder merge** per the ask-first carve-out. Not auto-merged.

- **G1** — Fix the doc-discipline anchor: the CONTRIBUTING heading has an em-dash, so the GitHub slug is `#documentation-discipline--update-docs-of-record-per-pr` (double hyphen). The single-hyphen link didn't resolve.
- **G2** — Refresh the stale current-state line (date `2026-07-08 → 2026-07-09`; plugin `0.23.2 → 0.23.4`, which the version-sync hook doesn't cover for CLAUDE.md's plugin-version string, so PR-A/B left it stale); reframe the "Where things are" `ROADMAP.md` entry (phased-delivery → post-cutover Now/Next/Later) and `plans/` entry (migration record → active planning surface); fix the Plans-table naming (`PLAN-NNN-<slug>.md` → `<NAME>-PLAN.md`, the convention actually used).

## Verification
- **Governance Rule 2 self-review** (fresh-context reviewer): verified all 4 corrections against the live repo — the anchor slug algorithm, current `VERSION` values, the `<NAME>-PLAN.md` convention, and `FRAMEWORK-TODO.md` existence + ROADMAP's `Now/Next/Later` structure. **Zero findings.**
- Conformance green; markdownlint clean.

## Remaining after this
Only **PR-E0–E4** (engine-agnosticism sweep) remains — blocked on a founder **GD-NN** policy decision (what counts as an engine-specific token in the spec; which flagged references are removed vs accepted as documented exceptions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)