### PR TITLE
docs(plans): mark FRWK-REVIEW-002 complete

### DIFF
--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -24,19 +24,17 @@
 
 ## Open
 
-### `[docs]` `FRWK-REVIEW-002-PR-E` — engine-agnosticism sweep (BLOCKED on founder GD-NN)
+### `[docs]` `FRWK-REVIEW-002-PR-E` — ✅ CLOSED (2026-07-09) — engine-agnosticism sweep
 
-- Context: FRWK-REVIEW-002 (plan `plans/FRWK-REVIEW-002-PLAN.md`, PRs #276–#281
-  merged). PR-E is the only unshipped piece. The spec carries engine-specific
-  tokens: the playbook `agent:` frontmatter field points into
-  `platforms/claude-code-plugin/` (`REVIEW_TEAM.md:259`); `doc-*`/"SKILL"
-  vocabulary in governance/layer docs; a workspace-CI section pinning
-  `aidoc-flow-ci@ci/vX` in `REVIEW_REMEDIATION_FLOW.md`; repo-root tool refs
-  (`tools/trace_walk.py`, `tools/sdd_coverage.py`) the spec doesn't vendor.
-- Fix shape: **needs a founder decision first (GD-NN in `framework/governance/DECISIONS.md`)** —
-  what counts as an engine-specific token, and which refs are removed vs accepted
-  as documented exceptions (like D-0022). Then ship as PR-E0 (decision only) +
-  PR-E1–E4 (≤3 surfaces each, engine-neutral edits). Scoped in the plan's PR-E table.
+- Context: FRWK-REVIEW-002 PR-E — the spec carried engine-specific tokens (the
+  playbook `agent:` field pointing into `platforms/claude-code-plugin/`;
+  `doc-*`/"SKILL" vocabulary; a workspace-CI section; repo-root tool refs).
+- Resolved: founder chose the **Hybrid** ruling, recorded as **GD-06** in
+  `framework/governance/DECISIONS.md` (PR-E0 #284). PR-E-impl (#285) neutralized
+  the generic vocabulary (doc-*/"SKILL" → engine-neutral, `claude -p` → neutral,
+  AIDOC table → Platform-B illustration, tool paths → reference implementation)
+  and kept the two sanctioned exceptions (the `agent:` executor field, softened;
+  the workspace-CI section, scope-noted). Spec `0.36.0 → 0.36.2`.
 
 ### `[sync]` `SYNC-CLAUDE-PLUGIN-VERSION-GAP` — ✅ CLOSED (2026-07-09) — `sync-version-refs.sh` didn't update CLAUDE.md's plugin-version string
 

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -1,7 +1,11 @@
 # Session Handoff
 
-> **✅ FRWK-REVIEW-002 COMPLETE except PR-E (2026-07-09)** (`plans/FRWK-REVIEW-002-PLAN.md`).
-> **Current versions:** framework spec `0.36.0` · plugin `0.23.4` · hermes `0.7.3`.
+> **✅ FRWK-REVIEW-002 COMPLETE (2026-07-09)** (`plans/FRWK-REVIEW-002-PLAN.md`).
+> All 46 findings resolved. **Current versions:** framework spec `0.36.2` · plugin
+> `0.23.4` · hermes `0.7.3`. PR-E (engine-agnosticism) shipped per the founder's
+> GD-06 Hybrid ruling (#284 decision + #285 neutralization). **Remaining backlog
+> (`plans/FRAMEWORK-TODO.md`, not FRWK-REVIEW-002):** SKILL-DEDUP-001 (skill
+> de-duplication) and the v1.0.0 deprecated-stub removal.
 > 46 findings from the 2026-07-09 plugin + core-docs review, fixed across 6 merged
 > impl PRs: **PR-A #276** (plugin `0.23.3`, skill-content drift — 68 audit-report
 > sites, iteration-cap citation, review_mode, phantom emitter), **PR-B #277** (plugin


### PR DESCRIPTION
Closes the `FRWK-REVIEW-002-PR-E` backlog entry and refreshes the HANDOFF banner now that the initiative is fully shipped (all 46 findings resolved; spec `0.36.2`, plugin `0.23.4`). Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)