### PR TITLE
docs(plans): track remaining FRWK-REVIEW-002 work in FRAMEWORK-TODO

### DIFF
--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -24,6 +24,51 @@
 
 ## Open
 
+### `[docs]` `FRWK-REVIEW-002-PR-E` — engine-agnosticism sweep (BLOCKED on founder GD-NN)
+
+- Context: FRWK-REVIEW-002 (plan `plans/FRWK-REVIEW-002-PLAN.md`, PRs #276–#281
+  merged). PR-E is the only unshipped piece. The spec carries engine-specific
+  tokens: the playbook `agent:` frontmatter field points into
+  `platforms/claude-code-plugin/` (`REVIEW_TEAM.md:259`); `doc-*`/"SKILL"
+  vocabulary in governance/layer docs; a workspace-CI section pinning
+  `aidoc-flow-ci@ci/vX` in `REVIEW_REMEDIATION_FLOW.md`; repo-root tool refs
+  (`tools/trace_walk.py`, `tools/sdd_coverage.py`) the spec doesn't vendor.
+- Fix shape: **needs a founder decision first (GD-NN in `framework/governance/DECISIONS.md`)** —
+  what counts as an engine-specific token, and which refs are removed vs accepted
+  as documented exceptions (like D-0022). Then ship as PR-E0 (decision only) +
+  PR-E1–E4 (≤3 surfaces each, engine-neutral edits). Scoped in the plan's PR-E table.
+
+### `[sync]` `SYNC-CLAUDE-PLUGIN-VERSION-GAP` — `sync-version-refs.sh` doesn't update CLAUDE.md's plugin-version string
+
+- Context: FRWK-REVIEW-002 PR-A/B bumped the plugin `0.23.2 → 0.23.4` but the
+  `Current state` line in `CLAUDE.md` stayed at `0.23.2` — PR-G #281 fixed it by
+  hand. The sync hook updates CLAUDE.md's framework-spec string but not the
+  plugin-version string, so every plugin bump leaves it stale.
+- Fix shape: extend `scripts/sync-version-refs.sh` plugin-version block to also
+  rewrite the `Claude Code plugin \`X.Y.Z\`` token in `CLAUDE.md`'s current-state
+  line (mirror the framework-spec handling); add a conformance guard if cheap.
+
+### `[skill]` `SKILL-DEDUP-001` — 36 per-layer skills are ~57% duplicated boilerplate (≈7,800 lines)
+
+- Context: FRWK-REVIEW-002 skill-redundancy review. The 4 families × 9 layers
+  (`doc-*` / `-audit` / `-fixer` / `-autopilot`) share near-identical saga /
+  break-circuit / adaptation / report-format blocks; PR-A fixed the drift
+  *instances* but not the duplication *class*. Also absorbs A7 (cosmetic
+  autopilot-wording normalization, deferred from PR-A) and L16 (quality-advisor
+  re-implements the audits' Structural-Checklist checks with no shared source).
+- Fix shape: generate the 36 per-layer `SKILL.md` from one template per family +
+  a per-layer parameter block (precedent: `sync-version-refs.sh` already rewrites
+  all 52 frontmatters), and/or move engine-generic blocks into the governance docs
+  the skills already cite. Promote to `→ SKILL-DEDUP-001-PLAN.md` before building.
+
+### `[skill]` `DEPRECATED-STUB-REMOVAL-V1` — remove `doc-review` / `trace-check` stubs at v1.0.0
+
+- Context: FRWK-REVIEW-002 L15. The two deprecated redirect stubs (`replacement:
+  doc-validator`) are correctly marked and scheduled for removal at the plugin
+  v1.0.0 milestone; no action before then (review concluded no live dependencies).
+- Fix shape: at the v1.0.0 cut, delete the two `skills/` dirs, drop them from the
+  registry/README/marketplace counts, and update the "52 = 50 + 2" claims to 50.
+
 **[docs] PLAN-003 §5.4c framework link-summary retrofit — deferred from Wave 1a**
 
 - Context: Wave 1 PR (2026-07-08) closed the parser-gate `--check-governance`

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -1,17 +1,18 @@
 # Session Handoff
 
-> **▶ IN FLIGHT (2026-07-09) — FRWK-REVIEW-002** (`plans/FRWK-REVIEW-002-PLAN.md`,
-> plan PR #275 merged). **Current versions:** framework spec `0.35.1` · plugin
-> `0.23.4` · hermes `0.7.3`. Fixes 46 findings from the 2026-07-09 plugin + core-docs
-> review across 7 tier-scoped PRs. **PR-A shipped** (plugin `0.23.3`): skill-content
-> drift — audit-report path unified across 68 sites, iteration-cap citation
-> corrected + backported, `review_mode` consistency, phantom emitter removed, verdict
-> clarifier propagated, creator/autopilot descriptions disambiguated. **PR-B shipped**
-> (plugin `0.23.4`): removed the dead `--threshold` flag (driver + 8 autopilots), CHG
-> advisory-hook coverage, `save-plan` wired to `work_plans_dir`, changelog structure,
-> `plugin.json` keywords, CHG precheck-exclusion note. **Next:** PR-F (docs-of-record
-> currency). **Held for founder:** PR-C/PR-D (spec tier), PR-E0–E4 (engine-agnosticism,
-> GD decision), PR-G (CLAUDE.md).
+> **✅ FRWK-REVIEW-002 COMPLETE except PR-E (2026-07-09)** (`plans/FRWK-REVIEW-002-PLAN.md`).
+> **Current versions:** framework spec `0.36.0` · plugin `0.23.4` · hermes `0.7.3`.
+> 46 findings from the 2026-07-09 plugin + core-docs review, fixed across 6 merged
+> impl PRs: **PR-A #276** (plugin `0.23.3`, skill-content drift — 68 audit-report
+> sites, iteration-cap citation, review_mode, phantom emitter), **PR-B #277** (plugin
+> `0.23.4`, mechanics — dead `--threshold`, CHG hook, save-plan config, changelog),
+> **PR-F #278** (docs-of-record currency + sync-script hazard fix), **PR-C #279** (spec
+> `0.35.2`, 17 spec-text corrections — BDD YAML-BDD, adaptation 6-knob, SPEC-Ready gate,
+> registry-wins), **PR-D #280** (spec `0.36.0`, realizing-layers registry block +
+> 28-rule lint catalog), **PR-G #281** (CLAUDE.md anchor + stale current-state).
+> Conformance 192 green. **Remaining, tracked in `plans/FRAMEWORK-TODO.md`:** PR-E
+> engine-agnosticism (BLOCKED on founder GD-NN), the sync-hook CLAUDE.md plugin-version
+> gap, SKILL-DEDUP-001 (skill de-duplication), and the v1.0.0 deprecated-stub removal.
 >
 > **✅ SESSION COMPLETE (2026-07-08) — PROVISIONAL-IDS-002 Phase 1 shipped.** Both PRs
 > merged (plan #269 + impl #270); `main` clean, no open PRs. The Phase-1 build ships


### PR DESCRIPTION
## What

Records all unshipped FRWK-REVIEW-002 tasks as tracked backlog entries in `plans/FRAMEWORK-TODO.md` (per the repo's "the entry IS the capture moment" rule), and marks `plans/HANDOFF.md` as complete-except-PR-E. Docs only — no version bump.

Four new `## Open` entries:
- **`FRWK-REVIEW-002-PR-E`** — engine-agnosticism sweep (BLOCKED on founder GD-NN decision).
- **`SYNC-CLAUDE-PLUGIN-VERSION-GAP`** — the version-sync hook doesn't update CLAUDE.md's plugin-version string (PR-G #281 fixed it by hand; extend the hook to prevent recurrence).
- **`SKILL-DEDUP-001`** — the 36 per-layer skills are ~57% duplicated boilerplate (≈7,800 lines); absorbs the deferred A7 cosmetic normalization and L16 quality-advisor drift-seed.
- **`DEPRECATED-STUB-REMOVAL-V1`** — remove the `doc-review`/`trace-check` stubs at the v1.0.0 milestone (L15).

## Context
The 6 FRWK-REVIEW-002 impl PRs (#276–#281) are merged; main is at spec `0.36.0` / plugin `0.23.4`, conformance 192 green. These entries ensure the remaining work — one founder-gated PR plus three deferred initiatives — stays tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)