### PR TITLE
ci: re-pin aidoc-flow-ci callers to @ci/v1.9.5

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -40,7 +40,7 @@ permissions:
   issues: write          # gh api label create/apply paths
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/ai-review.yml@ci/v1.8.1
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/ai-review.yml@ci/v1.9.5
     with:
       # reviewer engine is CONFIG-DRIVEN: leave this unset and the reusable reads
       # `.reviewer` (claude|codex) from your trust-config repo's

--- a/.github/workflows/audit-trail.yml
+++ b/.github/workflows/audit-trail.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/audit-trail-check.yml@e15ec7d44234726195da316a740ad1684a2c5abd # ci/v1.6.0
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/audit-trail-check.yml@ci/v1.9.5
     with:
       runner_labels: '"ubuntu-latest"'
     permissions:

--- a/.github/workflows/auto-merge-ai-prs.yml
+++ b/.github/workflows/auto-merge-ai-prs.yml
@@ -50,7 +50,7 @@ jobs:
     # failed ai-review or composition), but this saves the runner slot
     # entirely (per OPS-0065 security-auditor recommendation).
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/auto-merge-ai-prs.yml@ci/v1.8.1
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/auto-merge-ai-prs.yml@ci/v1.9.5
     with:
       # `||` fallback per Workflow-tool expression semantics: returns
       # the first truthy operand. workflow_run path resolves the LHS;

--- a/.github/workflows/composition.yml
+++ b/.github/workflows/composition.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/composition.yml@ci/v1.8.1
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/composition.yml@ci/v1.9.5
     with:
       runner_labels: '"ubuntu-latest"'
     secrets: inherit  # pragma: allowlist secret

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -36,7 +36,7 @@ concurrency:
 
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/labeler.yml@ci/v1.8.1
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/labeler.yml@ci/v1.9.5
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -22,7 +22,7 @@ jobs:
   internal:
     name: internal links (blocking)
     if: github.event_name != 'schedule'
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/links.yml@ci/v1.9.4
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/links.yml@ci/v1.9.5
     with:
       mode: internal
       fail-on-error: true
@@ -30,7 +30,7 @@ jobs:
   external:
     name: external links (non-blocking)
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/links.yml@ci/v1.9.4
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/links.yml@ci/v1.9.5
     with:
       mode: external
       fail-on-error: false

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/pre-commit.yml@ci/v1.8.1
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/pre-commit.yml@ci/v1.9.5
     with:
       python-version: '3.12'
       # Override examples:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -9,4 +9,4 @@ permissions:
   security-events: write
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/secret-scan.yml@ci/v1.9.3
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/secret-scan.yml@ci/v1.9.5


### PR DESCRIPTION
Version-only re-pin of stale `@ci/vX.Y.Z` pins to the current canon (`ci/v1.9.5`), per the new `sync/check-pin-currency.sh` audit. Picks up all reusable fixes since the old pins. Topology preserved; SHA-pinned audit-trail converted to tag pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)