### PR TITLE
ci: populate docs-sync (dry-run, @ci/v1.9.5)

### DIFF
--- a/.github/docs-sync.json
+++ b/.github/docs-sync.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://aidoc-flow.io/schemas/docs-sync-config-v1.json",
+  "version": 1,
+  "_comment": "Per-consumer docs-sync configuration. Start with dry_run: true for first 1-2 weeks per IPLAN-0018 §3.7 P3. Graduate to dry_run: false after ≥5 merges with zero proposed-vs-applied file-set divergence (per §3.1).",
+
+  "dry_run": true,
+
+  "changelog_stub": {
+    "_comment": "Stub-entry inserter — when merged commit touches trigger_paths AND CHANGELOG wasn't touched, append a stub entry under section_header. Stub is intentionally low-quality so contributors rewrite on next PR (currency, not polish).",
+    "enabled": true,
+    "trigger_paths": [".github/workflows/*.yml", "scripts/**"],
+    "destination": "CHANGELOG.md",
+    "section_header": "## [Unreleased]"
+  },
+
+  "version_sync": {
+    "_comment": "Version-string propagation — read each version_file; propagate into target files via per-consumer regex map (full regex-map design in alpha.2; alpha.1 stub does detection only).",
+    "enabled": true,
+    "sources": [
+      { "version_file": "VERSION", "targets": ["README.md"] }
+    ]
+  },
+
+  "cross_ref_repair": {
+    "_comment": "Cross-ref dead-link repair (full impl ships in alpha.2 — depends on lychee JSON output design + git-rename detection threshold).",
+    "enabled": false,
+    "rename_threshold": 50,
+    "allowed_paths": ["CHANGELOG.md", "README.md", "docs/**", "*.md"]
+  },
+
+  "allowed_paths": [
+    "CHANGELOG.md",
+    "README.md",
+    "docs/**",
+    "*.md"
+  ]
+}

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -1,0 +1,20 @@
+# Caller for aidoc-flow-ci's reusable docs-sync workflow (@ci/v1.9.5).
+# DRY-RUN rollout: computes proposed mechanical doc-fixes post-merge and
+# comments them on the PR — no push-back, no bot App needed (bot secrets are
+# only referenced by the live-mode Apply step, gated by dry_run != true).
+# Graduate to live mode (dry_run: false + aidoc-flow-bot App/secrets) per
+# IPLAN-0018 §3.7 after >=5 clean merges. Config: .github/docs-sync.json.
+name: docs-sync
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  call:
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/docs-sync.yml@ci/v1.9.5
+    secrets: inherit  # pragma: allowlist secret

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- **docs-sync workflow (dry-run)** — added `.github/workflows/docs-sync.yml` (caller of aidoc-flow-ci `docs-sync.yml@ci/v1.9.5`) + `.github/docs-sync.json`; post-merge mechanical doc-fixer in dry-run (proposes changes as a PR comment, no push-back).
+
 ### Added — canon secret-scan (gitleaks) workflow (2026-07-11)
 
 Adopted the aidoc-flow-ci secret-scan gate (@ci/v1.9.2, gitleaks binary).
-
 
 ### Fixed — Framework Spec `0.37.0 → 0.37.1` — complete the GD-06 engine-token sweep + doc-staleness in `REVIEW_SAGA.md` (2026-07-11)
 


### PR DESCRIPTION
Thin caller of aidoc-flow-ci `docs-sync.yml@ci/v1.9.5` + `.github/docs-sync.json`, per this repo's unified-CI plan. Post-merge dry-run doc-fixer — proposes changes as a PR comment, no push-back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)