### PR TITLE
fix(sync): extend version-sync hook to CLAUDE.md's plugin-version string

### DIFF
--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -38,15 +38,16 @@
   as documented exceptions (like D-0022). Then ship as PR-E0 (decision only) +
   PR-E1–E4 (≤3 surfaces each, engine-neutral edits). Scoped in the plan's PR-E table.
 
-### `[sync]` `SYNC-CLAUDE-PLUGIN-VERSION-GAP` — `sync-version-refs.sh` doesn't update CLAUDE.md's plugin-version string
+### `[sync]` `SYNC-CLAUDE-PLUGIN-VERSION-GAP` — ✅ CLOSED (2026-07-09) — `sync-version-refs.sh` didn't update CLAUDE.md's plugin-version string
 
 - Context: FRWK-REVIEW-002 PR-A/B bumped the plugin `0.23.2 → 0.23.4` but the
   `Current state` line in `CLAUDE.md` stayed at `0.23.2` — PR-G #281 fixed it by
-  hand. The sync hook updates CLAUDE.md's framework-spec string but not the
-  plugin-version string, so every plugin bump leaves it stale.
-- Fix shape: extend `scripts/sync-version-refs.sh` plugin-version block to also
-  rewrite the `Claude Code plugin \`X.Y.Z\`` token in `CLAUDE.md`'s current-state
-  line (mirror the framework-spec handling); add a conformance guard if cheap.
+  hand. The sync hook updated CLAUDE.md's framework-spec string but not the
+  plugin-version string, so every plugin bump left it stale.
+- Fixed: extended the `scripts/sync-version-refs.sh` plugin-version block to also
+  rewrite the `Claude Code plugin \`X.Y.Z\`` token in `CLAUDE.md`(mirrors the
+  framework-spec handling), and added a conformance guard
+  (`test_claude_md_current_state_matches_plugin_version`) so re-drift fails CI.
 
 ### `[skill]` `SKILL-DEDUP-001` — 36 per-layer skills are ~57% duplicated boilerplate (≈7,800 lines)
 

--- a/scripts/sync-version-refs.sh
+++ b/scripts/sync-version-refs.sh
@@ -18,6 +18,7 @@
 #       "version": "<X.Y.Z>"
 #   - All platforms/claude-code-plugin/skills/<name>/SKILL.md frontmatter
 #       version: "<X.Y.Z>"
+#   - CLAUDE.md "Claude Code plugin `<X.Y.Z>`" current-state line
 #   - README.md
 #       `claude-code-plugin/v<X.Y.Z>` references
 #   - platforms/claude-code-plugin/docs/SKILL_AUTHORING.md
@@ -139,6 +140,11 @@ if [[ -n "$plugin_ver" ]]; then
       replace_in_file "$skill" \
         "version: \"$plugin_prev\"" "version: \"$plugin_ver\""
     done
+    # CLAUDE.md current-state line: "Claude Code plugin `<X.Y.Z>`"
+    # (SYNC-CLAUDE-PLUGIN-VERSION-GAP — the framework-spec token was already
+    # synced below; the plugin token was not, so every plugin bump left it stale).
+    replace_in_file CLAUDE.md \
+      "Claude Code plugin \`$plugin_prev\`" "Claude Code plugin \`$plugin_ver\`"
     replace_in_file README.md \
       "claude-code-plugin/v$plugin_prev" "claude-code-plugin/v$plugin_ver"
     replace_in_file platforms/claude-code-plugin/README.md \

--- a/tests/conformance/platforms/test_plugin_release_metadata.py
+++ b/tests/conformance/platforms/test_plugin_release_metadata.py
@@ -118,6 +118,13 @@ class PluginReleaseMetadata(unittest.TestCase):
         tag = f"claude-code-plugin/v{_plugin_version()}"
         self.assertIn(tag, text)
 
+    def test_claude_md_current_state_matches_plugin_version(self):
+        # CLAUDE.md's "Current state" line quotes the plugin version as
+        # `Claude Code plugin `<X.Y.Z>``; the sync hook keeps it current
+        # (SYNC-CLAUDE-PLUGIN-VERSION-GAP). Guard against re-drift.
+        text = (REPO_ROOT / "CLAUDE.md").read_text(encoding="utf-8")
+        self.assertIn(f"Claude Code plugin `{_plugin_version()}`", text)
+
     def test_parity_doc_matches_plugin_release_inventory(self):
         text = PARITY_DOC.read_text(encoding="utf-8")
         self.assertIn(f"claude-code-plugin/v{_plugin_version()}", text)


### PR DESCRIPTION
## What

Closes the `SYNC-CLAUDE-PLUGIN-VERSION-GAP` backlog item surfaced during FRWK-REVIEW-002. `scripts/sync-version-refs.sh` already propagated the **framework-spec** version into CLAUDE.md's current-state line but **not** the **plugin** version — so PR-A/B's `0.23.2 → 0.23.4` bump left `Claude Code plugin \`0.23.2\`` stale until PR-G #281 fixed it by hand.

- Extend the plugin-VERSION fanout block to rewrite the `Claude Code plugin \`<X.Y.Z>\`` token in CLAUDE.md (mirrors the existing framework-spec handling), plus the header-comment coverage line.
- Add a conformance guard `test_claude_md_current_state_matches_plugin_version` — **no conformance test referenced CLAUDE.md before**, which is precisely why the drift went unnoticed.

## Verification
- Scratch-bumped the plugin `VERSION` to `0.99.99`, ran the hook, confirmed CLAUDE.md's plugin token rewrote to `0.99.99`; reverted cleanly (the hook re-stages, so a hard reset was needed to unwind).
- Conformance **193 green** (new guard included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)