### PR TITLE
ci: bump standards-drift checkout SHA to v7.0.1

### DIFF
--- a/.github/workflows/standards-drift.yml
+++ b/.github/workflows/standards-drift.yml
@@ -14,7 +14,7 @@ jobs:
       # SHA-pinned on purpose — this job is tier=governance and curl-executes a
       # remote script below, so it holds a stricter posture than the repo's other
       # workflows (which float on actions/checkout@v7). Do not "normalize" to a tag.
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Fetch drift-check script from aidoc-flow-ci canon
         run: |
           # Pinned to the commit SHA that ci/v1.6.0 resolves to (aidoc-flow-ci@e827ab8)


### PR DESCRIPTION
The one correct hunk of the closed #330.

`.github/workflows/standards-drift.yml` is deliberately SHA-pinned — it is `tier=governance` and curl-executes a remote script, so it holds a stricter posture than the repo's six other workflows, which float on `actions/checkout@v7`. #330 rewrote all seven to `@v7.0.1`, which is correct for this file and a regression for the other six (it forfeits automatic patch pickup and diverges from the `setup-python@v6` / `codeql-action/init@v4` convention). So: #330 closed, this hunk re-landed alone.

**SHA verified:** `gh api repos/actions/checkout/git/ref/tags/v7.0.1` → `3d3c42e5aac5ba805825da76410c181273ba90b1`, `object.type = commit` — directly fetchable, unlike the annotated-tag-object pin that broke this same workflow until `e2622ee8`.

**Verification:** `yaml.safe_load` clean; the surrounding "do not normalize to a tag" comment (added in #329) is untouched and still applies.

**Audit trail:** `[skip-audit-trail]` two-signal override rather than an OPS-0065 phrase — this is a one-line mechanical pin bump with no logic edit, which OPS-0065 skip discipline case (a) covers. Asserting a multi-agent review would be false, and "Self-review skipped per founder OK" would misattribute the decision.

Expect `BLOCKED` on `call/composition` until the reviewer-App credential is restored.