### PR TITLE
ci(secret-scan): add canon gitleaks secret-scan (PLAN-006 W4)

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,32 @@
+# Caller template for aidoc-flow-ci's reusable secret-scan workflow.
+#
+# Default config (gitleaks built-in ruleset) is sufficient for ~90%
+# of repos. Add install/templates/.gitleaks.toml to your repo only
+# if you need custom allowlists (test fixtures, docs examples).
+
+name: secret-scan
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  call:
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/secret-scan.yml@ci/v1.9.1
+    permissions:
+      contents: read
+      security-events: write
+    # Optional overrides:
+    # with:
+    #   config-path: .gitleaks.toml   # if you need custom allowlists
+    #   runner_labels: '["self-hosted", "aidoc", "ci-ephemeral"]'  # PRIVATE per OPS-0049


### PR DESCRIPTION
Populates the missing canon secret-scan (gitleaks). Verifying it passes on existing content before rollout.