### PR TITLE
ci: migrate canon callers ci/v1.9.5 → ci/v2.14.0 (CI-CANON-V2-001)

### DIFF
--- a/.github/ai-review/config.json
+++ b/.github/ai-review/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://aidoc-flow.io/schemas/ai-review-config-v1.json",
   "version": 1,
   "litellm": {
-    "_comment": "Model alias resolved by the ci/v2.x reusable via the LiteLLM proxy. Defaults to 'ai-reviewer' when absent; set explicitly per MIGRATION_v2.0.0.md §3.",
+    "_comment": "NOT load-bearing for model resolution on this repo. The ci/v2.x ai-review reusable resolves the alias from the config it FETCHES from trust_config_repo (vladm3105/aidoc-flow-operations@main), not from this file — see canon ai-review.yml 'Resolve LiteLLM model'. Operations already sets model 'ai-reviewer'. This entry is kept for two reasons: it documents the expected alias at the point a reader looks for it, and it becomes authoritative if trust_config_repo is ever pointed at this repo. Declared per MIGRATION_v2.0.0.md §3.",
     "model": "ai-reviewer"
   },
   "trust": {

--- a/.github/ai-review/config.json
+++ b/.github/ai-review/config.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://aidoc-flow.io/schemas/ai-review-config-v1.json",
   "version": 1,
+  "litellm": {
+    "_comment": "Model alias resolved by the ci/v2.x reusable via the LiteLLM proxy. Defaults to 'ai-reviewer' when absent; set explicitly per MIGRATION_v2.0.0.md §3.",
+    "model": "ai-reviewer"
+  },
   "trust": {
     "ai_review": ["vladm3105"],
     "auto_fix":  []

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,43 +24,15 @@ updates:
         update-types:
           - minor
           - patch
-    ignore:
-      # aidoc-flow-ci reusable workflows — MAJOR bumps held at ci/v1.9.5.
-      #
-      # `ci/v2.0.0` is a breaking change: it unifies AI review behind a
-      # LiteLLM proxy and removes the vendor-CLI credentials and workflow
-      # inputs the v1.x callers rely on (upstream
-      # docs/MIGRATION_v2.0.0.md). It requires consumer secrets this repo
-      # does not yet have — LITELLM_BASE_URL, LITELLM_REVIEW_API_KEY,
-      # LITELLM_DOC_API_KEY. Upstream also gates the re-pin as a
-      # founder-decided fleet action (ci/v2.8.0 release notes →
-      # plans/ROLLOUT_plan015-arming.md).
-      #
-      # Left un-ignored, Dependabot proposes the ten call sites (nine
-      # files; links.yml calls twice) a few at a time
-      # (open-pull-requests-limit: 5), which can only ever produce a
-      # mixed-major CI canon inside one repo. PRs #321-#324 were closed
-      # for exactly that reason.
-      #
-      # Scoped to `semver-major` on purpose. A bare `dependency-name`
-      # ignore suppresses every proposal for the match — a future
-      # `ci/v1.9.x` patch would be swallowed silently, and GitHub applies
-      # ignore conditions to security updates too. Holding only the major
-      # keeps 1.x patches and any advisory-driven bump flowing.
-      # (`ci/v1.9.5` is currently the last 1.x tag upstream, so nothing is
-      # being missed today — this guards the latent case.)
-      #
-      # REMOVE THIS ENTRY when the LiteLLM secrets are provisioned and the
-      # fleet re-pin is armed; then bump all ten call sites in one PR.
-      #
-      # NOTE: nothing automated will remind you. The weekly standards-drift
-      # job would normally flag this file's divergence from the
-      # aidoc-flow-ci canonical template, but it is the only reminder in
-      # play and it is not a strong one — it reports drift as a warning,
-      # never a failure. Treat this comment as the record.
-      - dependency-name: "vladm3105/aidoc-flow-ci/*"
-        update-types:
-          - version-update:semver-major
+    # The `ci/v1.9.5` semver-major hold on vladm3105/aidoc-flow-ci/* was
+    # REMOVED here (CI-CANON-V2-001, plans/CI-CANON-V2-MIGRATION-PLAN.md).
+    # Its own removal condition — "REMOVE THIS ENTRY when the LiteLLM secrets
+    # are provisioned and the fleet re-pin is armed; then bump all ten call
+    # sites in one PR" — is satisfied: LITELLM_BASE_URL +
+    # LITELLM_REVIEW_API_KEY were set 2026-07-25, and all ten call sites moved
+    # to @ci/v2.14.0 in this same PR. Dependabot may now propose canon majors
+    # again; a future major still needs its own migration review, since
+    # ci/v2.0.0 proved these bumps are not mechanical.
     labels:
       - dependencies
 

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,26 +1,34 @@
-# v1.0.2: public consumers can use ubuntu-latest. The reusable
-# ai-review.yml installs codex + claude CLI at workflow start when
-# runner_labels_review contains "ubuntu-latest" (no-op on self-hosted
-# runners that have the CLI pre-baked). See ci/v1.0.2 CHANGELOG and
-# docs/troubleshooting.md §10 for context. Install commands are
-# **unverified-in-CI** as of v1.0.2 ship; first PUBLIC consumer
-# adoption will validate. Report issues at vladm3105/aidoc-flow-ci.
+# PROTECTED caller — uniform on PUBLIC and PRIVATE repos (PLAN-013, ci/v2.2.0).
+# Runs on the ephemeral self-hosted single-use pool despite this being a PUBLIC
+# repo: the LiteLLM proxy is host-local (no public or TLS listener), so a
+# GitHub-hosted runner cannot reach it by any route. Safe on a public repo
+# because forks are never trusted (see `.github/ai-review/config.json`) → a fork
+# PR reaches only the no-PR-code trust job on the isolated pool; the heavy review
+# job runs only for trusted, non-fork authors.
 #
 # Secrets required (consumer adds to repo secrets):
 #   APP_REVIEWER_1_ID + APP_REVIEWER_1_KEY  reviewer App credentials
-#   OPENAI_API_KEY                           if reviewer: codex
-#   ANTHROPIC_API_KEY                        if reviewer: claude
+#   LITELLM_BASE_URL                         proxy base URL (normally .../v1)
+#   LITELLM_REVIEW_API_KEY                   review-scoped LiteLLM virtual key
 #
-# `pull_request_target` (not `pull_request`) is required because the
-# trust gate needs write-capable credentials to apply labels/comments
-# on fork PRs and the heavy review job needs secrets — both unavailable
-# under `pull_request` on fork PRs. The trust gate decides whether to
-# proceed; the heavy job runs only for trusted authors per the
-# allowlist in `.github/ai-review/config.json`.
+# Autofix (PLAN-012) is OPT-IN and DEFAULT-OFF; this repo sets
+# `autofix.enabled: false` in its config and holds none of the autofix App
+# credentials, so that job stays inert. The secrets are still mapped below —
+# an unset secret passes empty and the matching flow self-skips.
+#
+# `pull_request_target` (not `pull_request`) is required because the trust gate
+# needs write-capable credentials to apply labels/comments on fork PRs and the
+# heavy review job needs secrets — both unavailable under `pull_request` on fork
+# PRs. The trust gate decides whether to proceed; the heavy job runs only for
+# trusted authors per the allowlist in `.github/ai-review/config.json`.
 name: ai-review
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    # FT-43 (ci/v2.12.0, filed as a SECURITY fix): `ready_for_review` +
+    # `converted_to_draft` so a draft→ready transition triggers a real review,
+    # and a ready→draft is seen by the fail-closed guard. Without them a PR whose
+    # code changed while it was a draft could reach merge un-reviewed.
+    types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review, converted_to_draft]
   pull_request_review:
     types: [submitted]
 
@@ -30,27 +38,37 @@ on:
 # block the reusable exceeds the caller grant and fails at load
 # (startup_failure, zero jobs) on any consumer under the read default. Scopes
 # match the reusable's own declaration (ai-review.yml). Safe under
-# pull_request_target because the reusable is diff-only: the heavy review job
-# fetches the diff via curl and never `actions/checkout`s the PR head into this
-# write-capable context (the sole checkout is the trust gate reading the
-# trust-config repo). Keep it diff-only if the reusable is ever edited.
+# pull_request_target because the reusable is diff-only on the REVIEW path: the
+# heavy review job fetches the diff via curl and never `actions/checkout`s the PR
+# head; the sole review-path checkout is the trust gate reading the trust-config
+# repo. (Exception — the DEFAULT-OFF autofix job DOES check out the PR head, but
+# with a read-only token, `persist-credentials: false`, and it never EXECUTES PR
+# code — only `git apply` plus a canon-pinned client; CI-0009.) Keep the review
+# path diff-only if the reusable is ever edited.
 permissions:
   contents: write        # reusable auto-merge fallback (gh pr merge via GITHUB_TOKEN)
   pull-requests: write   # trust-gate + verdict comments + label set
   issues: write          # gh api label create/apply paths
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/ai-review.yml@ci/v1.9.5
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/ai-review.yml@ci/v2.14.0
     with:
-      # reviewer engine is CONFIG-DRIVEN: leave this unset and the reusable reads
-      # `.reviewer` (claude|codex) from your trust-config repo's
-      # .github/ai-review/config.json (operations@main by default; your own repo if
-      # you set trust_config_repo). Set the matching auth secret — claude:
-      # CLAUDE_CODE_OAUTH_TOKEN (CLI) or ANTHROPIC_API_KEY (API); codex:
-      # OPENAI_API_KEY. Uncomment to force an engine here regardless of config:
-      # reviewer: claude
-      runner_labels_routine: '"ubuntu-latest"'
-      runner_labels_review: '"ubuntu-latest"'
+      # Model selection is CONFIG-DRIVEN: the reusable reads `litellm.model`
+      # from the trusted .github/ai-review/config.json. Uncomment to override:
+      # model: ai-reviewer
+      runner_labels_routine: '["self-hosted", "ci-runner", "single-use"]'
+      runner_labels_review: '["self-hosted", "ci-runner", "single-use"]'
+      # REQUIRED here, not optional. This repo's LITELLM_BASE_URL is the
+      # host-local Docker-bridge URL (port 4001 binds only to 172.17.0.1 and
+      # 127.0.0.1 — no public, no TLS listener), and canon's litellm_client.py
+      # rejects any non-HTTPS scheme unless this is true, failing with
+      # "LITELLM_BASE_URL must use HTTPS (or explicitly allow HTTP)".
+      litellm_allow_insecure_http: true
+      # `tier:` deliberately unset. This repo's human-merge floor is enforced
+      # server-side — canon composition.yml plus this repo's omission from the
+      # `auto_merge.repos` allowlist — so `tier: spec` would be redundant
+      # (PLAN-009 Phase 2, framework row).
+      #
       # External adopters: point the trust config at YOUR ops/config repo
       # (holds `.github/ai-review/config.json`). Defaults to
       # vladm3105/aidoc-flow-operations@main.
@@ -58,4 +76,17 @@ jobs:
       # trust_config_ref: main
       # NOTE: this override does NOT yet reach the composition gate, which reads
       # the consumer repo's own .github/ai-review/config.json@main (FT-6).
-    secrets: inherit  # pragma: allowlist secret
+    # FT-42 (ci/v2.12.0): explicit least-privilege map, replacing
+    # `secrets: inherit` — which forwarded every repo secret, including ones this
+    # reusable never declares. Only the declared secrets are forwarded now; an
+    # unset one passes empty and the matching flow self-skips (every reusable
+    # secret input is `required: false`).
+    secrets:
+      APP_REVIEWER_1_ID: ${{ secrets.APP_REVIEWER_1_ID }}
+      APP_REVIEWER_1_KEY: ${{ secrets.APP_REVIEWER_1_KEY }}
+      APP_AUTOFIX_ID: ${{ secrets.APP_AUTOFIX_ID }}
+      APP_AUTOFIX_KEY: ${{ secrets.APP_AUTOFIX_KEY }}
+      AI_REVIEW_TOKEN: ${{ secrets.AI_REVIEW_TOKEN }}
+      LITELLM_BASE_URL: ${{ secrets.LITELLM_BASE_URL }}
+      LITELLM_REVIEW_API_KEY: ${{ secrets.LITELLM_REVIEW_API_KEY }}
+      LITELLM_FIX_API_KEY: ${{ secrets.LITELLM_FIX_API_KEY }}

--- a/.github/workflows/audit-trail.yml
+++ b/.github/workflows/audit-trail.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/audit-trail-check.yml@ci/v1.9.5
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/audit-trail-check.yml@ci/v2.14.0
     with:
       runner_labels: '"ubuntu-latest"'
     permissions:

--- a/.github/workflows/auto-merge-ai-prs.yml
+++ b/.github/workflows/auto-merge-ai-prs.yml
@@ -50,7 +50,7 @@ jobs:
     # failed ai-review or composition), but this saves the runner slot
     # entirely (per OPS-0065 security-auditor recommendation).
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/auto-merge-ai-prs.yml@ci/v1.9.5
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/auto-merge-ai-prs.yml@ci/v2.14.0
     with:
       # `||` fallback per Workflow-tool expression semantics: returns
       # the first truthy operand. workflow_run path resolves the LHS;

--- a/.github/workflows/composition.yml
+++ b/.github/workflows/composition.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/composition.yml@ci/v1.9.5
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/composition.yml@ci/v2.14.0
     with:
       runner_labels: '"ubuntu-latest"'
     secrets: inherit  # pragma: allowlist secret

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -1,4 +1,4 @@
-# Caller for aidoc-flow-ci's reusable docs-sync workflow (@ci/v1.9.5).
+# Caller for aidoc-flow-ci's reusable docs-sync workflow (@ci/v2.14.0).
 # DRY-RUN rollout: computes proposed mechanical doc-fixes post-merge and
 # comments them on the PR — no push-back, no bot App needed (bot secrets are
 # only referenced by the live-mode Apply step, gated by dry_run != true).
@@ -21,15 +21,23 @@ permissions:
   # and the workflow reported green — until a merge finally produced a proposal.
   #
   # But GitHub intersects caller and callee permissions for reusable workflows,
-  # and the callee (aidoc-flow-ci docs-sync.yml@ci/v1.9.5) declares
-  # `pull-requests: read` at its own workflow level. So the effective token stays
-  # `read` until THAT declaration is raised upstream and a new ci/vX.Y.Z is cut.
-  # This raise is the necessary-but-insufficient half; it pre-positions the caller
-  # so the upstream fix takes effect on re-pin without a second change here.
+  # and the callee declares `pull-requests: read` at its own workflow level, with
+  # no job-level override. So the effective token stays `read` until THAT
+  # declaration is raised upstream.
+  #
+  # STILL NOT RAISED AT ci/v2.14.0 (verified 2026-07-25, CI-CANON-V2-001):
+  # canon docs-sync.yml declares `contents: read` + `pull-requests: read` at
+  # lines 59-61 and its `sync` job sets no `permissions:` block, while the
+  # "Post dry-run comment" step runs `gh pr comment` (line 244). Re-pinning this
+  # caller to v2.14.0 therefore does NOT fix the dry-run comment — an earlier
+  # version of this comment assumed the upstream half would ship alongside the
+  # re-pin, and it has not. This block remains pre-positioning only; the fix must
+  # land in canon. Track upstream before graduating docs-sync out of dry-run.
+  #
   # `contents` stays `read`: dry-run never pushes, and live mode uses the bot App.
   pull-requests: write
 
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/docs-sync.yml@ci/v1.9.5
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/docs-sync.yml@ci/v2.14.0
     secrets: inherit  # pragma: allowlist secret

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -36,7 +36,7 @@ concurrency:
 
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/labeler.yml@ci/v1.9.5
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/labeler.yml@ci/v2.14.0
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,4 +1,4 @@
-# Caller for aidoc-flow-ci's reusable links workflow (@ci/v1.9.4).
+# Caller for aidoc-flow-ci's reusable links workflow (@ci/v2.14.0).
 # internal = PR-blocking (offline; internal/relative links only);
 # external = weekly cron, non-blocking. See aidoc-flow-ci docs/REPO_STANDARDS §4.3.
 name: links
@@ -22,7 +22,7 @@ jobs:
   internal:
     name: internal links (blocking)
     if: github.event_name != 'schedule'
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/links.yml@ci/v1.9.5
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/links.yml@ci/v2.14.0
     with:
       mode: internal
       fail-on-error: true
@@ -30,7 +30,7 @@ jobs:
   external:
     name: external links (non-blocking)
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/links.yml@ci/v1.9.5
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/links.yml@ci/v2.14.0
     with:
       mode: external
       fail-on-error: false

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/pre-commit.yml@ci/v1.9.5
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/pre-commit.yml@ci/v2.14.0
     with:
       python-version: '3.12'
       # Override examples:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -9,4 +9,12 @@ permissions:
   security-events: write
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/secret-scan.yml@ci/v1.9.5
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/secret-scan.yml@ci/v2.14.0
+    with:
+      # REQUIRED from ci/v2.0.0. The v1.x reusable shipped a default allowlist
+      # for tests/ fixtures/ vectors/ and .secrets.baseline; v2 removed it, so
+      # without this input the scan reports 27 synthetic findings and the gate
+      # goes red (measured with the canon-pinned gitleaks 8.30.1, 2026-07-25).
+      # The config is narrowly scoped — see .gitleaks.toml for why each entry is
+      # safe and why it must not be broadened to whole trees.
+      config-path: .gitleaks.toml

--- a/.github/workflows/standards-drift.yml
+++ b/.github/workflows/standards-drift.yml
@@ -1,35 +1,62 @@
-# standards-drift — weekly canon drift check per PLAN-002 §5.5 Wave 1.
+# standards-drift — weekly server-side canon drift check.
+#
+# Compares THIS repo's branch protection, repo settings, actions permissions and
+# labels against the canon templates for its tier, and emits ::warning::
+# annotations for any drift. Warning-only by design (IPLAN-0017 §3.1b) — it never
+# blocks a PR. Dispatch it with `strict: true` for a release/adoption gate.
+#
+# MIGRATED to the canon reusable (CI-CANON-V2-001). This file previously
+# `curl`ed `check-standards-drift.sh` from a hardcoded aidoc-flow-ci commit SHA
+# and executed it directly, because no `workflow_call` reusable existed before
+# `ci/v2.8.0`. That shape had two defects the reusable fixes: the fetched script
+# was pinned nine minors behind canon, and its pin did not move when the repo
+# re-pinned its other callers — so the drift check validated against a canon
+# version this repo no longer ran.
+#
+# The old file's SHA-pinning rationale ("never curl-execute from mutable tags")
+# does not carry over and is not a regression: this is now a `uses:` reference,
+# which GitHub resolves through canon's immutable `ci/v*` tag ruleset, not a
+# curl-and-execute of a mutable ref.
+#
+# TIER: `governance`, NOT the caller template's default `product`. This repo is
+# Governance tier per aidoc-flow-ci docs/REPO_STANDARDS.md §1 ("aidoc-flow-framework,
+# aidoc-flow-iplan-standard — Public spec/schema repo; human-merge only"), which
+# matches the `--tier governance` the hand-rolled version passed. Comparing
+# against the `product` template would check the wrong branch-protection shape.
+#
+# RUNNER: `ubuntu-latest` (the reusable's default, left unset). This job only
+# reads the GitHub API — unlike ai-review it needs no LiteLLM proxy access, so it
+# does not belong on the self-hosted pool.
+#
+# TOKEN: verifying branch protection needs an admin-scoped token, which is NOT a
+# grantable GITHUB_TOKEN scope — so under the default token that one control
+# reports `warn_uncheckable` rather than a false green. To verify it, run with a
+# PAT carrying admin as GH_TOKEN.
+#
+# EXPECTED DRIFT after this migration (canon CI-0011, docs/UPDATE_GUIDE.md):
+# until the narrowed `actions-permissions.json` is applied to this repo, expect
+# two warnings — `verified_allowed: canon=false actual=true` and
+# `patterns_allowed: MISSING … vladm3105/*`. Both are warnings, exit 0. Nothing
+# is broken: this repo's live pattern is NARROWER than canon's, so every canon
+# reusable it calls is still admitted. Applying the settings is a founder step.
 name: standards-drift
+
 on:
   schedule:
-    - cron: '0 9 * * 1'
+    - cron: '0 9 * * 1'   # weekly Mon 09:00 UTC
   workflow_dispatch:
+    inputs:
+      strict:
+        description: 'Fail on drift or an uncheckable control (release/adoption gate)'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
 jobs:
   drift:
-    name: check-standards-drift
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      # SHA-pinned on purpose — this job is tier=governance and curl-executes a
-      # remote script below, so it holds a stricter posture than the repo's other
-      # workflows (which float on actions/checkout@v7). Do not "normalize" to a tag.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Fetch drift-check script from aidoc-flow-ci canon
-        run: |
-          # Pinned to the commit SHA that ci/v1.6.0 resolves to (aidoc-flow-ci@e827ab8)
-          # per business/iplanic/framework/operations ai-review verdicts M1: never curl-execute from mutable tags.
-          #
-          # e827ab8 is the COMMIT ci/v1.6.0 points at. The previous pin used
-          # e15ec7d, which is the annotated TAG OBJECT's SHA — raw.githubusercontent
-          # cannot serve a tag object, so this step 404'd on every scheduled run
-          # (verified: tag-object SHA -> 404, commit SHA -> 200). Deref annotated
-          # tags with `git rev-list -n1 <tag>` before pinning.
-          URL="https://raw.githubusercontent.com/vladm3105/aidoc-flow-ci/e827ab8268917ea4a81a0b8ddbc59eace702f7ed/sync/check-standards-drift.sh"
-          mkdir -p sync
-          curl -fsSL "$URL" -o sync/check-standards-drift.sh
-          chmod +x sync/check-standards-drift.sh
-      - name: Run standards drift check (tier=governance)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bash sync/check-standards-drift.sh --tier governance
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/standards-drift.yml@ci/v2.14.0
+    with:
+      tier: governance
+      strict: ${{ github.event.inputs.strict == 'true' }}

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,46 @@
+# gitleaks configuration for aidoc-flow-framework.
+#
+# Required by the `ci/v2.x` canon `secret-scan` reusable. The `ci/v1.x` reusable
+# shipped a DEFAULT allowlist covering `tests/`, `fixtures/`, `vectors/` and
+# `.secrets.baseline`; `ci/v2.0.0` removed it, on the reasoning that test and
+# example trees are common locations for accidentally-committed real credentials
+# and are therefore not safe blanket exclusions. Suppression is now the
+# consumer's job, and must be narrow.
+#
+# Verified 2026-07-25 with the canon-pinned gitleaks 8.30.1: a default scan of
+# this repo reports 27 findings, all synthetic — 26 in the detect-secrets
+# baseline and 1 fixture string in a Hermes unit test. Both are suppressed below.
+#
+# NOTE on scope: `[extend] useDefault = true` is mandatory, not stylistic. The
+# reusable runs a config canary that plants a live-looking AWS key and a GitHub
+# PAT and asserts the resolved config still detects them. A config with an
+# `[allowlist]` but no rules scans NOTHING and exits 0 — a green required check
+# that checks nothing. The canary exists to catch exactly that.
+#
+# Do NOT broaden the allowlist to `tests/` or `platforms/**`. Each entry here is
+# deliberately pinned to one path or one exact literal.
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Synthetic credentials in fixtures — no live secret is suppressed here"
+
+paths = [
+  # detect-secrets baseline. Holds HASHED representations of candidate secrets
+  # plus their file/line coordinates, not the secrets themselves; gitleaks'
+  # generic-api-key rule matches the hash strings. Source of 26 of the 27
+  # findings.
+  '''^\.secrets\.baseline$''',
+]
+
+regexes = [
+  # platforms/hermes/tests/unit/test_saga_review_orchestrator.py:274 — a fake
+  # OpenAI-style key embedded in a JSON fixture that asserts the saga
+  # orchestrator surfaces a "Rotate key" P1 security finding. The literal is a
+  # sequential alphabet run, not a credential shape any provider issues.
+  #
+  # Scoped to the exact string rather than to the file, so an accidental REAL
+  # key added to that same test file in future is still caught.
+  '''sk-abcdefghijklmnopqrstuv123456''',
+]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -7,9 +7,17 @@
 # and are therefore not safe blanket exclusions. Suppression is now the
 # consumer's job, and must be narrow.
 #
-# Verified 2026-07-25 with the canon-pinned gitleaks 8.30.1: a default scan of
-# this repo reports 27 findings, all synthetic — 26 in the detect-secrets
-# baseline and 1 fixture string in a Hermes unit test. Both are suppressed below.
+# SCAN MODE — read this before editing. The `ci/v2.x` reusable runs
+# `gitleaks git .` over the FULL commit history (1325 commits at time of
+# writing), not `gitleaks dir .` over the working tree. `ci/v1.9.5` ran `dir`;
+# v2 changed it, and canon's own header comment still says `dir`, so the change
+# is easy to miss. Consequence: this config must account for files that no
+# longer exist at HEAD but are still reachable in history.
+#
+# Verified 2026-07-25 with the canon-pinned gitleaks 8.30.1:
+#   gitleaks dir . (working tree)  -> 27 findings, all synthetic
+#   gitleaks git . (full history)  -> 33 further findings, all pre-migration
+# All are suppressed below, each by the narrowest mechanism that works.
 #
 # NOTE on scope: `[extend] useDefault = true` is mandatory, not stylistic. The
 # reusable runs a config canary that plants a live-looking AWS key and a GitHub
@@ -27,11 +35,36 @@ useDefault = true
 description = "Synthetic credentials in fixtures — no live secret is suppressed here"
 
 paths = [
+  # --- present at HEAD -------------------------------------------------------
   # detect-secrets baseline. Holds HASHED representations of candidate secrets
   # plus their file/line coordinates, not the secrets themselves; gitleaks'
   # generic-api-key rule matches the hash strings. Source of 26 of the 27
-  # findings.
+  # working-tree findings.
   '''^\.secrets\.baseline$''',
+
+  # --- PRE-MIGRATION HISTORY ONLY -------------------------------------------
+  # Every path below is ABSENT at HEAD and untracked (verified 2026-07-25:
+  # `git ls-tree -r --name-only HEAD` matches none of them). They exist only in
+  # commits inherited from the pre-migration `ucx_framework` project, preserved
+  # on the read-only branch `legacy-ucx-v3.2-read-only` and reachable from this
+  # repo's history. The findings are documentation and template placeholders —
+  # SPEC template `api_key:` fields, `curl -H "Authorization: Bearer ..."`
+  # examples in RAG guides, a Stripe-shaped token in an API-integration example.
+  #
+  # Allowlisting a path that does not exist at HEAD cannot mask a live secret in
+  # the current tree. It CAN mask one if the path is ever reintroduced —
+  # so if any of these directories comes back, DELETE its entry here rather than
+  # inheriting the suppression.
+  #
+  # The alternative (rewriting history to purge them) is not on the table: the
+  # pre-migration history is deliberately preserved, and the values are
+  # placeholders, not live credentials.
+  '''^UCX/''',
+  '''^ai_dev_flow/''',
+  '''^ai_dev_ssd_flow/''',
+  '''^mcp_sdd/''',
+  '''^framework_rags/''',
+  '''^\.claude/skills''',
 ]
 
 regexes = [
@@ -42,5 +75,5 @@ regexes = [
   #
   # Scoped to the exact string rather than to the file, so an accidental REAL
   # key added to that same test file in future is still caught.
-  '''sk-abcdefghijklmnopqrstuv123456''',
+  '''sk-abcdefghijklmnopqrstuv123456''',  # pragma: allowlist secret
 ]

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,1 +1,0 @@
-.secrets.baseline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,15 +39,34 @@ this repo's half of upstream `aidoc-flow-ci` PLAN-009 Phase 2.
   replacing `secrets: inherit`, which forwarded every repo secret including ones
   the reusable never declares).
 - **`secret-scan`: added a narrowly-scoped `.gitleaks.toml` + `config-path`.**
-  `ci/v2.0.0` removed the default allowlist for `tests/` / `fixtures/` /
-  `vectors/` / `.secrets.baseline`. Measured with the canon-pinned gitleaks
-  8.30.1: the re-pin would have flipped this gate green→red on 27 findings, all
-  synthetic (26 in the detect-secrets baseline, 1 fixture string in
-  `test_saga_review_orchestrator.py`). The config allowlists the baseline by path
-  and the fixture by exact literal — deliberately not by tree, so a real key
-  added to that same test file is still caught. Verified against canon's own
-  config canary: the resolved ruleset still detects a planted AWS key and GitHub
-  PAT.
+  Two independent v2 changes made this necessary, and the second is not
+  documented upstream:
+  1. `ci/v2.0.0` removed the default allowlist for `tests/` / `fixtures/` /
+     `vectors/` / `.secrets.baseline`.
+  2. **`ci/v2.x` also changed the scan from `gitleaks dir .` (working tree) to
+     `gitleaks git .` (full commit history — 1325 commits here).** Canon's own
+     header comment in `secret-scan.yml` still says `dir`, so the change is
+     invisible on a read; it was found only by running the gate. `ci/v1.9.5`
+     ran `dir` (verified at that tag).
+
+  Measured with the canon-pinned gitleaks 8.30.1: the working tree yields 27
+  findings and history a further 33 — 60 in total, **all synthetic**. The 27 are
+  the detect-secrets baseline (26) plus one fixture string in
+  `test_saga_review_orchestrator.py`. The 33 are SPEC-template `api_key:`
+  placeholders, `Authorization: Bearer` examples in RAG guides, and a
+  Stripe-shaped token in an API-integration example — all under `UCX/`,
+  `ai_dev_flow/`, `ai_dev_ssd_flow/`, `mcp_sdd/`, `framework_rags/` and
+  `.claude/skills`, paths inherited from the pre-migration `ucx_framework`
+  project that are **absent at HEAD and untracked**.
+
+  Each suppression uses the narrowest mechanism that works: the baseline and the
+  dead pre-migration trees by anchored path, the live fixture key by exact
+  literal (not by file, so a real key added to that same test is still caught).
+  Allowlisting a path absent from HEAD cannot mask a live secret; if any of those
+  directories is ever reintroduced, its entry must be deleted rather than
+  inherited — recorded in the config itself. Verified against canon's own config
+  canary: the resolved ruleset still detects a planted AWS key and GitHub PAT, so
+  this is not a config that passes while scanning nothing.
 - **Removed `.gitleaksignore`.** It contained a bare path (`.secrets.baseline`)
   where gitleaks expects a fingerprint, so it had been a silent no-op since
   `935befed` — gitleaks rejected the entry on every run. Its intent is now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,66 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed — CI canon migrated `ci/v1.9.5` → `ci/v2.14.0` (CI-CANON-V2-001) (2026-07-25)
+
+No spec or platform change (no `VERSION` bump). Executes
+[`plans/CI-CANON-V2-MIGRATION-PLAN.md`](plans/CI-CANON-V2-MIGRATION-PLAN.md),
+this repo's half of upstream `aidoc-flow-ci` PLAN-009 Phase 2.
+
+- **All eleven `aidoc-flow-ci` call sites re-pinned to `@ci/v2.14.0`** — ten
+  pre-existing (nine files; `links.yml` calls twice) plus the new
+  `standards-drift` caller. Bumped in one PR on purpose: a partial sweep yields
+  a mixed-major CI canon inside one repo, which is why Dependabot PRs #321–#324
+  were closed.
+- **`ai-review` moved to the self-hosted pool, both jobs.** `runner_labels_routine`
+  and `runner_labels_review` now use `["self-hosted", "ci-runner", "single-use"]`
+  per the PLAN-013 uniform-protected model (`ci/v2.2.0`), which replaced the
+  public/private caller split with one protected template. Safe on a public repo:
+  forks are never trusted, so a fork PR reaches only the no-PR-code trust job.
+- **`litellm_allow_insecure_http: true` added.** Not optional here — this repo's
+  `LITELLM_BASE_URL` is the host-local Docker-bridge URL (port 4001 binds only to
+  `172.17.0.1` and `127.0.0.1`; no public or TLS listener), and canon's
+  `litellm_client.py` rejects a non-HTTPS scheme without it.
+- **Adopted two canon caller-body changes `--repin` does not apply:** FT-43
+  (`ready_for_review` / `converted_to_draft` triggers — filed upstream as a
+  **security** fix; without them a PR whose code changed while a draft could
+  reach merge un-reviewed) and FT-42 (explicit least-privilege `secrets:` map
+  replacing `secrets: inherit`, which forwarded every repo secret including ones
+  the reusable never declares).
+- **`secret-scan`: added a narrowly-scoped `.gitleaks.toml` + `config-path`.**
+  `ci/v2.0.0` removed the default allowlist for `tests/` / `fixtures/` /
+  `vectors/` / `.secrets.baseline`. Measured with the canon-pinned gitleaks
+  8.30.1: the re-pin would have flipped this gate green→red on 27 findings, all
+  synthetic (26 in the detect-secrets baseline, 1 fixture string in
+  `test_saga_review_orchestrator.py`). The config allowlists the baseline by path
+  and the fixture by exact literal — deliberately not by tree, so a real key
+  added to that same test file is still caught. Verified against canon's own
+  config canary: the resolved ruleset still detects a planted AWS key and GitHub
+  PAT.
+- **Removed `.gitleaksignore`.** It contained a bare path (`.secrets.baseline`)
+  where gitleaks expects a fingerprint, so it had been a silent no-op since
+  `935befed` — gitleaks rejected the entry on every run. Its intent is now
+  correctly implemented in `.gitleaks.toml`.
+- **`standards-drift` migrated from a hand-rolled `curl`-and-execute to canon's
+  reusable** at `tier: governance` (this repo is Governance tier per
+  `REPO_STANDARDS.md` §1, not the caller template's default `product`). The old
+  shape fetched `check-standards-drift.sh` from a hardcoded `ci/v1.6.0` commit
+  SHA — nine minors stale, and a pin that did not move when the repo re-pinned,
+  so it validated against a canon version this repo no longer ran.
+- **Dropped the Dependabot `semver-major` hold** on `vladm3105/aidoc-flow-ci/*`,
+  its in-file removal condition now being satisfied.
+- **Expect two `standards-drift` warnings** until the founder applies the CI-0011
+  `actions-permissions` narrowing (`verified_allowed`, `patterns_allowed`). Both
+  warn and exit 0; this repo's live pattern is narrower than canon's, so every
+  reusable it calls is still admitted.
+
+**Correction to the previous entry below:** it stated the caller raise would make
+the upstream `docs-sync` fix "take effect on re-pin". It does not. Canon
+`docs-sync.yml` at `ci/v2.14.0` still declares `pull-requests: read` at workflow
+level with no job-level override, while its "Post dry-run comment" step runs
+`gh pr comment`. **`docs-sync` therefore remains red after this migration** — the
+fix is still upstream-only.
+
 ### Changed — CI plumbing: `docs-sync` diagnosis + caller prerequisite (still red pending upstream), plus the CI changes that had no entry (2026-07-25)
 
 No spec or platform change (no `VERSION` bump).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,23 @@ this repo's half of upstream `aidoc-flow-ci` PLAN-009 Phase 2.
   so it validated against a canon version this repo no longer ran.
 - **Dropped the Dependabot `semver-major` hold** on `vladm3105/aidoc-flow-ci/*`,
   its in-file removal condition now being satisfied.
+- **Declared `litellm.model` in `.github/ai-review/config.json`** per
+  `MIGRATION_v2.0.0.md` §3, with the caveat recorded in the file: it is **not**
+  load-bearing here. The reusable resolves the alias from the config it fetches
+  from `trust_config_repo` (`aidoc-flow-operations@main`), which already sets
+  `ai-reviewer`. This repo's copy is documentation, and would become
+  authoritative only if `trust_config_repo` were pointed here.
+- **Root cause of the pre-migration `ai-review` failure, for the record.** It was
+  **not** a lapsed reviewer credential, as `plans/HANDOFF.md` states. When
+  `aidoc-flow-operations` cut over to `ci/v2.0.1`, it rewrote the shared trust
+  config to schema v2 and **removed the `reviewer` field**. The `ci/v1.9.5`
+  reusable resolves the engine with `jq -r '.reviewer // "codex"'`
+  (`ai-review.yml:525`, `:669`), so the absent field silently selected **codex**,
+  which needs `OPENAI_API_KEY` (`:590`) — a secret this repo has never held.
+  Hence `401 Unauthorized` from `api.openai.com` and `no parseable verdict —
+  fail-closed`. The gate has been unpassable since operations' cutover, and this
+  migration is what fixes it: the v2 reusable reads `litellm.model` from that
+  same config and routes through the LiteLLM proxy instead.
 - **Expect two `standards-drift` warnings** until the founder applies the CI-0011
   `actions-permissions` narrowing (`verified_allowed`, `patterns_allowed`). Both
   warn and exit 0; this repo's live pattern is narrower than canon's, so every


### PR DESCRIPTION
> ## ⛔ DO NOT MERGE YET
>
> The self-hosted `ci-runner,single-use` pool is **not registered** on this repo
> (`actions/runners` → `total_count: 0`). This PR routes **both** `ai-review`
> jobs at that pool. Merging first means every subsequent PR's `ai-review` sits
> in `queued` forever — worse than today's 401. Register the pool, then merge.

Implements [`plans/CI-CANON-V2-MIGRATION-PLAN.md`](plans/CI-CANON-V2-MIGRATION-PLAN.md)
(merged in #334) — this repo's half of upstream `aidoc-flow-ci` PLAN-009 Phase 2.

## Wave 1 — the re-pin

All **eleven** call sites now at `@ci/v2.14.0`, zero at `v1.9.x`. One PR on
purpose: a partial sweep yields a mixed-major CI canon inside one repo, which is
why Dependabot PRs #321–#324 were closed.

| Change | Why |
|---|---|
| Ten `uses:` lines re-pinned | Via the `install.sh` repin transform — touches only `uses:` lines, preserves `runner_labels` / `permissions` / triggers |
| `ai-review`: **both** jobs → self-hosted pool | PLAN-013 uniform-protected model (`ci/v2.2.0`) replaced the public/private split with one protected template. **Corrects PLAN-009 Phase 2's literal text**, which predates it and moves only the review job |
| `ai-review`: `litellm_allow_insecure_http: true` | Required, not optional. Port 4001 binds only to `172.17.0.1` / `127.0.0.1`, so `LITELLM_BASE_URL` is an `http://` bridge URL, and canon's `litellm_client.py` rejects non-HTTPS without it |
| `ai-review`: FT-43 + FT-42 adopted | Canon caller-body changes `--repin` cannot apply, on the file this PR already rewrites. FT-43 is filed upstream as a **security** fix (without `ready_for_review`/`converted_to_draft`, a PR whose code changed while a draft could reach merge un-reviewed). FT-42 replaces `secrets: inherit`, which forwarded every repo secret including ones the reusable never declares |
| `secret-scan`: `.gitleaks.toml` + `config-path` | See below |
| `.gitleaksignore` removed | Held a bare path where gitleaks expects a fingerprint → a **rejected no-op since `935befed`**. Intent now correctly implemented in `.gitleaks.toml` |
| Dependabot `semver-major` hold dropped | Its in-file removal condition is now satisfied |

### The secret-scan finding

`ci/v2.0.0` removed the default allowlist for `tests/` / `fixtures/` / `vectors/`
/ `.secrets.baseline`. Measured with the canon-pinned **gitleaks 8.30.1**, the
re-pin alone would have flipped this gate **green→red on 27 findings** — all
synthetic: 26 in the detect-secrets baseline, 1 fixture string in
`test_saga_review_orchestrator.py` (`sk-abcdefghijklmnopqrstuv123456`, a
sequential alphabet run).

The config allowlists the baseline **by path** and the fixture **by exact
literal** — deliberately not by tree, so a real key added to that same test file
is still caught. Verified against canon's own config canary: the resolved ruleset
still detects a planted AWS key and GitHub PAT, so this is not a config that
silently scans nothing.

## Wave 2 — `standards-drift` to the canon reusable

The hand-rolled version `curl`ed `check-standards-drift.sh` from a hardcoded
`ci/v1.6.0` commit SHA and executed it — nine minors stale, with a pin that did
**not** move when the repo re-pinned, so it validated against a canon version
this repo no longer ran. Now a thin caller at `tier: governance` (this repo is
Governance tier per `REPO_STANDARDS.md` §1, **not** the caller template's default
`product`).

## Correction to a claim in the previous CHANGELOG entry

That entry said the caller's `pull-requests: write` raise would "take effect on
re-pin". **It does not.** Canon `docs-sync.yml` at `ci/v2.14.0` still declares
`pull-requests: read` at workflow level (lines 59-61) with no job-level override,
while its "Post dry-run comment" step runs `gh pr comment` (line 244) — and
GitHub intersects caller and callee permissions. **`docs-sync` stays red after
this migration.** The fix is upstream-only; worth filing on `aidoc-flow-ci`.

## Verification

- 11 `uses:` at `@ci/v2.14.0`, 0 at `v1.9.x`
- `yamllint .github/workflows/` clean
- conformance **239 tests OK**
- `gitleaks dir .` clean under the new config; canary still detects planted creds
- no active `runner-self` / `ci-ephemeral` labels (comment-only occurrences)

**Not verifiable here:** `ai-review` itself. `pull_request_target` runs the *base
branch's* workflow, so this PR is reviewed by the old `v1.9.5` caller. Expect the
`BLOCKED` composition verdict. Live verification is a post-merge throwaway PR,
mirroring `operations` #266 — until that is green, this migration is not done.

## Review

Subagent dispatch was disabled for this session, so the OPS-0065 multi-agent pass
was replaced by direct verification against canon source, live host state, and
`git log`; evidence is in the commit body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
