### PR TITLE
test: throwaway probe — verify ai-review v2 end-to-end (CI-CANON-V2-001)

### DIFF
--- a/tmp/AI-REVIEW-V2-PROBE.md
+++ b/tmp/AI-REVIEW-V2-PROBE.md
@@ -1,0 +1,5 @@
+# ai-review v2 verification probe
+
+Temporary file for CI-CANON-V2-001 post-merge verification of the
+ci/v2.14.0 ai-review path (pool routing + LiteLLM reachability).
+This PR is closed without merging once the gate reports a verdict.


### PR DESCRIPTION
> **Throwaway. Do not merge.** Closed once the `ai-review` gate reports a verdict.

Post-merge verification for CI-CANON-V2-001 (#335). A green migration PR proved
only that the YAML parses — #335 was itself reviewed by the *old* `v1.9.5`
caller, because `pull_request_target` runs the base branch's workflow. This is
the first PR whose base carries the `@ci/v2.14.0` callers, so it is the first
real exercise of the v2 path.

**What this is testing**

1. Both `ai-review` jobs schedule on the self-hosted pool (`self-hosted`,
   `ci-runner`, `single-use`) rather than queueing forever.
2. The review job reaches the host-local LiteLLM proxy over the `http://`
   Docker-bridge URL, i.e. `litellm_allow_insecure_http: true` is doing its job.
3. The reviewer returns a **parseable verdict** — replacing the
   `no parseable verdict — fail-closed` that v1.9.5 produced, caused by the
   shared trust config going schema-v2 and the v1 reusable silently falling back
   to codex with no `OPENAI_API_KEY`.
4. `composition` can then see a counting reviewer-App approval at head.

Either verdict (`approve` or `request_changes`) counts as success — the question
is whether the reviewer *runs and answers*.

**Result: all four confirmed.** `call / ai-review` pass, `call / composition`
pass (first success in ~9 days), both jobs on the pool, `ai:review-passed`
applied. One fix was needed mid-verification: `LITELLM_BASE_URL` was loopback,
unreachable from inside the runner container; corrected to the Docker-bridge
address.
