### PR TITLE
docs: record CI-CANON-V2-001 outcome + correct two wrong root causes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,13 +285,34 @@ future company projects; it ships independently semver-tagged
 `ops/iplans/IPLAN-0017_unified-ci-flows.md` +
 `ops/iplans/IPLAN-0017-CHARTER_aidoc-flow-ci.md`.
 
-**Per-repo state (2026-06-22):** **public repo; GitHub-hosted runners
-(per "## CI host policy" — do not self-host).** Current standalone
-`.github/workflows/ai-review.yml` is LIVE (codex reviewer). Migrates
-to `uses: aidoc-flow-ci/...@ci/v1.0.0` in **Phase A** of IPLAN-0017
-rollout — the eat-our-own-dogfood proof point (smallest cost; public-repo
-iteration speed; fork-safe `pull_request` trigger). 🔴 Phase 0 (founder
-creates `aidoc-flow-ci` repo) is the prerequisite.
+**Per-repo state (2026-07-25):** **public repo, but NOT purely
+GitHub-hosted.** All eleven `aidoc-flow-ci` call sites are pinned
+`@ci/v2.14.0` (CI-CANON-V2-001; plan `plans/CI-CANON-V2-MIGRATION-PLAN.md`,
+PRs #334/#335; decisions `plans/DECISIONS.md` D-0066).
+
+Runner split — deliberate, do not "normalize":
+
+- **`ai-review` runs entirely on the self-hosted single-use pool**
+  (`["self-hosted", "ci-runner", "single-use"]`, **both** the trust and
+  review jobs) per the PLAN-013 uniform-protected model. It has to: the
+  LiteLLM proxy is host-local with no public or TLS listener, so a
+  GitHub-hosted runner cannot reach it. Safe on a public repo because forks
+  are never trusted, so a fork PR reaches only the no-PR-code trust job.
+  The caller also sets `litellm_allow_insecure_http: true` — the bridge URL
+  is `http://`, and canon's client refuses non-HTTPS without it.
+- **Everything else stays on `ubuntu-latest`**, including the
+  fork-code-executing lint callers (`links`, `pre-commit`).
+
+Two operational facts that cost a session when unrecorded:
+
+- **`LITELLM_BASE_URL` must be the Docker-bridge address**
+  (`http://172.17.0.1:4001/v1`), never loopback — jobs run inside a
+  container, where `localhost` is the container. LiteLLM publishes host
+  4001 → container 4000, and is a different service from `llm_router`.
+- **`secret-scan` at v2 scans full git history** (`gitleaks git`), not the
+  working tree (`gitleaks dir`, which is what canon's own header comment
+  still claims). Validate locally with `git`, or a clean local run will
+  still fail CI. Suppressions live in `.gitleaks.toml`.
 
 ### Local overrides shared — the foundational rule
 

--- a/plans/DECISIONS.md
+++ b/plans/DECISIONS.md
@@ -10,6 +10,81 @@ graduation.
 
 ---
 
+## D-0066 — CI canon migration: target the latest tag, not the plan's; and a shared trust config makes a partial fleet migration a breaking change
+
+**2026-07-25.** Four decisions from executing CI-CANON-V2-001
+(`plans/CI-CANON-V2-MIGRATION-PLAN.md`, PRs #334/#335).
+
+- **Target `ci/v2.14.0`, not PLAN-009's `ci/v2.8.0`.** Upstream's fleet-cutover
+  plan names `v2.8.0`, but that banner dates to 2026-07-18 and canon has since
+  shipped six further minors; `v2.14.0` is the current `Latest` and the tag
+  canon's own install templates reference. Re-pinning to the plan's literal
+  target would have required an immediate second bump. **Rule: a plan naming a
+  version target is naming it as of its writing date — re-resolve against
+  `Latest` at execution time, and record the deviation rather than following the
+  stale number.**
+
+- **Where upstream plan text conflicts with upstream source, source wins.**
+  PLAN-009 Phase 2's Edit F says to move only `ai-review`'s heavy *review* job
+  to the self-hosted pool and keep the trust job on `ubuntu-latest`. Canon's
+  actual caller template has been a **single** protected file since `ci/v2.2.0`
+  (PLAN-013), setting **both** `runner_labels_routine` and
+  `runner_labels_review` to the pool. PLAN-009's own superseded-target banner
+  says as much; its Phase 2 body was never updated. Following the prose would
+  have diverged from canon and under-sized the runner pool by half.
+
+- **`gitleaks` scan scope changed silently at v2; verify against the command CI
+  runs, not the one the docs describe.** `ci/v1.9.5` ran `gitleaks dir .`
+  (working tree); `ci/v2.x` runs `gitleaks git .` (full history — 1343 commits
+  here). Canon's own header comment still says `dir`. Local verification with
+  `dir` passed clean and CI then failed on 33 history findings, all
+  pre-migration `ucx_framework` placeholders. **Rule: when validating a CI gate
+  locally, read the step body for the actual invocation; a header comment is not
+  the contract.**
+
+- **A shared trust config makes a partial fleet migration a breaking change.**
+  This repo's `ai-review` had been failing `no parseable verdict — fail-closed`
+  since `aidoc-flow-operations` cut over to `ci/v2.0.1` on 2026-07-16 — not, as
+  `plans/HANDOFF.md` recorded, because a reviewer key lapsed. Operations rewrote
+  the **shared** trust config (`trust_config_repo`, which every consumer reads by
+  default) to schema v2, removing the `reviewer` field. The `v1.9.5` reusable
+  resolves the engine with `jq -r '.reviewer // "codex"'`, so the absent field
+  silently selected **codex**, which requires `OPENAI_API_KEY` — never held here.
+  Hence `401 Unauthorized` from `api.openai.com`. **Consequence for this repo:
+  its AI review gate was unpassable for ~9 days and every merge in that window
+  went through `--admin`, including #335's.** The migration is the fix: the v2
+  reusable reads `litellm.model` from that same config. Recorded here because
+  the failure mode is not local — a config this repo does not own can break its
+  gate, and the symptom (`no parseable verdict`) names neither the cause nor the
+  owner.
+
+- **`LITELLM_BASE_URL` must be the Docker-bridge address, not loopback.** The
+  single-use runner executes jobs **inside a container**, so `127.0.0.1` /
+  `localhost` resolves to the container itself, not the host. Set it to
+  `http://172.17.0.1:4001/v1`. Verified from inside a job container: the bridge
+  address answers `GET /v1/models` with **HTTP 401** (proxy alive, virtual key
+  required — the correct unauthenticated response), while both loopback forms are
+  unreachable. Set to loopback first, the v2 review job failed
+  `litellm: proxy request failed after 3 attempts: URLError`; corrected
+  2026-07-25T20:44Z and it passed on the next run. Note the LiteLLM container
+  publishes **host 4001 → container 4000**, and is a *different* service from
+  `llm_router-llm-router-1` (unpublished 4000/tcp, plus a separate host listener
+  on `0.0.0.0:4000`) — pointing at 4000 hits the wrong service.
+
+- **Two independent causes of `BLOCKED` were conflated; fixing `ai-review` only
+  removes one.** With the migration verified (`call / ai-review` and
+  `call / composition` both green on the #336 probe — composition's first success
+  in ~9 days), PRs here *still* report `BLOCKED`. Cause: branch protection
+  requires the status context **`Lint / format / security hooks`**, but the check
+  actually reports as **`call / Lint / format / security hooks`** — the reusable-
+  workflow job prefix. A context that is never reported can never be satisfied, so
+  every PR is blocked no matter how green. This is the "phantom
+  branch-protection context" upstream PLAN-009 flags for framework/business/
+  iplanic, and it is **independent of the reviewer**: it predates the migration
+  and survives it. Fixing it is a branch-protection write (🔴 founder); until then
+  `--admin` remains structurally necessary here, which is precisely the condition
+  that made `--admin` feel routine.
+
 ## D-0065 — CI-plumbing PRs get a CHANGELOG entry (founder call, 2026-07-25); and warning-only tooling can hide a hard failure behind a gate that never fires
 
 **2026-07-25.** Two decisions from the open-PR triage session.

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -1,5 +1,79 @@
 # Session Handoff
 
+> **✅ SESSION 2026-07-25 (later) — CI canon migrated to `ci/v2.14.0`
+> (CI-CANON-V2-001).** Plan #334, implementation #335, both merged. All eleven
+> `aidoc-flow-ci` call sites are now `@ci/v2.14.0`; `standards-drift` moved from a
+> hand-rolled `curl`-and-execute (pinned nine minors stale at a `ci/v1.6.0`
+> commit SHA) to canon's reusable at `tier: governance`; `ai-review` runs **both**
+> jobs on the self-hosted pool with `litellm_allow_insecure_http: true`; FT-42
+> (least-privilege `secrets:` map) and FT-43 (draft/ready triggers — an upstream
+> **security** fix) adopted; `.gitleaks.toml` added; the Dependabot `semver-major`
+> hold dropped. Full record: `CHANGELOG.md` + `plans/DECISIONS.md` **D-0066**.
+>
+> **⚠️ CORRECTION — the `ai-review` root cause below is WRONG.** The banner
+> further down says `ai-review` "is 401 (no working reviewer key)" and prescribes
+> "restore the reviewer-App credential." **Neither is right, and that wording cost
+> this session real time.** The reviewer-App credentials
+> (`APP_REVIEWER_1_ID`/`_KEY`) were valid throughout and were never consulted for
+> the review call. What actually happened: when `aidoc-flow-operations` cut over
+> to `ci/v2.0.1` on 2026-07-16 it rewrote the **shared** trust config
+> (`trust_config_repo`, which this repo reads by default) to schema v2 and
+> **removed the `reviewer` field**. The `ci/v1.9.5` reusable resolves the engine
+> with `jq -r '.reviewer // "codex"'`, so the missing field silently selected
+> **codex**, which needs `OPENAI_API_KEY` — a secret this repo has never held →
+> `401` from `api.openai.com` → `no parseable verdict — fail-closed`. The gate was
+> unpassable here for ~9 days, and every merge in that window (incl. #335) went
+> through founder `--admin`. **The migration is the fix**, not a credential
+> restore. See D-0066.
+>
+> **Wave 0 infrastructure is live on this repo.** Two single-use runners
+> (`ci-runner@framework-1`, `ci-runner@framework-2`) registered with
+> `self-hosted,ci-runner,single-use`; `LITELLM_BASE_URL` +
+> `LITELLM_REVIEW_API_KEY` set. **`LITELLM_BASE_URL` must be the Docker-bridge
+> address `http://172.17.0.1:4001/v1`, NOT loopback** — the runner executes inside
+> a container, where `127.0.0.1`/`localhost` is the container itself. It was first
+> set to loopback and the v2 review job failed `proxy request failed after 3
+> attempts: URLError`; corrected 2026-07-25T20:44Z. Verified from inside a job
+> container: bridge → `GET /v1/models` returns HTTP 401 (alive, auth required);
+> loopback → unreachable.
+>
+> **✅ VERIFIED END-TO-END (throwaway PR #336, closed unmerged).** `call /
+> ai-review` **pass** and `call / composition` **pass** — composition's first
+> success in ~9 days. Both `ai-review` jobs scheduled on the pool with no
+> queueing; LiteLLM reached over the bridge URL; reviewer returned a parseable
+> verdict (`ai:review-passed`, review posted by the `aidoc-reviewer` App). A
+> green migration PR proved nothing on its own — #335 was reviewed by the *old*
+> v1.9.5 caller, since `pull_request_target` runs the base branch's workflow — so
+> this probe is the actual evidence.
+>
+> **⚠️ PRs here are STILL `BLOCKED`, for a second and unrelated reason.** Branch
+> protection requires the status context **`Lint / format / security hooks`**,
+> but the check reports as **`call / Lint / format / security hooks`** (the
+> reusable-workflow job prefix). A never-reported context can never be satisfied,
+> so every PR is blocked however green it is. This is the phantom
+> branch-protection context upstream PLAN-009 flags for
+> framework/business/iplanic; it **predates this migration and survives it**, and
+> it is why `--admin` has felt routine here. Fix is a 🔴 founder branch-protection
+> write — required contexts should be `call / Lint / format / security hooks`,
+> `Framework + platform conformance`, `call / composition`. Verify against a live
+> PR afterwards; GitHub's protection API is easy to get subtly wrong.
+>
+> **Still open (🔴 founder):** Wave 3 — apply the CI-0011 `actions-permissions`
+> narrowing (until then `standards-drift` reports two warnings, exit 0, nothing
+> broken), and delete the now-unreferenced `CLAUDE_CODE_OAUTH_TOKEN`. **Keep
+> `AI_REVIEW_TOKEN`** — it is on the verify-it-did-not-lapse list, not the
+> deprecated list.
+>
+> **Two upstream `aidoc-flow-ci` defects found, not yet filed:** (1) `secret-scan`
+> changed from `gitleaks dir` to `gitleaks git` (full history) at v2 while its own
+> header comment still says `dir` — this is why a locally-clean scan failed in CI;
+> (2) `docs-sync` still declares `pull-requests: read` at workflow level with no
+> job override while its dry-run step runs `gh pr comment`, so **`docs-sync`
+> remains red after this migration** — the caller-side raise in #333 is
+> necessary-but-insufficient and the real fix is upstream.
+>
+> ---
+>
 > **✅ SESSION 2026-07-25 (wrap) — handoff hygiene + open-PR triage.**
 > Reviewed this file against live git state, found the SEED-ABSORPTION-001 banner
 > stale (said #326 OPEN; it merged 2026-07-24 21:15 EST / 01:15Z `4423a1cc`) and

--- a/tmp/AI-REVIEW-V2-PROBE.md
+++ b/tmp/AI-REVIEW-V2-PROBE.md
@@ -1,0 +1,5 @@
+# ai-review v2 verification probe
+
+Temporary file for CI-CANON-V2-001 post-merge verification of the
+ci/v2.14.0 ai-review path (pool routing + LiteLLM reachability).
+This PR is closed without merging once the gate reports a verdict.


### PR DESCRIPTION
Governance records for the `ci/v1.9.5` → `ci/v2.14.0` migration (#334/#335),
verified end-to-end by throwaway PR #336 (closed unmerged): `call / ai-review`
and `call / composition` both green — composition's first success in ~9 days.

Exactly **3 doc surfaces**, within the governance-PR cap.

## The two corrections

**1. `plans/HANDOFF.md` had the wrong root cause, and it misdirected this
session.** It stated `ai-review` "is 401 (no working reviewer key)" and
prescribed "restore the reviewer-App credential." Both wrong — those credentials
were valid throughout and were never consulted for the review call. What
actually happened: when `aidoc-flow-operations` cut over to `ci/v2.0.1` it
rewrote the **shared** trust config (`trust_config_repo`, which this repo reads
by default) to schema v2 and **removed the `reviewer` field**. The `v1.9.5`
reusable resolves the engine with `jq -r '.reviewer // "codex"'`, so the missing
field silently selected **codex**, which needs `OPENAI_API_KEY` — never held
here → `401` from `api.openai.com` → `no parseable verdict — fail-closed`.

**2. PRs here remain `BLOCKED` for a second, unrelated reason.** Branch
protection requires the status context `Lint / format / security hooks`, but the
check reports as `call / Lint / format / security hooks` (reusable-workflow job
prefix). A never-reported context can never be satisfied, so **every PR is
blocked however green it is** — including this one. That phantom **predates this
migration and survives it**, and it is why `--admin` has felt routine here.

## `plans/DECISIONS.md` — new D-0066

Five decisions from executing the migration: target the latest canon tag rather
than the plan's stale one; where upstream plan prose conflicts with upstream
source, source wins; the `gitleaks` scan scope changed `dir`→`git` at v2 while
the header comment still says `dir`; a shared trust config makes a partial fleet
migration a breaking change; `LITELLM_BASE_URL` must be the Docker-bridge
address, not loopback.

## `CLAUDE.md`

The CI section still described a standalone codex-reviewer workflow migrating to
`@ci/v1.0.0` in a Phase A that completed long ago. Replaced with the as-built
state: the deliberate runner split (`ai-review` entirely on the self-hosted pool
because the proxy is host-local; everything else, including the
fork-code-executing lint callers, on `ubuntu-latest`), plus the two operational
facts that cost a session when unrecorded — bridge-vs-loopback base URL, and the
full-history secret scan.
