### PR TITLE
ci(secret-scan): add canon gitleaks secret-scan @ci/v1.9.2 (W4)

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,16 @@
+# Caller for aidoc-flow-ci's reusable secret-scan (gitleaks binary). Canon.
+name: secret-scan
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+permissions:
+  contents: read
+  security-events: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  call:
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/secret-scan.yml@ci/v1.9.2


### PR DESCRIPTION
secret-scan via the fixed v1.9.2 (gitleaks binary). Verifying it deploys + passes.