### PR TITLE
docs(hermes): HERMES-REVIEW-001 PR-DOCS — reconcile 0.7.3 docs/version drift sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — Hermes `0.7.3` docs/version drift sweep — HERMES-REVIEW-001 PR-DOCS (2026-07-10)
+
+- **Reconciled active-facing Hermes docs to the real `0.7.3` / spec `0.36.2`
+  state** (2026-07-09 Hermes review findings H3/H4/H5/M4/M5/M8, L6). `pyproject.toml`
+  version `0.1.0` → `0.7.3`; `platforms/hermes/README.md` conformance block +
+  platform-info table (canonical `hermes/v*` cell, complete 27-tool table, module
+  count `20`, persona count `16`); `docs/HERMES_INTEGRATION.md` paths rewritten to
+  `platforms/hermes` + Python `>=3.12` + retired `ucx_kb` KB sections repointed to
+  engramory; `docs/README.md` `2.0.0`/`ucx_hermes` self-id + dead migration link +
+  `SPEC-011`; `docs/ROADMAP.md` legacy table marked historical; `CHANGELOG.md`
+  `[0.7.3]` section cut from the bundled `[Unreleased]`. `scripts/sync-version-refs.sh`
+  extended to cover the Hermes `pyproject.toml` + README version blocks (closes
+  FRAMEWORK-TODO `HERMES-README-VERSION-DRIFT`). Hermes-stream docs/tooling only.
+
 ### Changed — Framework Spec `0.36.1 → 0.36.2` — FRWK-REVIEW-002 PR-E engine-agnosticism neutralization (2026-07-09)
 
 Implements the GD-06 Hybrid ruling — neutralizes the generic platform vocabulary

--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -310,21 +310,21 @@
   VERSION → run sync → observe web-site badge change) is the
   Confirmation gate in IPLAN-0008.
 
-### `[sync]` `HERMES-README-VERSION-DRIFT` — `platforms/hermes/README.md` Version + framework-spec cells stale
+### `[sync]` `HERMES-README-VERSION-DRIFT` — ✅ CLOSED (2026-07-10, HERMES-REVIEW-001 PR-DOCS) — `platforms/hermes/README.md` Version + framework-spec cells stale
 
 - *Context:* Plugin `0.20.1` PATCH (2026-06-14) found and fixed the same
   drift class in `platforms/claude-code-plugin/README.md` (`0.6.3` →
   `claude-code-plugin/v<X.Y.Z>` canonical form). `platforms/hermes/README.md`
-  lines 107-108 still carry the bug: `Version | hermes/v0.1.0` (actual
-  `0.3.0`) and `framework spec 0.1.0` (actual `0.21.1`).
-- *Fix shape:* (a) Canonicalize the hermes README Version cell to the
-  `hermes/v<X.Y.Z>` tag form — the v0.20.1 sync-script extension now
-  covers this pattern, so the next Hermes VERSION bump auto-propagates.
-  (b) The "Conforms to" cell uses a bare framework-spec X.Y.Z and needs
-  a separate sync pattern in `scripts/sync-version-refs.sh` (the
-  framework-VERSION fanout block) — add
-  `replace_in_file platforms/hermes/README.md "framework spec \`$fw_prev\`" ...`.
-  Out of scope for the plugin-first PATCH; pull when Hermes work resumes.
+  carried the bug: `Version | 0.1.0` and `framework spec 0.1.0` (plus
+  `pyproject.toml` frozen at `0.1.0` and the README `$ cat VERSION` /
+  `$ cat FRAMEWORK_SPEC_VERSION` blocks).
+- *Resolution (HERMES-REVIEW-001 PR-DOCS):* (a) canonicalized the hermes README
+  Version cell to the `hermes/v<X.Y.Z>` tag form (already sync-covered); (b) added
+  the hermes README `framework spec \`X\`` prose + `$ cat FRAMEWORK_SPEC_VERSION`
+  awk sync to the framework-VERSION fanout block; (c) added `platforms/hermes/pyproject.toml`
+  version + README `$ cat VERSION` awk sync to the hermes-VERSION fanout block. All
+  stale `0.1.0` strings reconciled to the real `0.7.3` / spec `0.36.2`; future bumps
+  auto-propagate.
 
 ### `[skill]` `MODEL-PRECHECK-ROLLOUT` — original framing (superseded; see PARKED entry above)
 

--- a/platforms/hermes/CHANGELOG.md
+++ b/platforms/hermes/CHANGELOG.md
@@ -14,6 +14,29 @@ this platform adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [0.7.3] — 2026-07-10
+
+### Documentation
+
+- **HERMES-REVIEW-001 PR-DOCS — active-facing docs/version drift sweep.** Finalizes
+  the 0.7.3 release record and reconciles stale version/path/count references
+  surfaced by the 2026-07-09 Hermes review (H3/H4/H5/M4/M5/M8, L6): `pyproject.toml`
+  version `0.1.0` → `0.7.3`; `README.md` conformance block + platform-info table to
+  real values (`VERSION` `0.7.3`, `FRAMEWORK_SPEC_VERSION`/spec `0.36.2`, canonical
+  `hermes/v*` Version cell), source-module count `18` → `20` (+`team_emulator`),
+  persona count `15` → `16`, and a complete 27-tool table; `docs/HERMES_INTEGRATION.md`
+  pre-migration `ucx_framework/ucx_hermes` paths rewritten to the `platforms/hermes`
+  layout, the `Python 3.11+` contradiction fixed to `>=3.12`, and the retired `ucx_kb`
+  KB-runtime sections repointed to engramory; `docs/README.md` `2.0.0`/`ucx_hermes`
+  self-id corrected, dead `migration/MIGRATION_FROM_MCP_UCX.md` link retired,
+  `SPEC-011` added to the spec list; `docs/ROADMAP.md` legacy `2.0.0` table marked
+  historical. Also extends `scripts/sync-version-refs.sh` to cover the Hermes
+  `pyproject.toml` + README version blocks so they no longer re-drift
+  (closes FRAMEWORK-TODO `HERMES-README-VERSION-DRIFT`). Docs + tooling only; no
+  runtime behavior change.
+
 ### Added
 
 - **Review calibration: no-findings rationale cap + strip author self-claim
@@ -39,7 +62,7 @@ this platform adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   lens. Added the `chg` review crew to `persona_mappings.yaml` (crew parity with the
   framework CHG crew) and removed the `HERMES_DEFERRED_LAYERS` whitelist, so the
   crew-coverage conformance test now enforces CHG like the lifecycle layers. Crew-map
-  parity only — a *live/sanctioned* CHG saga review (adding `09_CHG` to
+  parity only — a _live/sanctioned_ CHG saga review (adding `09_CHG` to
   `saga.schema.json` + a dispatch path) is a deferred follow-on; no default flow
   dispatches a `chg` review. No framework spec change.
 
@@ -94,8 +117,8 @@ this platform adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   enforces both platforms' tables against `REVIEW_SAGA.md` and validates a sample
   journal from each runner against `saga.schema.json` (the test `docs/PARITY.md`
   previously over-claimed already existed). **No version bump** — Phase 1 makes the
-  state machine *accept* the transition (parity contract); the orchestrator does not
-  yet *write* it (break-circuit exercise + resume is Phase 1b).
+  state machine _accept_ the transition (parity contract); the orchestrator does not
+  yet _write_ it (break-circuit exercise + resume is Phase 1b).
 
 ### Removed
 
@@ -124,7 +147,7 @@ this platform adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   persona profiles (`skills/personas/*.md`): dropped the dead `SYS/REQ/CTR/TSPEC`
   scoring-weight lines, removed those tokens from each persona's `doc_types`
   list, and removed the dedicated layer rows + sections (e.g. integration_lead's
-  "CTR Expertise", qa_lead's "TSPEC Quality Metrics"). *Deliberately retained:*
+  "CTR Expertise", qa_lead's "TSPEC Quality Metrics"). _Deliberately retained:_
   the `agent-skills/` historical notes documenting the layers as "cut from
   v3"/"deprecated" (accurate history) and the threshold-rules `req`/`ctr` tokens
   (unrelated meanings — rate/Currency-Transaction-Report).
@@ -168,10 +191,10 @@ this platform adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `references/governance-load-protocol.md` — were replaced with the current single-path
   layer model (no tiers; necessary-upstream contract; MVP → PROD → NEW MVP). Skill
   `version: 2.0.0 → 2.1.0`. Doc-accuracy only — no engine/runtime change, no `framework/`
-  change. *(Deferred backlog: the ~25-file cosmetic "v3.2" string residue across the
+  change. _(Deferred backlog: the ~25-file cosmetic "v3.2" string residue across the
   inherited governance scaffold; the hand-vendored `references/` framework-doc copies
   (D-0013 delete-vs-resync); the element-ID SHA-256 residue, framework-gated by
-  PROVISIONAL-IDS-002.)*
+  PROVISIONAL-IDS-002.)_
 
 - **Element-ID alignment to the framework 4-segment hash form** (PLATFORM-ALIGN
   Part B, `0.1.0 → 0.2.0`). The runtime element-ID validators in
@@ -183,7 +206,7 @@ this platform adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   8-layer EARS/BDD prompt templates' element-ID examples + the `UCC_PROMPT_EARS`
   ID-convention legend were migrated off the legacy type-code scheme
   (`EARS.NN.<CODE>.<seq>`, `PRD.NN.US.NN`, 3-segment refs) to the 4-segment hash
-  form. *Stricter validation:* a previously-accepted 3-segment ID now fails —
+  form. _Stricter validation:_ a previously-accepted 3-segment ID now fails —
   intended (the 3-segment form was the legacy variant the framework retired).
 
 - **EARS pattern alignment** — brought the Hermes vendored EARS pattern tables
@@ -195,11 +218,11 @@ this platform adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   6-pattern model with a mixed `IF…THEN` connective. Now: the five canonical
   patterns (Ubiquitous, Event/`WHEN`, State/`WHILE`, Optional/`WHERE`,
   Unwanted/`IF`) in the uniform `the [system] shall …` form (no `THEN`); "complex"
-  reframed as *composition* of the base patterns (the standalone `Complex` row +
+  reframed as _composition_ of the base patterns (the standalone `Complex` row +
   the `CX` type code removed). Doc-only; no runtime behavior change.
-  *(Note: the prompts' legacy type-code element-ID scheme — `EARS.NN.<code>.<seq>`
+  _(Note: the prompts' legacy type-code element-ID scheme — `EARS.NN.<code>.<seq>`
   vs the framework's hash-based `EARS.NN.SS.xxxx` — is a separate, pre-existing
-  divergence, out of scope here.)*
+  divergence, out of scope here.)_
 
 ## [0.1.1] — 2026-05-21
 

--- a/platforms/hermes/README.md
+++ b/platforms/hermes/README.md
@@ -10,10 +10,10 @@ No native Claude Code integration; clients talk MCP.
 
 | Component | Count | Path |
 |-----------|------:|------|
-| Source modules | 18 | `src/mcp_server/` — `cleanup`, `cli`, `consistency`, `core`, `creation`, `executor`, `link_validation`, `models`, `preflight`, `prescreening`, `prompts`, `remediation`, `reporting`, `review`, `scan`, `scoring`, `skills`, `utils`, `validation` |
+| Source modules | 20 | `src/mcp_server/` — `cleanup`, `cli`, `consistency`, `core`, `creation`, `executor`, `link_validation`, `models`, `preflight`, `prescreening`, `prompts`, `remediation`, `reporting`, `review`, `scan`, `scoring`, `skills`, `team_emulator`, `utils`, `validation` |
 | Tests (pytest) | 447 | `tests/` — unit, integration, contract |
 | MCP prompts | 46 | `prompts/` + `prompts/templates/` |
-| Personas | 15 | `skills/personas/` |
+| Personas | 16 | `skills/personas/` |
 | Platform-specific skills | 5 | `skills/hermes/` — `ucx-github-deploy-governance`, `ucx-github-governance`, `ucx-kb-context`, `ucx-kb-maintenance`, `ucx-sdd-bridge` |
 | Agent-skills package | 181 | `agent-skills/spec-driven-development/` — `sdd-orchestrator` + `sdd-review-personas` |
 | Docs | 80 | `docs/` — `CHANGELOG/`, `architecture/`, `plans/`, `policies/`, `specs/` |
@@ -44,21 +44,31 @@ a reference):
 
 ## Use
 
-Hermes exposes **platform-wide MCP tools** for the SDD workflow:
+Hermes exposes **platform-wide MCP tools** for the SDD workflow (27
+registered tools, `TOOLS` in `src/mcp_server/tool_registry.py`):
 
 | Tool | Purpose |
 |------|---------|
-| `sdd_init` | Scaffold `<project>/UCX/` from `framework/layers/` |
-| `sdd_validate` | Structural validation of an artifact against its layer template |
-| `sdd_validate_chg` | CHG (Change Management) artifact validation |
-| `sdd_validate_links` | Cross-document link validation |
-| `sdd_score_validate` | Readiness scoring (quality gate) |
-| `sdd_score_show` / `sdd_score_compare` | Score inspection / diff |
-| `sdd_preflight` | Environment / input readiness check |
-| `sdd_consistency` | Cross-document traceability check |
-| `sdd_create` / `sdd_create_build` | Artifact authoring + template build |
-| `sdd_review` | Review workflow |
-| `sdd_scan` | Project scan |
+| `sdd_init` | Scaffold `<project>/UCX/` assets (personas, templates, schemas, prompts) |
+| `sdd_set_project` / `sdd_get_project` | Set / show the session default project |
+| `sdd_env_show` | Show project `.env` keys without exposing values |
+| `sdd_preflight` | Runtime / environment readiness check before create/review/remediate |
+| `sdd_create_build` / `sdd_create` | Assemble creation prompt / write the final artifact |
+| `sdd_validate` | Structural validation against the layer schema/template |
+| `sdd_validate_chg` | CHG (Change Management) governance validation |
+| `sdd_validate_links` | Markdown cross-document link validation |
+| `sdd_consistency` | Artifact lineage / stage-consistency check |
+| `sdd_score_show` / `sdd_score_validate` / `sdd_score_compare` | Compute / gate / diff quality score |
+| `sdd_review` | Assemble the multi-persona review prompt |
+| `sdd_remediate` | Run remediation from review findings (source-protected derived copies) |
+| `sdd_run_lifecycle` | Run multiple lifecycle stages in sequence |
+| `sdd_next_action` | Recommend the next lifecycle stage for a document folder |
+| `sdd_prescreen` | Identify high-priority remediation candidates |
+| `sdd_scan` | Extract finding-category counts from a report |
+| `sdd_clean` | Remove obsolete stage artifacts (keep latest per stage) |
+| `sdd_personas_show` / `sdd_personas_set` / `sdd_personas_diff` | Show / update / diff persona assignments |
+| `sdd_list_executors` / `sdd_register_executor` | List / register API executors |
+| `sdd_team_plan` | Run the AI-employee planning council (supervisor-approved artifacts) |
 
 The MCP client picks the tool; Hermes operates on any of the 8 SDD
 layers (BRD, PRD, EARS, BDD, ADR, SPEC, TDD, IPLAN) generically.
@@ -71,13 +81,13 @@ version declarations:
 
 ```sh
 $ cat VERSION
-0.1.0
+0.7.3
 
 $ cat FRAMEWORK_SPEC_VERSION
-0.1.0
+0.36.2
 ```
 
-Hermes declares conformance to framework spec `0.1.0`; the
+Hermes declares conformance to framework spec `0.36.2`; the
 framework's own version is at `../../framework/VERSION`. The Phase 4
 conformance suite enforces this declaration matches.
 
@@ -104,8 +114,8 @@ conformance guard); run it from the platform root with
 | Distribution | `hermes-server` (PyPI when published) |
 | Script entry | `hermes-mcp` → `mcp_server.server:main_sync` |
 | Python | `>=3.12` |
-| Version | `0.1.0` (independent SemVer; tag namespace `hermes/v*`) |
-| Conforms to | framework spec `0.1.0` (declared in `FRAMEWORK_SPEC_VERSION`) |
+| Version | `hermes/v0.7.3` (independent SemVer; tag namespace `hermes/v*`) |
+| Conforms to | framework spec `0.36.2` (declared in `FRAMEWORK_SPEC_VERSION`) |
 | License | MIT |
 | Repository | <https://github.com/vladm3105/aidoc-flow-framework> |
 | Platform changelog | [`CHANGELOG.md`](CHANGELOG.md) |

--- a/platforms/hermes/docs/HERMES_INTEGRATION.md
+++ b/platforms/hermes/docs/HERMES_INTEGRATION.md
@@ -2,7 +2,7 @@
 
 ## What Changed
 
-The UCX MCP server (`ucx_hermes`) now enforces an API-only executor model
+The Hermes MCP server (`mcp_server`, distributed as `hermes-server`) enforces an API-only executor model
 for LLM-enabled stages through LiteLLM. Deterministic stages do not invoke
 executors. Legacy CLI executor paths are unsupported.
 
@@ -84,13 +84,13 @@ In `~/.hermes/config.yaml`, the MCP server entry should include:
 ```yaml
 mcp_servers:
   sdd-lifecycle:
-    command: /opt/data/ucx_framework/.venv/bin/python
+    command: python            # or the installed `hermes-mcp` console script
     args:
       - -m
       - mcp_server.server
-    cwd: /opt/data/ucx_framework/ucx_hermes/src
+    cwd: /path/to/aidoc-flow-framework/platforms/hermes
     env:
-      PYTHONPATH: /opt/data/ucx_framework/ucx_hermes/src
+      PYTHONPATH: /path/to/aidoc-flow-framework/platforms/hermes/src
 ```
 
 ### 2. Hermes Skills
@@ -98,7 +98,7 @@ mcp_servers:
 Install the bridge skill into Hermes:
 
 ```bash
-cp -r /opt/data/ucx_framework/ucx_hermes/skills/hermes/ucx-sdd-bridge \
+cp -r /path/to/aidoc-flow-framework/platforms/hermes/skills/hermes/ucx-sdd-bridge \
   ~/.hermes/skills/
 ```
 
@@ -116,46 +116,36 @@ Skill version note:
 
 - Use `ucx-sdd-bridge` `v1.1.1+` for API-only executor guidance,
   fan-out/fan-in (`saga_parallel`) review controls, and executor troubleshooting.
-- Optional KB skills:
-  - `ucx-kb-context` for retrieval enrichment during UCX V3 lifecycle stages
-  - `ucx-kb-maintenance` for post-IPLAN knowledge updates with governance controls
-  - `ucx-kb-maintenance/KB_GENERAL_RULES.md` for mandatory coverage and ingestion policy across all document artifacts
-  - `ucx-kb-maintenance/KB_ENTRY_TEMPLATE.md` for KB admission checklist and canonical entry structure
 - Governance skills:
   - `ucx-github-governance` for issue/PR label flow and round-based merge governance
   - `ucx-github-deploy-governance` for CI/CD, QA, staging/prod readiness, and post-deploy issue loops
+- The `ucx-kb-context` / `ucx-kb-maintenance` bridge skills ship in
+  `skills/hermes/` but depend on a knowledge-base runtime (`ucx_kb`) that is
+  **not part of this platform** — KB/retrieval enrichment is superseded by
+  engramory (see §4). Treat them as inactive prompt guidance for now.
 
 Skill activation matrix:
 
 | Scenario | Primary Skill | Optional Companion | Notes |
 |----------|---------------|--------------------|-------|
-| BRD->IPLAN lifecycle orchestration in `framework` | `ucx-sdd-bridge` | `ucx-kb-context` | Keep document-layer flow MCP-only; do not use CLI lifecycle commands. |
-| Multi-persona review with fan-out/fan-in (`review_mode=saga_parallel`) | `ucx-sdd-bridge` | `ucx-kb-context` | Use KB retrieval before review for prior findings/constraints. |
-| Remediation planning and policy-gated apply | `ucx-sdd-bridge` | `ucx-kb-context` | Use API executor for `sdd_remediate`; use KB for accepted remediation patterns. |
-| Post-IPLAN implementation knowledge capture | `ucx-kb-maintenance` | `ucx-sdd-bridge` | Run after approved implementation evidence; KB updates do not advance lifecycle stages. |
-| KB unavailable or stale | `ucx-sdd-bridge` | none | Continue lifecycle gates; log reduced-confidence context and escalate high-impact assumptions. |
+| BRD->IPLAN lifecycle orchestration in `framework` | `ucx-sdd-bridge` | none | Keep document-layer flow MCP-only; do not use CLI lifecycle commands. |
+| Multi-persona review with fan-out/fan-in (`review_mode=saga_parallel`) | `ucx-sdd-bridge` | none | API-only executor routing; no KB runtime in this platform. |
+| Remediation planning and policy-gated apply | `ucx-sdd-bridge` | none | Use API executor for `sdd_remediate`. |
 
 ### 3. Project Setup
 
 For each project using UCX:
 
 ```bash
-# 1) Create shared framework virtual environment (required once per machine)
-cd /opt/data/ucx_framework
-scripts/bootstrap_ucx_venv.sh
+# 1) Create the platform virtual environment (required once per machine)
+cd /path/to/aidoc-flow-framework/platforms/hermes
+python -m venv .venv && .venv/bin/pip install -e .
 
-# Optional when project-knowledge MCP is enabled:
-scripts/bootstrap_ucx_venv.sh --with-kb
+# 2) Validate the runtime import
+PYTHONPATH=src .venv/bin/python -c "import mcp_server; print('hermes-server ok')"
 
-# 2) Validate runtime imports
-/opt/data/ucx_framework/.venv/bin/python -c "import mcp_server; print('ucx_hermes ok')"
-PYTHONPATH=/opt/data/ucx_framework /opt/data/ucx_framework/.venv/bin/python -c "import ucx_kb; print('ucx_kb ok')"
-
-# 3) Start MCP runtimes before BRD lifecycle work
-/opt/data/ucx_framework/.venv/bin/python -m mcp_server.server
-
-# Required when KB mode is enabled:
-PYTHONPATH=/opt/data/ucx_framework /opt/data/ucx_framework/.venv/bin/python -m ucx_kb.mcp.server
+# 3) Start the MCP runtime before BRD lifecycle work
+PYTHONPATH=src .venv/bin/python -m mcp_server.server
 
 # 4) Start Hermes session
 hermes chat
@@ -190,70 +180,32 @@ Preflight pass criteria (`sdd_preflight context=any`):
 
 Minimum checks before first lifecycle run:
 
-- `/opt/data/ucx_framework/.venv/bin/python` exists and reports Python `>=3.12`.
-- `mcp_server` import check passes in the shared virtual environment.
+- The platform `.venv` python exists and reports Python `>=3.12`.
+- `mcp_server` import check passes in the platform virtual environment.
 - `sdd-lifecycle` runtime is started before BRD prompt build.
-- KB-enabled projects: `project-knowledge` runtime is started before BRD prompt build.
 - `UCX/` scaffold exists for the target project.
 - `persona_mappings.yaml` exists and persona mapping health check does not report missing persona files.
 - Required executor environment keys are present for the configured provider path.
 
 BRD start gate:
 
-- Do not run BRD `sdd_create_build` until `sdd-lifecycle` startup is confirmed, and in KB mode `kb_status` plus `kb_graph_status` return successfully.
+- Do not run BRD `sdd_create_build` until `sdd-lifecycle` startup is confirmed.
 - Environment bootstrap and required framework tool availability are mandatory before any document creation stage starts.
 
-### 4. KB Preflight and Degraded Mode
+### 4. Knowledge-base retrieval (out of scope for this runtime)
 
-Framework baseline:
+Earlier revisions of this guide described a `project-knowledge` MCP server
+(`ucx_kb` package) with `kb_status` / `kb_graph_status` / `kb_search` preflight
+and a KB smoke-test runbook. That `ucx_kb` runtime is **not part of the current
+Hermes platform** — knowledge-base / retrieval enrichment is superseded by
+**engramory** (a separate repository, currently paused). The `ucx-kb-context` /
+`ucx-kb-maintenance` bridge skills remain in `skills/hermes/` as prompt guidance,
+but there is no `ucx_kb` MCP runtime to register against in this platform.
 
-- Keep framework MCP config minimal (`sdd-lifecycle` only).
-- Register `project-knowledge` only in a real project runtime where `ucx_kb` is initialized.
-
-Project-level MCP registration snippet (add in project runtime config):
-
-```json
-{
-  "mcpServers": {
-    "project-knowledge": {
-      "command": "/opt/data/ucx_framework/.venv/bin/python",
-      "args": ["-m", "ucx_kb.mcp.server"],
-      "cwd": "/opt/data/ucx_framework"
-    }
-  }
-}
-```
-
-Before lifecycle calls that depend on KB context:
-
-1. Call `kb_status`.
-2. Call `kb_graph_status`.
-3. Determine KB mode:
-   - `ready`: both calls succeed.
-   - `degraded`: one call fails.
-   - `unavailable`: both calls fail.
-
-If mode is `degraded` or `unavailable`, continue UCX lifecycle gates and record reduced-confidence reasoning notes. Do not block stage progression due to KB availability.
-
-### 5. KB Smoke Test (Operator Runbook)
-
-Run from `/opt/data/ucx_framework` after DB services are up and `.env` is configured for `ucx_kb`:
-
-```bash
-python -m ucx_kb.mcp.server
-```
-
-In Hermes session, verify these calls succeed:
-
-- `kb_status` (RAG status payload)
-- `kb_graph_status` (graph status payload)
-- `kb_search` with a small query (result or empty result without error)
-
-Pass criteria:
-
-- No MCP server startup exception
-- No tool contract error for the three calls above
-- Hermes can continue `sdd_*` lifecycle calls regardless of KB result cardinality
+Operate the SDD lifecycle with `sdd-lifecycle` only; do not register a
+`project-knowledge` server or gate lifecycle stages on KB availability. When
+engramory retrieval is reintroduced, its integration will be documented in the
+engramory repository.
 
 ## Standard Workflow
 
@@ -526,10 +478,10 @@ If you are migrating from a pre-UCX V3 runtime:
 
 | Component | Required Version |
 |-----------|-----------------|
-| UCX MCP Server | ucx_hermes v2.0.0+ |
+| Hermes MCP Server (`hermes-server`) | `hermes/v0.7.3`+ (spec `0.36.2`) |
 | Hermes Agent | Any with MCP support |
 | ucx-sdd-bridge skill | v1.1.1+ |
-| Python | 3.11+ |
+| Python | `>=3.12` |
 
 ## Files Modified
 

--- a/platforms/hermes/docs/README.md
+++ b/platforms/hermes/docs/README.md
@@ -1,7 +1,9 @@
 # UCX Hermes — Primary AI Agent Orchestration Platform
 
-> **Status**: Canonical / Active / Primary
-> **Version**: 2.0.0
+> **Status**: Historical migration record (pre-migration `mcp_ucx` → `ucx_hermes`).
+> For the current platform overview see [`../README.md`](../README.md) and
+> [`HERMES_INTEGRATION.md`](HERMES_INTEGRATION.md).
+> **Current runtime**: `hermes/v0.7.3` (framework spec `0.36.2`); package `mcp_server` at `platforms/hermes/`.
 > **Date**: 2026-05-02
 > **Previous**: mcp_ucx v1.22.0 (DEPRECATED)
 > **Timezone**: America/New_York
@@ -26,11 +28,11 @@ This directory (`ucx_hermes/`) is now the **sole active runtime** for the UCX MC
 | Field | Value |
 | --- | --- |
 | Canonical Name | UCX Hermes |
-| Package Directory | `ucx_hermes/` |
+| Package Directory | `platforms/hermes/` (runtime package `mcp_server`) |
 | MCP Server Name | `sdd-lifecycle` |
 | Sub-Framework Code | `ucx` (used in report naming: `BRD-03.ucx.validate.json`) |
 | Status | **Active** |
-| Version | 2.0.0 |
+| Version | `hermes/v0.7.3` (framework spec `0.36.2`) |
 | Date | 2026-05-02 |
 | Timezone | America/New_York |
 
@@ -192,7 +194,7 @@ All MCP tools resolve personas, prompts, and templates exclusively from `{projec
 
 | Asset Type | Runtime Path |
 | --- | --- |
-| Persona definitions (15 core) | `{project}/UCX/skills/personas/{persona}.md` |
+| Persona definitions (16 core) | `{project}/UCX/skills/personas/{persona}.md` |
 | Persona-to-doc-type mappings | `{project}/UCX/skills/persona_mappings.yaml` |
 | Layer alias mappings | `{project}/UCX/skills/layer_aliases/` |
 | Creation prompt templates | `{project}/UCX/prompts/templates/creation/` |
@@ -278,6 +280,7 @@ authoring policy.
 - [SPEC-008 MCP Output Schema Contracts](specs/SPEC-008_mcp_output_schema_contracts.md)
 - [SPEC-009 MCP Remediation and Fix Flow Contracts](specs/SPEC-009_mcp_remediation_and_fix_flow_contracts.md)
 - [SPEC-010 MCP Prescreen, Scan, and Scoring Contracts](specs/SPEC-010_mcp_prescreen_scan_scoring_contracts.md)
+- [SPEC-011 Team Emulator Contract](specs/SPEC-011_team_emulator_contract.md)
 
 ## 6. Policies
 
@@ -288,14 +291,13 @@ authoring policy.
 
 ## 7. Migration from mcp_ucx
 
-This section tracks migration from the legacy `mcp_ucx/` package to `ucx_hermes/`.
-
-See [migration/MIGRATION_FROM_MCP_UCX.md](migration/MIGRATION_FROM_MCP_UCX.md) for:
-
-- Path mapping (old -> new)
-- MCP configuration changes
-- What was patched and why
-- Rollback instructions
+The `mcp_ucx` → `ucx_hermes` migration is complete, and the platform has since
+migrated again into this repository's `platforms/hermes/` layout (runtime package
+`mcp_server`). The pre-migration project (pristine `ucx_framework` v0.20.4) is
+preserved on the protected, read-only branch **`legacy-ucx-v3.2-read-only`**; see
+the framework repo's `docs/PROJECT.md` §6 for change-management history. The
+former `migration/MIGRATION_FROM_MCP_UCX.md` runbook is retired (the migration it
+described has landed).
 
 ## 8. Hermes Integration
 

--- a/platforms/hermes/docs/ROADMAP.md
+++ b/platforms/hermes/docs/ROADMAP.md
@@ -12,9 +12,14 @@ Historical notes:
 - Runtime paths, commands, and operational guidance for active work are
   `ucx_hermes` references.
 
-| Field | Value |
+> **Historical snapshot (as of 2026-05-02).** The table below is a legacy
+> `ucx_hermes` release record; it is **not** the active version. The current
+> runtime is `hermes/v0.7.3` (framework spec `0.36.2`) — see the platform
+> [`CHANGELOG.md`](../CHANGELOG.md) and [`../README.md`](../README.md).
+
+| Field | Value (historical) |
 | --- | --- |
-| Current Version | **2.0.0** |
+| Current Version | **2.0.0** *(historical; now `hermes/v0.7.3`)* |
 | Latest Release | **2.0.0** (Hermes hardening: AI executor removal, bridge skill, integration doc — IPLAN-034) |
 | Previous Release | 1.22.0 (TDD/IPLAN readiness — PLAN-033) |
 | Base Release | 1.22.0 (mcp_ucx final — frozen) |

--- a/platforms/hermes/pyproject.toml
+++ b/platforms/hermes/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hermes-server"
-version = "0.1.0"
+version = "0.7.3"
 description = "MCP server for UCX Hermes SDD lifecycle workflows"
 requires-python = ">=3.12"
 dependencies = [

--- a/scripts/sync-version-refs.sh
+++ b/scripts/sync-version-refs.sh
@@ -224,6 +224,23 @@ if [[ -n "$fw_ver" ]]; then
         && log "  updated plugin README: \$ cat FRAMEWORK_SPEC_VERSION block -> $fw_ver"
     fi
 
+    # platforms/hermes/README.md quotes the framework spec version the same two
+    # ways (prose "...framework spec `X`..." + a `$ cat FRAMEWORK_SPEC_VERSION`
+    # example block). Same fix as the plugin README, mirrored here so the Hermes
+    # conformance block no longer re-drifts (HERMES-README-VERSION-DRIFT).
+    replace_in_file platforms/hermes/README.md \
+      "framework spec \`$fw_prev\`" "framework spec \`$fw_ver\`"
+    if [[ -f platforms/hermes/README.md ]]; then
+      awk -v prev="$fw_prev" -v new="$fw_ver" '
+        marker { if ($0 == prev) $0 = new; marker = 0 }
+        /^\$ cat FRAMEWORK_SPEC_VERSION$/ { marker = 1 }
+        { print }
+      ' platforms/hermes/README.md > platforms/hermes/README.md.tmp \
+        && mv platforms/hermes/README.md.tmp \
+              platforms/hermes/README.md \
+        && log "  updated hermes README: \$ cat FRAMEWORK_SPEC_VERSION block -> $fw_ver"
+    fi
+
     # The conformance test pins the expected spec version as a literal release
     # tripwire; it must track framework/VERSION. Correctness is also guarded by
     # the sibling assertEqual(..., framework_version()) and by GATE-SPEC-E008
@@ -297,6 +314,26 @@ if [[ -n "$hermes_ver" ]]; then
       "hermes/v$hermes_prev" "hermes/v$hermes_ver"
     replace_in_file docs/PARITY.md \
       "hermes/v$hermes_prev" "hermes/v$hermes_ver"
+
+    # platforms/hermes/pyproject.toml carries the bare package version, and
+    # platforms/hermes/README.md has a `$ cat VERSION` example block with the
+    # bare X.Y.Z on its own line. Neither was previously synced, so both drifted
+    # to the initial 0.1.0 (HERMES-README-VERSION-DRIFT / HERMES-REVIEW-001 H3).
+    # Sync pyproject via replace_in_file; sync the bare README line via awk,
+    # anchored to the preceding `$ cat VERSION` marker so the generic X.Y.Z is
+    # only touched inside that block.
+    replace_in_file platforms/hermes/pyproject.toml \
+      "version = \"$hermes_prev\"" "version = \"$hermes_ver\""
+    if [[ -f platforms/hermes/README.md ]]; then
+      awk -v prev="$hermes_prev" -v new="$hermes_ver" '
+        marker { if ($0 == prev) $0 = new; marker = 0 }
+        /^\$ cat VERSION$/ { marker = 1 }
+        { print }
+      ' platforms/hermes/README.md > platforms/hermes/README.md.tmp \
+        && mv platforms/hermes/README.md.tmp \
+              platforms/hermes/README.md \
+        && log "  updated hermes README: \$ cat VERSION block -> $hermes_ver"
+    fi
   fi
 fi
 


### PR DESCRIPTION
## PR-DOCS of HERMES-REVIEW-001

Second of five PRs implementing [`plans/HERMES-REVIEW-001-PLAN.md`](plans/HERMES-REVIEW-001-PLAN.md). Fixes the docs/version-drift findings (H3/H4/H5/M4/M5/M8, L6) from the 2026-07-09 four-agent Hermes review. **Docs + tooling only — no runtime behavior change.**

### Version decision

VERSION deliberately stays `0.7.3`: this PR corrects docs that had drifted to `0.1.0`/`2.0.0` so they match the already-current version, and finalizes the `0.7.3` release record (the CHANGELOG had everything bundled under `[Unreleased]`). The plan's "PATCH ×2" is realized as: PR-DOCS finalizes `0.7.3`; the next PATCH bump (`0.7.4`) is PR-CODE. Keeping VERSION unchanged also avoids the global `sed` in the sync hook rewriting PARITY historical `hermes/v` references.

### Changes (D1–D7)

| Item | Fix |
|---|---|
| D1 | `pyproject.toml` version `0.1.0` → `0.7.3` |
| D2 | `README.md` conformance block + platform-info table → real values (`VERSION` `0.7.3`, spec `0.36.2`, canonical `hermes/v*` cell) |
| D7 | README source-module count `18` → `20` (+`team_emulator`), persona count `15` → `16`, complete **27-tool** table |
| D3 | `docs/HERMES_INTEGRATION.md` — `ucx_framework/ucx_hermes` paths → `platforms/hermes` layout; `Python 3.11+` → `>=3.12`; retired `ucx_kb` KB sections repointed to engramory |
| D4 | `docs/README.md` — `2.0.0`/`ucx_hermes` self-id, dead `MIGRATION_FROM_MCP_UCX.md` link retired, `SPEC-011` added |
| D5 | `docs/ROADMAP.md` legacy `2.0.0` table marked historical |
| D6 | `CHANGELOG.md` `[0.7.3]` section cut from the bundled `[Unreleased]` |

Risk mitigation: `scripts/sync-version-refs.sh` extended to cover the Hermes `pyproject.toml` + README version blocks so they no longer re-drift (closes FRAMEWORK-TODO `HERMES-README-VERSION-DRIFT`).

### Verification

- `511` Hermes pytest + `193` conformance tests green.
- Sync-script: `bash -n` clean; ran the hook once → verified idempotent no-op on the current consistent state; awk blocks mirror the proven plugin patterns.
- Two parallel author-side adversarial reviews (docs accuracy + shared-script correctness): **both clean, no load-bearing findings**. Counts (27/20/16) verified against the live repo; all links/paths/SPEC-011 exist.