### PR TITLE
ci: populate links workflow (@ci/v1.9.4)

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,36 @@
+# Caller for aidoc-flow-ci's reusable links workflow (@ci/v1.9.4).
+# internal = PR-blocking (offline; internal/relative links only);
+# external = weekly cron, non-blocking. See aidoc-flow-ci docs/REPO_STANDARDS §4.3.
+name: links
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  internal:
+    name: internal links (blocking)
+    if: github.event_name != 'schedule'
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/links.yml@ci/v1.9.4
+    with:
+      mode: internal
+      fail-on-error: true
+
+  external:
+    name: external links (non-blocking)
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/links.yml@ci/v1.9.4
+    with:
+      mode: external
+      fail-on-error: false

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,9 @@
+# lychee config — framework. Excludes platforms/** (deep platform/skill docs)
+# + examples/** (system-under-test corpora, maintained by framework agents,
+# never hand-edited) + tests/** from link checking. These carry pre-existing
+# internal-link debt tracked in plans/FRAMEWORK-TODO.md. The links gate covers
+# hand-maintained top-level docs (README, docs, plans, CHANGELOG, ai_dev_flow).
+# exclude_path skips those dirs as SOURCES; exclude skips durable-doc links
+# that POINT into them (e.g. CHANGELOG → examples/…).
+exclude_path = ["platforms", "examples", "tests"]
+exclude = ["/platforms/", "/examples/", "/tests/"]

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,9 +1,14 @@
-# lychee config — framework. Excludes platforms/** (deep platform/skill docs)
-# + examples/** (system-under-test corpora, maintained by framework agents,
-# never hand-edited) + tests/** from link checking. These carry pre-existing
-# internal-link debt tracked in plans/FRAMEWORK-TODO.md. The links gate covers
-# hand-maintained top-level docs (README, docs, plans, CHANGELOG, ai_dev_flow).
-# exclude_path skips those dirs as SOURCES; exclude skips durable-doc links
-# that POINT into them (e.g. CHANGELOG → examples/…).
+# lychee config — framework. Two classes of exclusion:
+#  1. platforms/** + examples/** + tests/** — deep platform/skill docs +
+#     system-under-test corpora (never hand-edited); pre-existing internal-link
+#     debt tracked as FRAMEWORK-TODO LINKS-PLATFORM-DEBT.
+#  2. cross-repo relative links (../business, ../operations, …) — resolve only
+#     in the local multi-repo workspace, never in single-repo CI. Verified by
+#     the umbrella, not per-repo CI.
 exclude_path = ["platforms", "examples", "tests"]
-exclude = ["/platforms/", "/examples/", "/tests/"]
+exclude = [
+  "/platforms/", "/examples/", "/tests/",
+  "/business/", "/operations/", "/iplanic/", "/interlog/",
+  "/engramory/", "/iplan-standard/", "/aidoc-flow-ci/",
+  "/knowledge-rag/", "/web-site/",
+]

--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -24,6 +24,24 @@
 
 ## Open
 
+### `[ci]` `LINKS-PLATFORM-DEBT` — pre-existing internal-link debt under `platforms/**` + `examples/**`
+
+- Context: 2026-07-11, aidoc-flow-ci links-workflow population (ci/v1.9.4). A
+  `lychee --offline` sweep of hand-maintained + generated docs found **248
+  broken internal links**, ~245 of them clustered in
+  `platforms/hermes/agent-skills/spec-driven-development/**` skill docs, plus a
+  few durable-doc links pointing into `examples/url-shortener/**` (a
+  regenerated system-under-test corpus that must never be hand-edited).
+- Interim: the deployed `.lychee.toml` scopes the links gate to hand-maintained
+  top-level docs via `exclude_path = ["platforms", "examples", "tests"]` (+ URL
+  excludes for links pointing into them), so the gate is green on what's
+  actually maintained. The excluded paths carry the debt.
+- Fix shape: audit the `platforms/hermes/agent-skills/**` READMEs for the
+  relocated/renamed targets (likely one systematic dir move); repair
+  durable-doc → example links or confirm the example corpus regen resolves
+  them. Then narrow the `.lychee.toml` excludes. Framework-domain remediation,
+  NOT a CI change — example artifacts are fixed by regen, never by hand.
+
 ### `[docs]` `PREPROD-HYGIENE` — extend `test_spec_hygiene` `ENGINE_TOKENS` to guard `plugin`/`SKILL`/`doc-*`
 
 - Context: pre-prod readiness audit (2026-07-11). The engine-token sweep in


### PR DESCRIPTION
Routes internal-link checking through the fixed aidoc-flow-ci reusable (`links.yml@ci/v1.9.4`), per this repo's unified-CI plan. Ships `.lychee.toml` scoping the gate to hand-maintained docs; pre-existing `platforms/**`+`examples/**` link debt (248 links) excluded + tracked as FRAMEWORK-TODO `LINKS-PLATFORM-DEBT`. 0 errors locally under the shipped config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)