### PR TITLE
docs: fix 2 stale spec-version stragglers (post-fix verification review)

### DIFF
--- a/DESC.md
+++ b/DESC.md
@@ -309,7 +309,7 @@ From Claude Code:
 
 The migration is complete (cutover shipped as `v1.0.0`); the project is now in
 **post-cutover development** (latest project release `v1.1.0`), tracking
-framework spec `0.35.1`. The Claude Code plugin is a **pre-1.0 preview** — APIs
+framework spec `0.36.2`. The Claude Code plugin is a **pre-1.0 preview** — APIs
 and surfaces may change before 1.0. Platform versions are in the
 [Platforms](#platforms) table above.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,7 +31,7 @@ permanent asymmetry.
 Near-term, in-flight work.
 
 - **Hermes parity catch-up** — bring Hermes up to the plugin's current spec surface
-  (framework `0.35.1`). Hermes already has team-mode + 8-layer playbook injection +
+  (framework `0.36.2`). Hermes already has team-mode + 8-layer playbook injection +
   saga conformance (D-0045…D-0053; the whole 0.32.x arc is auto-satisfied via its
   vendored `sdd_doc_lint` + shared templates). The residual items are small doc/skill
   deltas — **H-11c** (SHA-256 residue, now unblocked by PROVISIONAL-IDS-002) + the


### PR DESCRIPTION
The post-fix verification review of the FRWK-REVIEW-002 cumulative result came back clean on everything substantive (conformance 193 green, bundle byte-identical, all cross-references resolve, GD-06 neutralization complete, CHANGELOG coherent) — with 2 trivial stragglers: two current-state claims the spec bumps to `0.36.2` missed.

- `DESC.md:312` — spec `0.35.1` → `0.36.2` (the adjacent plugin claim was updated; this one was missed).
- `ROADMAP.md:34` — framework `0.35.1` → `0.36.2` (the "Now" Hermes-parity target).

Grep confirms no other current-state stale versions remain. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)