### PR TITLE
ci(secret-scan): add canon gitleaks secret-scan (W4)

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,12 @@
+name: secret-scan
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+permissions:
+  contents: read
+  security-events: write
+jobs:
+  call:
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/secret-scan.yml@ci/v1.9.2

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -9,6 +9,4 @@ permissions:
   security-events: write
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/secret-scan.yml@ci/v1.9.2
-    with:
-      config-path: .gitleaks.toml
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/secret-scan.yml@ci/v1.9.3

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -10,3 +10,5 @@ permissions:
 jobs:
   call:
     uses: vladm3105/aidoc-flow-ci/.github/workflows/secret-scan.yml@ci/v1.9.2
+    with:
+      config-path: .gitleaks.toml

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,11 +1,5 @@
-# gitleaks configuration. Extends the default rule set; the allowlist below
-# keeps gitleaks from flagging the detect-secrets baseline (which intentionally
-# records secret *hashes*, not secrets).
 [extend]
-  useDefault = true
-
-[allowlist]
-  description = "Files allowed to contain secret-like tokens"
-  paths = [
-    '''\.secrets\.baseline$''',
-  ]
+useDefault = true
+[[allowlists]]
+description = "detect-secrets baseline (hashed placeholders / audited FPs, not live secrets)"
+paths = ['''\.secrets\.baseline$''']

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,5 +1,0 @@
-[extend]
-useDefault = true
-[[allowlists]]
-description = "detect-secrets baseline (hashed placeholders / audited FPs, not live secrets)"
-paths = ['''\.secrets\.baseline$''']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added — canon secret-scan (gitleaks) workflow (2026-07-11)
+
+Adopted the aidoc-flow-ci secret-scan gate (@ci/v1.9.2, gitleaks binary).
+
+
 ### Fixed — Framework Spec `0.37.0 → 0.37.1` — complete the GD-06 engine-token sweep + doc-staleness in `REVIEW_SAGA.md` (2026-07-11)
 
 - **Neutralized 3 engine-token leaks GD-06 missed** in


### PR DESCRIPTION
Fixed v1.9.2 secret-scan (gitleaks binary). Verifying findings.