### PR TITLE
docs: codify GOV-TODO-ISSUE-SPLIT in CLAUDE.md + new AGENTS.md (#345)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,87 @@
+# AGENTS.md — working agreement for AI coding agents on aidoc-flow-framework
+
+Orients any AI agent (Claude Code, Codex, Gemini CLI, Copilot, Hermes, custom)
+working on this repo. **[`CLAUDE.md`](CLAUDE.md) is the full working agreement**;
+this file is the short orientation plus the rules that are most often missed.
+Where the two disagree, `CLAUDE.md` wins — fix this file.
+
+## What this repo is
+
+One engine-agnostic specification (`framework/`) and two independent platforms
+that consume it: **Hermes** (MCP server, `platforms/hermes/`) and the **Claude
+Code plugin** (`platforms/claude-code-plugin/`). The spec defines the 8-layer SDD
+flow (BRD → PRD → EARS → BDD → ADR → SPEC → TDD → IPLAN → Code). Both platforms
+pass the same shared conformance suite (`tests/conformance/`).
+
+## Filing gaps — TODO entry **and** GitHub issue
+
+When you find a defect, inconsistency, or missing capability, it gets **both**:
+
+1. An entry in `plans/FRAMEWORK-TODO.md` — the triage queue. Inline as
+   discovered: tag + one-line title + *Context* (what surfaced it) + *Fix shape*.
+   The entry IS the capture moment; there is no "later PR".
+2. **A GitHub issue on this repo** when the entry is (a) actionable by someone
+   other than you, (b) reproducible at `file:line` with a concrete fix shape, or
+   (c) user-visible / blocks a consumer. Speculative or purely local items stay
+   TODO-only.
+
+The issue body carries: reproduction at `file:line`, blast radius, why it was
+hard to diagnose, a suggested fix, and what is **not** broken. One issue per
+defect. Link both ways — the TODO heading ends with `→ #N`, the issue names the
+TODO entry ID — and close both on the same merge SHA.
+
+If the defect is owned by **another** repo (the CI canon `aidoc-flow-ci`, a
+sibling submodule, an upstream spec), the issue goes **there**, not here. The
+test is ownership, not severity. See `CLAUDE.md` → "Cross-repo feedback".
+
+**Verify what you published.** Use `gh issue create --body-file -`; `--body -`
+sets the body to a literal `-`, exits 0, and prints a URL, so it looks like it
+worked. Read it back:
+
+```sh
+gh issue view <N> -R vladm3105/aidoc-flow-framework --json body --jq '.body | length'
+```
+
+## Non-negotiables
+
+- **Never hand-edit example artifacts.** Files under `examples/<name>/docs/` and
+  `examples/<name>/.aidoc/` are the system-under-test. Remediate them by
+  dispatching the framework's own skills; a class of remediation the skills
+  cannot handle is a **framework workflow gap**, never a reason to edit the
+  artifact.
+- **Conformance stays green.** Never weaken a check in `tests/conformance/` to
+  make it pass — fix the spec or the platform.
+- **The spec is the contract.** `framework/` is engine-agnostic: no platform
+  names, no runtime code. Platforms consume `framework/layers/<NN>_<X>/`; they
+  never ship their own copies (D-0013).
+- **Submit only finalized work.** A PR has already completed its review-and-fix
+  cycles locally. Amendment PRs patching a just-merged PR are a smell that the
+  original shipped early.
+- **Plans get two review cycles before the plan PR opens** — see `CLAUDE.md`
+  → "Development workflow".
+
+## Where state lives (this repo owns its own continuity)
+
+| Surface | Path |
+|---|---|
+| Live handoff | `plans/HANDOFF.md` — read it first, every session |
+| TODO / backlog | `plans/FRAMEWORK-TODO.md` |
+| Decisions | `plans/DECISIONS.md`; spec governance in `framework/governance/DECISIONS.md` |
+| Plans | `plans/<NAME>-PLAN.md` |
+| Changelog / roadmap | `CHANGELOG.md`, `ROADMAP.md` |
+
+Never put any of these in `tmp/`, and never centralize them in the `aidoc-flow`
+umbrella — the umbrella holds no development of its own.
+
+## Tooling
+
+- **GitHub: use the `gh` CLI**, not the GitHub MCP servers or raw API calls. If
+  unauthenticated, run `gh auth login`.
+- Sessions run in ephemeral containers: **only committed + pushed work
+  survives.** Commit messages carry no model identifiers.
+- Conventional commit prefixes (`docs:`, `feat:`, `fix:`, `refactor:`,
+  `chore:`), one logical change per commit.
+
+Everything else — CI consumption from `aidoc-flow-ci`, governance PR discipline,
+auto-merge defaults, multi-agent review, versioning and tagging — is in
+[`CLAUDE.md`](CLAUDE.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,32 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added — `AGENTS.md` + the `GOV-TODO-ISSUE-SPLIT` filing rule (2026-07-26)
+
+No spec or platform change (no `VERSION` bump). Governance working rules only.
+
+- **`AGENTS.md` (new).** Cross-agent orientation for Codex / Gemini CLI /
+  Copilot / Hermes — the repo had none. Names `CLAUDE.md` as the full working
+  agreement and carries the rules most often missed (gap filing, never
+  hand-editing example artifacts, conformance stays green, where state lives).
+- **`CLAUDE.md` — own-repo gaps get a TODO entry *and* a GitHub issue.** The
+  sibling of the cross-repo feedback rule: an entry that is actionable by a
+  non-finder, reproducible at `file:line`, or consumer-blocking also gets an
+  issue on this repo, linked both ways and closed on the same SHA. Resolves the
+  working-rule half of
+  [#345](https://github.com/vladm3105/aidoc-flow-framework/issues/345); the
+  framework-spec half (`DOC_GOVERNANCE_CORE.md` Principle 9 →
+  `FRAMEWORK_FEEDBACK_LOG.md` Tier 2) still needs CHG / GATE-SPEC ratification.
+- **Element-ID gaps filed** as
+  [#342](https://github.com/vladm3105/aidoc-flow-framework/issues/342)–[#345](https://github.com/vladm3105/aidoc-flow-framework/issues/345)
+  and indexed in `plans/FRAMEWORK-TODO.md` (PR #346): no callable ID generator,
+  the D-0062 normalization transform reaching only `BRD-TEMPLATE`, and TDD
+  documenting no element-ID contract.
+- **`plans/HANDOFF.md`** records
+  [aidoc-flow-ci#322](https://github.com/vladm3105/aidoc-flow-ci/issues/322) —
+  `ai-review` self-cancels via its own review submission, which is the actual
+  reason PRs here need `--admin`, not the `composition` check.
+
 ### Changed — CI canon migrated `ci/v1.9.5` → `ci/v2.14.0` (CI-CANON-V2-001) (2026-07-25)
 
 No spec or platform change (no `VERSION` bump). Executes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,10 @@
 Persistent context for the **AI Doc Flow Framework**. Auto-loaded every
 session. Keep it short and current.
 
+Non-Claude agents (Codex, Gemini CLI, Copilot, Hermes) start at
+[`AGENTS.md`](AGENTS.md) — the short cross-agent orientation. This file remains
+the full working agreement; where the two disagree, this one wins.
+
 ## What this project is
 
 The document-flow framework, delivered as **one engine-agnostic specification
@@ -272,6 +276,46 @@ Use the **GitHub CLI (`gh`)** as the default for all GitHub operations — PRs,
 issues, reviews, releases, repo queries — not the GitHub MCP servers
 (`github-tt`, `github-vl`) or raw API calls. If `gh` is unauthenticated, run
 `gh auth login` rather than falling back to MCP/API.
+
+## Own-repo gaps — TODO entry **and** GitHub issue (GOV-TODO-ISSUE-SPLIT)
+
+The sibling of the cross-repo rule below, for defects **this repo owns**. Two
+surfaces, one flow — the TODO file is the queue, the issue is the externally
+visible record:
+
+| Surface | Role | Rule |
+|---|---|---|
+| `plans/FRAMEWORK-TODO.md` | the triage **queue** | unchanged — every gap gets an entry, inline as discovered (tag + title + *Context* + *Fix shape*). The entry IS the capture moment; no "later PR" |
+| GitHub issue on this repo | the **externally visible** record | opened when the entry meets **any** of: (a) actionable by someone other than its finder, (b) reproducible at `file:line` with a concrete fix shape, (c) user-visible or blocks a consumer |
+
+Purely local, speculative, or already-planned items stay TODO-only — the tracker
+must not become a second copy of the backlog.
+
+**An issue body carries the same evidence the cross-repo rule demands** (below):
+reproduction at `file:line`, blast radius, why it was hard to diagnose, a
+suggested fix, and what is NOT broken. Same `--body-file -` + read-back
+verification. Same one-issue-per-defect granularity.
+
+**Link both ways.** The TODO entry's heading ends with `→ #N`; the issue's
+*Related* section names the TODO entry ID. Close both on the same merge SHA
+(the TODO entry moves to **Closed**; the issue closes with the same ref).
+
+**Why.** `plans/FRAMEWORK-TODO.md` is read only by a session entering *this*
+repo — the exact latency failure the cross-repo rule was written to fix, applied
+to consumers of this framework, who cannot see the file at all. This repo held
+one issue against ~40 TODO entries, with 11 issue templates and a full label
+taxonomy provisioned and unused, because no rule ever routed anything there.
+
+**Spec counterpart is not yet ratified.** The framework-spec version of this rule
+(`framework/governance/DOC_GOVERNANCE_CORE.md` Principle 9 →
+`FRAMEWORK_FEEDBACK_LOG.md` Tier 2) is proposed in
+[#345](https://github.com/vladm3105/aidoc-flow-framework/issues/345) and needs
+CHG / GATE-SPEC ratification plus a `framework/VERSION` bump. This section is the
+repo working rule in the meantime; do not treat it as the ratified spec.
+
+*Origin:* `GOV-TODO-ISSUE-SPLIT` (2026-07-26), found while filing three
+element-ID gaps ([#342](https://github.com/vladm3105/aidoc-flow-framework/issues/342)–[#344](https://github.com/vladm3105/aidoc-flow-framework/issues/344))
+that governance would have parked in a markdown file no consumer reads.
 
 ## Cross-repo feedback — file it as a GitHub issue on the owning repo
 

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -1,5 +1,31 @@
 # Session Handoff
 
+> **⚠️ SESSION 2026-07-26 — `ai-review` self-cancel is why PRs still need
+> `--admin`; filed upstream as
+> [aidoc-flow-ci#322](https://github.com/vladm3105/aidoc-flow-ci/issues/322).**
+> The reviewer's own review submission fires `pull_request_review: submitted`,
+> which starts a second run in concurrency group `ai-review-<PR#>`; canon's
+> `cancel-in-progress` predicate (`ai-review.yml:97-102` @ `ci/v2.14.0`) exempts
+> only `labeled`/`unlabeled`, so that run **cancels the run that posted the
+> review**. The cancelled `call / ai-review` check-run persists on the head SHA,
+> and since that context is required, the GraphQL rollup is FAILURE while
+> `gh pr checks` looks green. `gh pr merge` reports only "the base branch policy
+> prohibits the merge", naming nothing. **Do not label-cycle to recover** — each
+> cycle adds another cancelled run (observed on PR #346: one → two). A fresh SHA
+> does not clear it either; the self-cancel repeats on every push. Until #322
+> lands, `--admin` is the only route, and the standing
+> `AIDOC-CI-COMPOSITION-CHECK-PRHEAD` TODO entry attributing this to
+> `composition` is **wrong** — composition is green on the PR head.
+>
+> **Element-ID gaps filed 2026-07-26.** A cross-layer review of the element-ID
+> hash contract produced
+> [#342](https://github.com/vladm3105/aidoc-flow-framework/issues/342)–[#345](https://github.com/vladm3105/aidoc-flow-framework/issues/345),
+> indexed in `plans/FRAMEWORK-TODO.md`: no callable ID generator (9 skill/prompt
+> surfaces instruct LLM-side SHA-256), the D-0062 normalization transform reached
+> only `BRD-TEMPLATE`, TDD documents no element-ID contract at all, and governance
+> never routes an own-repo gap to the issue tracker. #345's working-rule half is
+> now in `CLAUDE.md` + `AGENTS.md`; its spec half awaits GATE-SPEC.
+>
 > **✅ SESSION 2026-07-25 (later) — CI canon migrated to `ci/v2.14.0`
 > (CI-CANON-V2-001).** Plan #334, implementation #335, both merged. All eleven
 > `aidoc-flow-ci` call sites are now `@ci/v2.14.0`; `standards-drift` moved from a


### PR DESCRIPTION
Codifies the working-rule half of #345: own-repo gaps get **both** a
`plans/FRAMEWORK-TODO.md` entry (the triage queue, unchanged) **and** a GitHub
issue when the entry is actionable by a non-finder, reproducible at `file:line`,
or consumer-blocking. Speculative/local items stay TODO-only.

Three surfaces (governance-PR Rule 1 limit):

| File | Change |
|---|---|
| `CLAUDE.md` | new "Own-repo gaps — TODO entry **and** GitHub issue" section, placed as the sibling of the cross-repo rule; plus a one-line pointer to `AGENTS.md` |
| `AGENTS.md` | **new** — the repo had none. Short cross-agent orientation (Codex / Gemini CLI / Copilot / Hermes) per the workspace convention; names `CLAUDE.md` as the full working agreement |
| `plans/HANDOFF.md` | records aidoc-flow-ci#322 per the cross-repo link-back rule |

**Not included:** the framework-spec half of #345
(`DOC_GOVERNANCE_CORE.md` Principle 9 → `FRAMEWORK_FEEDBACK_LOG.md` Tier 2).
That is a `framework/governance/` surface needing CHG / GATE-SPEC ratification
and a `framework/VERSION` bump; both files say so explicitly so neither is
mistaken for ratified spec.

**Not auto-merging** — governance PR touching `CLAUDE.md`. Yours to review and
merge. Note it will likely need `--admin` for the same reason #346 did
(aidoc-flow-ci#322).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
