### PR TITLE
fix(ci): composition permissions block (fixes startup_failure)

### DIFF
--- a/.github/workflows/composition.yml
+++ b/.github/workflows/composition.yml
@@ -21,6 +21,10 @@ on:
     # See composition-private.yml for full rationale.
     workflows: ["ai-review"]
     types: [completed]
+permissions:
+  pull-requests: read
+  contents: read
+
 jobs:
   call:
     uses: vladm3105/aidoc-flow-ci/.github/workflows/composition.yml@ci/v1.8.1


### PR DESCRIPTION
composition was `startup_failure`-ing (missing `permissions:` block under read-default token). Adds `pull-requests: read` + `contents: read`. Canon fix: aidoc-flow-ci#133; proven on iplan-standard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)