### PR TITLE
docs: index #348 (gitleaks pre-commit Go floor) in FRAMEWORK-TODO

### DIFF
--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -24,6 +24,20 @@
 
 ## Open
 
+### `[ci]` `GITLEAKS-PRECOMMIT-GO-FLOOR` — the local gitleaks pre-commit hook cannot install on Go < 1.21 and aborts every commit → [#348](https://github.com/vladm3105/aidoc-flow-framework/issues/348)
+
+- *Context:* 2026-07-26, while committing PRs #346/#347.
+  `.pre-commit-config.yaml:82-85` pins `gitleaks/gitleaks@v8.21.2`, a
+  `language: golang` hook pre-commit builds from source; Go 1.19.8 rejects the
+  module's `go 1.22.0` + `toolchain` directives, so the build always fails — at
+  *install* time, which aborts the commit before any other hook runs. Local
+  addition (`935befed`), not canon: canon's `pre-commit-hook-block.yaml` @
+  `ci/v2.14.0` has no gitleaks entry and no sibling repo pins it. Redundant with
+  `call / gitleaks` in CI (green throughout) + `detect-secrets` locally.
+- *Fix shape:* drop the hook (CI already scans full history at v2); if a local
+  pass is wanted, use a prebuilt-binary or container delivery and document the
+  toolchain floor in `CONTRIBUTING.md`.
+
 ### `[skill]` `IDGEN-NO-GENERATOR` — 9 skill/prompt surfaces instruct LLM-side SHA-256; no callable generator exists → [#342](https://github.com/vladm3105/aidoc-flow-framework/issues/342)
 
 - *Context:* founder review 2026-07-26. `compute_element_hash()`


### PR DESCRIPTION
One-line index entry completing the GOV-TODO-ISSUE-SPLIT pairing for
[#348](https://github.com/vladm3105/aidoc-flow-framework/issues/348): the issue
carries the detail (reproduction, blast radius, fix shape), the TODO file carries
the queue line.

Docs-only, one file, no spec or platform change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
