### PR TITLE
fix: drop the local gitleaks pre-commit hook (#348)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,10 +79,14 @@ repos:
       - id: detect-secrets
         args: [--baseline, .secrets.baseline]
 
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.21.2
-    hooks:
-      - id: gitleaks  # git-aware secret scan; config in .gitleaks.toml
+  # No local gitleaks hook (#348). The upstream hook is `language: golang`, so
+  # pre-commit builds it from source; gitleaks' go.mod uses the three-part `go
+  # 1.22.0` directive plus `toolchain`, both Go >= 1.21 features. On any machine
+  # with an older toolchain the failure lands in hook *installation*, which
+  # aborts the whole commit before any other hook runs — and the error names
+  # go.mod, not gitleaks. Secret scanning is unaffected: `detect-secrets` above
+  # covers the commit stage, and .github/workflows/secret-scan.yml runs gitleaks
+  # over the full git history in CI, consuming this repo's .gitleaks.toml.
 
   # ---- dependency vulnerability audit ----------------------------------------
   # Heavy / network-bound — runs in the `manual` stage (CI) + pre-push, not on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,31 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Removed — the local `gitleaks` pre-commit hook (#348) (2026-07-26)
+
+No spec or platform change (no `VERSION` bump). Tooling only.
+
+- **`.pre-commit-config.yaml` — `gitleaks/gitleaks@v8.21.2` dropped.** The
+  upstream hook is `language: golang`, so pre-commit builds it from source, and
+  gitleaks' `go.mod` uses the three-part `go 1.22.0` directive plus `toolchain`
+  — both Go ≥ 1.21 features. On an older toolchain the build can never succeed,
+  and because the failure is in hook *installation* it aborts the whole commit
+  before any other hook runs, with an error naming `go.mod` rather than gitleaks.
+  A comment at the same location records why the hook is absent so it is not
+  re-added.
+- **Secret-scanning coverage is unchanged.** `detect-secrets` still runs on the
+  commit stage locally, and `.github/workflows/secret-scan.yml` runs gitleaks
+  over the **full git history** in CI against this repo's `.gitleaks.toml` (the
+  config file is untouched). The local hook duplicated the CI gate at the cost
+  of a Go build every contributor had to be able to run; no version floor was
+  documented anywhere.
+- **`CONTRIBUTING.md`** gains a "Secret scanning — where each pass runs" table
+  (stage → tool → scope → config) plus the consequence that follows from CI
+  scanning history rather than the working tree: a clean local tree can still
+  fail the gate, so validate findings with `git log -p` / `git grep` and record
+  justified suppressions in `.gitleaks.toml`.
+- `plans/FRAMEWORK-TODO.md` — `GITLEAKS-PRECOMMIT-GO-FLOOR` moved to **Closed**.
+
 ### Added — `AGENTS.md` + the `GOV-TODO-ISSUE-SPLIT` filing rule (2026-07-26)
 
 No spec or platform change (no `VERSION` bump). Governance working rules only.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,15 @@ See [`tests/CONTRIBUTING.md`](tests/CONTRIBUTING.md) (test-suite contribution gu
 
 The framework spec is GATE-SPEC governed. Any change under `framework/` (the spec subtree) requires bumping `framework/VERSION` and going through the conformance suite. See [`docs/PROJECT.md`](docs/PROJECT.md) §6 (Change Management).
 
+## Secret scanning — where each pass runs
+
+| Stage | Tool | Scope | Config |
+|---|---|---|---|
+| `pre-commit` (local) | `detect-secrets` | staged files | `.secrets.baseline` |
+| CI (`secret-scan.yml`) | `gitleaks` | **full git history** (`gitleaks git`, canon `ci/v2.x`) | `.gitleaks.toml` |
+
+There is deliberately **no local gitleaks hook** ([#348](https://github.com/vladm3105/aidoc-flow-framework/issues/348)): the upstream hook builds gitleaks from source and needs Go ≥ 1.21, and the failure lands in hook installation, aborting the commit before any other hook runs. Because CI scans history rather than the working tree, a clean local tree can still fail the gate — validate a suspected finding with `git log -p` / `git grep` over history, and record justified suppressions in `.gitleaks.toml`.
+
 ## Reporting bugs and security issues
 
 - Functional bugs: <https://github.com/vladm3105/aidoc-flow-framework/issues>

--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -24,20 +24,6 @@
 
 ## Open
 
-### `[ci]` `GITLEAKS-PRECOMMIT-GO-FLOOR` — the local gitleaks pre-commit hook cannot install on Go < 1.21 and aborts every commit → [#348](https://github.com/vladm3105/aidoc-flow-framework/issues/348)
-
-- *Context:* 2026-07-26, while committing PRs #346/#347.
-  `.pre-commit-config.yaml:82-85` pins `gitleaks/gitleaks@v8.21.2`, a
-  `language: golang` hook pre-commit builds from source; Go 1.19.8 rejects the
-  module's `go 1.22.0` + `toolchain` directives, so the build always fails — at
-  *install* time, which aborts the commit before any other hook runs. Local
-  addition (`935befed`), not canon: canon's `pre-commit-hook-block.yaml` @
-  `ci/v2.14.0` has no gitleaks entry and no sibling repo pins it. Redundant with
-  `call / gitleaks` in CI (green throughout) + `detect-secrets` locally.
-- *Fix shape:* drop the hook (CI already scans full history at v2); if a local
-  pass is wanted, use a prebuilt-binary or container delivery and document the
-  toolchain floor in `CONTRIBUTING.md`.
-
 ### `[skill]` `IDGEN-NO-GENERATOR` — 19 skill/prompt surfaces instruct LLM-side SHA-256; no callable generator exists → [#342](https://github.com/vladm3105/aidoc-flow-framework/issues/342)
 
 - *Context:* founder review 2026-07-26. `compute_element_hash()`
@@ -1150,6 +1136,24 @@
 - *Status:* SHIPPED (spec 0.32.3, 2026-06-29 — BeeLocal docs sweep).
 
 ## Closed
+
+### `[ci]` `GITLEAKS-PRECOMMIT-GO-FLOOR` — ✅ CLOSED (2026-07-26) — the local gitleaks pre-commit hook could not install on Go < 1.21 and aborted every commit
+
+- *Context:* 2026-07-26, while committing PRs #346/#347.
+  `.pre-commit-config.yaml:82-85` pinned `gitleaks/gitleaks@v8.21.2`, a
+  `language: golang` hook pre-commit builds from source; Go 1.19.8 rejects the
+  module's `go 1.22.0` + `toolchain` directives, so the build always failed — at
+  *install* time, which aborts the commit before any other hook runs. Local
+  addition (`935befed`), not canon: canon's `pre-commit-hook-block.yaml` @
+  `ci/v2.14.0` has no gitleaks entry and no sibling repo pins it. Redundant with
+  `call / gitleaks` in CI (green throughout) + `detect-secrets` locally.
+- ✅ **Fixed** ([#348](https://github.com/vladm3105/aidoc-flow-framework/issues/348)):
+  hook dropped, replaced by a comment at the same location recording *why* there
+  is no local gitleaks pass so it is not re-added. `CONTRIBUTING.md` gains a
+  "Secret scanning — where each pass runs" table making the split explicit
+  (`detect-secrets` local / `gitleaks` over full history in CI) and warning that
+  a clean working tree can still fail the CI gate. `.gitleaks.toml` is untouched
+  — it is what CI consumes.
 
 ### `[skill]` `MODEL-PRECHECK-ROLLOUT` — autopilots print the per-layer model recommendation (2026-06-23)
 


### PR DESCRIPTION
Closes #348.

## The defect

`.pre-commit-config.yaml` pinned `gitleaks/gitleaks@v8.21.2`, a `language: golang` hook that pre-commit builds from source. gitleaks' `go.mod` uses the three-part `go 1.22.0` directive plus `toolchain` — both Go ≥ 1.21 features — so on an older toolchain the build can never succeed.

The failure lands in hook **installation**, which aborts the whole commit before any other hook runs, behind an error naming `go.mod`:

```
An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/go', 'install', './...')
    go: errors parsing go.mod:
    …/go.mod:3: invalid go version '1.22.0': must match format 1.23
    …/go.mod:5: unknown directive: toolchain
```

That reads as a broken Go install rather than a repo hook requiring a toolchain no contributor was told to have. No version floor was documented anywhere.

## Why removal rather than a version floor

The hook was redundant. It is a local addition (`935befed`), not canon — canon's `install/templates/pre-commit-hook-block.yaml` @ `ci/v2.14.0` has no gitleaks entry and no sibling repo pins it. The same scan already runs in CI over a **wider** scope.

## Changes

| File | Change |
|---|---|
| `.pre-commit-config.yaml` | hook removed; a comment at the same location records *why* there is no local gitleaks pass, so it is not silently re-added |
| `CONTRIBUTING.md` | new "Secret scanning — where each pass runs" table (stage → tool → scope → config), plus the consequence that follows from CI scanning history rather than the working tree |
| `CHANGELOG.md` | `[Unreleased]` entry |
| `plans/FRAMEWORK-TODO.md` | `GITLEAKS-PRECOMMIT-GO-FLOOR` moved to **Closed** |

## Coverage is unchanged

- `detect-secrets` still runs on the commit stage locally (`.secrets.baseline`).
- `.github/workflows/secret-scan.yml` runs gitleaks over the **full git history** in CI (`gitleaks git` at canon v2), consuming `.gitleaks.toml` — **untouched by this PR**.

Because CI scans history rather than the working tree, a clean local tree can still fail the gate. `CONTRIBUTING.md` now says so and points at `git log -p` / `git grep` for validation and `.gitleaks.toml` for suppressions.

## Verification

- `pre-commit run --files …` on all four changed files: **all hooks green**, including the conformance suite.
- The commit that produced this branch ran **without** `SKIP=gitleaks` — previously required on this machine. Self-verifying.
- `grep -rn gitleaks tests/ scripts/ .github/workflows/` — the only hits are in `secret-scan.yml`, which is unaffected.
- No spec or platform change; no `VERSION` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
