### PR TITLE
ci: docs-sync permission prerequisite + D-0065 (CI PRs get CHANGELOG entries)

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -12,7 +12,22 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  # PREREQUISITE ONLY — this alone does NOT fix the failing dry-run comment.
+  #
+  # Dry-run's "Post dry-run comment" step posts to the merge's PR and needs
+  # pull-requests: write; with `read` it dies on
+  # `GraphQL: Resource not accessible by integration (addComment)` under
+  # `set -euo pipefail`. The step is gated on `proposed != 0`, so it never ran —
+  # and the workflow reported green — until a merge finally produced a proposal.
+  #
+  # But GitHub intersects caller and callee permissions for reusable workflows,
+  # and the callee (aidoc-flow-ci docs-sync.yml@ci/v1.9.5) declares
+  # `pull-requests: read` at its own workflow level. So the effective token stays
+  # `read` until THAT declaration is raised upstream and a new ci/vX.Y.Z is cut.
+  # This raise is the necessary-but-insufficient half; it pre-positions the caller
+  # so the upstream fix takes effect on re-pin without a second change here.
+  # `contents` stays `read`: dry-run never pushes, and live mode uses the bot App.
+  pull-requests: write
 
 jobs:
   call:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,38 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed — CI plumbing: `docs-sync` diagnosis + caller prerequisite (still red pending upstream), plus the CI changes that had no entry (2026-07-25)
+
+No spec or platform change (no `VERSION` bump).
+
+- **`docs-sync` has failed on every `main` push since #329, and is NOT fixed by
+  this change.** Diagnosis: dry-run mode's "Post dry-run comment" step posts to
+  the merge's PR and needs `pull-requests: write`; with `read` it dies on
+  `GraphQL: Resource not accessible by integration (addComment)` under
+  `set -euo pipefail`. The step is gated on `proposed != 0`, so it had never
+  executed and the workflow reported green from the day it landed — until a merge
+  finally produced a proposal. Latent since the workflow was added; the merges
+  only exposed it.
+  This PR raises the **caller** to `pull-requests: write`, which is necessary but
+  **not sufficient**: GitHub intersects caller and callee permissions for reusable
+  workflows, and the callee (`aidoc-flow-ci` `docs-sync.yml@ci/v1.9.5`) declares
+  `pull-requests: read` at its own workflow level, so the effective token stays
+  `read`. **The real fix is upstream** — raise it in `aidoc-flow-ci`, cut a new
+  `ci/vX.Y.Z`, re-pin here. Until then `docs-sync` stays red. The caller raise is
+  landed now so the upstream fix takes effect on re-pin without a second change.
+- **Retroactive entries for the three CI PRs that shipped without one**, per the
+  new convention in `plans/DECISIONS.md` D-0065:
+  - **#329** — held the `aidoc-flow-ci` canon at `ci/v1.9.5` with a
+    `semver-major`-scoped Dependabot `ignore` (`ci/v2.0.0` is breaking: LiteLLM
+    unification, requires `LITELLM_*` secrets this repo lacks), and fixed
+    `standards-drift.yml`, which had pinned `actions/checkout` to an annotated
+    **tag object** rather than a commit — raw.githubusercontent cannot serve one,
+    so the job had 404'd on every scheduled run.
+  - **#331** — `actions/setup-python` `v6 → v7` across four workflows. v7's only
+    removal is the `pip-install` input, unused here.
+  - **#332** — `standards-drift.yml` `actions/checkout` SHA to `v7.0.1`
+    (`3d3c42e5`), the one non-regressive hunk of the closed #330.
+
 ### Fixed — HANDOFF live-banner corrections (2026-07-25)
 
 No spec or platform change (no `VERSION` bump).

--- a/plans/DECISIONS.md
+++ b/plans/DECISIONS.md
@@ -10,6 +10,54 @@ graduation.
 
 ---
 
+## D-0065 — CI-plumbing PRs get a CHANGELOG entry (founder call, 2026-07-25); and warning-only tooling can hide a hard failure behind a gate that never fires
+
+**2026-07-25.** Two decisions from the open-PR triage session.
+
+- **CI-only PRs carry a CHANGELOG entry.** #329, #331 and #332 all landed
+  without one. The reasoning at the time was that CI plumbing has no
+  project-visible behaviour change, so an entry would be noise. The repo's own
+  `docs-sync` tooling disagreed — its `changelog_stub` op proposed a CHANGELOG
+  update after those merges — and the founder ruled for the tooling. **Rule
+  going forward: a PR that changes `.github/workflows/**`,
+  `.github/dependabot.yml`, or CI configuration gets a `[Unreleased]` entry like
+  any other change.** Rationale: the "no user-visible change" test is the wrong
+  one for this repo, where CI *is* the governance surface — #329's Dependabot
+  hold and #332's SHA pin are exactly the decisions a future session needs to
+  find without reading git log. Retroactive entries for the three PRs were added
+  in the same commit as this decision. Supersedes the inline justification in
+  #329's commit body ("No CHANGELOG entry: CI plumbing, no project-visible
+  behaviour change; …").
+- **A gated step that has never executed is untested, not working.**
+  `docs-sync` had been broken since it was added: its caller granted
+  `pull-requests: read` while the dry-run comment step needs `write`. The step is
+  gated on `proposed != 0`, so it never ran, and the workflow reported green for
+  weeks. The same shape recurred twice more in one day — `standards-drift`
+  404'ing on an annotated-tag-object pin (fixed in #329) surfaced only because
+  its output was finally read, and the `skip-audit-trail` override could not be
+  applied to an open PR because the caller does not listen for `labeled` events.
+  **When auditing CI, treat "never observed to run" as a red flag equal to
+  "observed to fail"** — check the gate conditions, not just the badge.
+- **Corollary, earned the hard way in this very commit: a caller-side permission
+  raise does not fix a reusable workflow.** The first draft of this change raised
+  the `docs-sync` caller to `pull-requests: write` and declared the bug Fixed.
+  Author-side review caught that GitHub **intersects** caller and callee
+  permissions, and the callee (`aidoc-flow-ci` `docs-sync.yml@ci/v1.9.5`) declares
+  `pull-requests: read` at its own workflow level — so the effective token would
+  have stayed `read` and the workflow would have stayed red behind a CHANGELOG
+  entry claiming otherwise. Exactly the false-green failure this decision
+  documents, reproduced while documenting it. The real fix is upstream; the caller
+  raise is kept as the necessary-but-insufficient half.
+- **Open follow-up (not in this PR — 3-surface governance cap).** The new
+  CHANGELOG rule is recorded here but contradicted where contributors will
+  actually look: `CONTRIBUTING.md`'s documents-of-record matrix has no
+  `.github/**` row, so a CI-only PR falls under `Trivial / … → (none)`; and
+  `scripts/check-docs-updated.sh` has no `.github/*` case arm, so its
+  doc-currency reminder will never fire for one. Both need updating for this rule
+  to stick — otherwise it is itself a gate that never fires.
+
+---
+
 ## D-0064 — SEED-ABSORPTION-001: three project-side decisions behind GD-08 (Part B is a regression-lock, not a template change; `realizing_layers` stays unmutated; `ACC01` is case-scoped)
 
 **2026-07-24.** Implemented the SEED-ABSORPTION-001 plan (spec-tier record is


### PR DESCRIPTION
## What this does — and explicitly does not do

`docs-sync` has failed on **every `main` push since #329**. This PR diagnoses it, records the founder decision that prompted it, and lands the caller-side half of the fix. **It does not make `docs-sync` green** — see below.

## Diagnosis

Dry-run mode's `Post dry-run comment` step posts to the merge's PR and needs `pull-requests: write`. With `read` it dies on `GraphQL: Resource not accessible by integration (addComment)` under `set -euo pipefail`.

The step is gated on `proposed != '0'`, so **it had never executed** — the workflow reported green from the day it landed. The first merge to produce a proposal (`changelog_stub: proposed update to CHANGELOG.md`, after #329/#331/#332 shipped without CHANGELOG entries) is what finally ran it. Latent since the workflow was added; the merges only exposed it.

## Why the caller-side raise is not the fix

GitHub **intersects** caller and callee permissions for reusable workflows. The callee — `aidoc-flow-ci` `docs-sync.yml@ci/v1.9.5` — declares `pull-requests: read` at its own workflow level (line 61, verified against the tag). So raising only this caller leaves the effective token at `read`.

**The real fix is upstream:** raise it in `aidoc-flow-ci`, cut a new `ci/vX.Y.Z`, re-pin here. This PR raises the caller anyway as the necessary-but-insufficient half, so the upstream fix takes effect on re-pin without a second change here. `contents` stays `read` — dry-run never pushes, and live mode uses the bot App.

## D-0065

Two records:

1. **Founder call: CI-plumbing PRs get a CHANGELOG entry.** #329/#331/#332 all shipped without one on the reasoning that CI plumbing has no project-visible change. The repo's own tooling disagreed, and the founder ruled for the tooling. Retroactive entries for all three are included.
2. **A gated step that has never executed is untested, not working.** Third instance in one day, alongside `standards-drift` 404-ing on an annotated-tag-object pin and the `skip-audit-trail` override being unappliable to an open PR.

## Author-side review (OPS-0065)

Two agents in parallel (code-reviewer + documentation-specialist), one fold cycle. **One BLOCKER, one load-bearing doc finding, one nit — all folded.**

The BLOCKER was mine: the first draft raised only the caller and declared the bug **Fixed**. That would have shipped a false "Fixed" claim for a still-red workflow — the exact false-green failure mode D-0065 documents, reproduced while documenting it. I verified the reviewer's claim independently (fetched the reusable at `ci/v1.9.5`, confirmed `pull-requests: read`) before rewriting `Fixed` → `Changed` with an explicit "still red pending upstream".

**Known gap, deliberately not fixed here.** The new CHANGELOG rule is contradicted where contributors will look: `CONTRIBUTING.md`'s documents-of-record matrix has no `.github/**` row (CI-only PRs fall under `Trivial / … → (none)`), and `scripts/check-docs-updated.sh` has no `.github/*` case arm, so its reminder will never fire for one. Both reviewers flagged it. Recorded as an open follow-up in D-0065 rather than fixed here, to stay inside the 3-surface governance-PR cap.

## Verification

`yaml.safe_load` clean · `markdownlint` clean on both docs · superseded quote checked as an exact prefix of `e2622ee8`'s body · `D-0065` confirmed the correct next number, newest-first ordering preserved.

Expect `BLOCKED` on `call/composition` as usual.