### PR TITLE
ci: bring .github/ai-review/config.json to schema v2 (#341)

### DIFF
--- a/.github/ai-review/config.json
+++ b/.github/ai-review/config.json
@@ -1,8 +1,8 @@
 {
-  "$schema": "https://aidoc-flow.io/schemas/ai-review-config-v1.json",
-  "version": 1,
+  "$schema": "https://raw.githubusercontent.com/vladm3105/aidoc-flow-ci/ci/v2.14.0/schemas/ai-review-config-v2.schema.json",
+  "version": 2,
+  "_note": "NOT load-bearing for model resolution on this repo. The ci/v2.x ai-review reusable resolves the alias from the config it FETCHES from trust_config_repo (vladm3105/aidoc-flow-operations@main), not from this file — see canon ai-review.yml 'Resolve LiteLLM model'. Operations already sets model 'ai-reviewer'. This file is kept because it documents the expected policy at the point a reader looks for it, and because it becomes authoritative if trust_config_repo is ever pointed at this repo. It is declared at schema v2 so that path actually works: canon asserts version == 2 before reading any field (CI-0014), so a v1 file pointed at would hard-fail the required ai-review check rather than become authoritative. This _note sits at the root, not inside litellm, because the v2 schema declares litellm additionalProperties:false. Declared per MIGRATION_v2.0.0.md §3.",
   "litellm": {
-    "_comment": "NOT load-bearing for model resolution on this repo. The ci/v2.x ai-review reusable resolves the alias from the config it FETCHES from trust_config_repo (vladm3105/aidoc-flow-operations@main), not from this file — see canon ai-review.yml 'Resolve LiteLLM model'. Operations already sets model 'ai-reviewer'. This entry is kept for two reasons: it documents the expected alias at the point a reader looks for it, and it becomes authoritative if trust_config_repo is ever pointed at this repo. Declared per MIGRATION_v2.0.0.md §3.",
     "model": "ai-reviewer"
   },
   "trust": {
@@ -19,6 +19,7 @@
     "carry_forward_on_skip_label": true
   },
   "auto_merge": {
+    "_comment": "This repo is DELIBERATELY OMITTED from the operations-side auto_merge.repos allowlist — it is the spec/governance repo (tier:spec, human-always; CLAUDE.md locked decision). The flags below state the policy this repo would declare if its config were ever authoritative; they do not opt it in, because the allowlist that governs auto-merge is read from trust_config_repo, not from here.",
     "enabled": true,
     "spec_paths_blocked": ["framework/", "spec/"]
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,37 @@ No spec or platform change (no `VERSION` bump). Tooling only.
   fail the gate, so validate findings with `git log -p` / `git grep` and record
   justified suppressions in `.gitleaks.toml`.
 - `plans/FRAMEWORK-TODO.md` — `GITLEAKS-PRECOMMIT-GO-FLOOR` moved to **Closed**.
+### Changed — `.github/ai-review/config.json` brought to schema v2 (#341) (2026-07-26)
+
+No spec or platform change (no `VERSION` bump). CI configuration only; the file
+is inert today and this PR does not change any check's behaviour.
+
+- **`version: 1` → `version: 2`, `$schema` → canon's
+  `ai-review-config-v2.schema.json`** (pinned at `ci/v2.14.0`, matching this
+  repo's caller pins, rather than the previously-declared
+  `aidoc-flow.io/schemas/ai-review-config-v1.json`).
+- **Why it mattered.** The file's own comment claimed it *"becomes authoritative
+  if `trust_config_repo` is ever pointed at this repo."* CI-0014 makes both the
+  `trust` and `ai-review` jobs assert `version == 2` **before reading any
+  field**, so a v1 file pointed at would hard-fail the required `ai-review`
+  check instead — leaving no passing path to merge. Bringing the file to v2
+  makes the documented fallback actually work.
+- **A second, previously-unreported violation is fixed in the same pass.** The
+  v2 schema declares `litellm` with `additionalProperties: false` and `model` as
+  its only property, so the long `_comment` that lived *inside* `litellm` was
+  invalid independently of the version key. Validating the old file against
+  canon's schema yields **two** errors, not one. The prose moved to the root
+  `_note` (which the schema permits) and now also records why it cannot sit
+  inside `litellm`.
+- **`auto_merge` gains a `_comment`** stating plainly that this repo is
+  deliberately omitted from the operations-side `auto_merge.repos` allowlist —
+  it is the spec/governance repo, human-merge always — and that the flags here
+  describe policy rather than opting anything in. The allowlist that governs
+  auto-merge is read from `trust_config_repo`, never from this file.
+- **Nothing changes today.** Every `trust_config_repo:` line in every caller is
+  commented out, so all jobs resolve the default
+  `vladm3105/aidoc-flow-operations`, whose config is already `version: 2`.
+  Validated with `jsonschema` against canon's schema at `ci/v2.14.0`.
 
 ### Added — `AGENTS.md` + the `GOV-TODO-ISSUE-SPLIT` filing rule (2026-07-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ No spec or platform change (no `VERSION` bump). Tooling only.
   fail the gate, so validate findings with `git log -p` / `git grep` and record
   justified suppressions in `.gitleaks.toml`.
 - `plans/FRAMEWORK-TODO.md` — `GITLEAKS-PRECOMMIT-GO-FLOOR` moved to **Closed**.
+
 ### Changed — `.github/ai-review/config.json` brought to schema v2 (#341) (2026-07-26)
 
 No spec or platform change (no `VERSION` bump). CI configuration only; the file


### PR DESCRIPTION
Closes #341 (filed from `aidoc-flow-ci` per CI-0020).

## The defect

`.github/ai-review/config.json` declared `"version": 1` while carrying a comment claiming the file *"becomes authoritative if `trust_config_repo` is ever pointed at this repo."*

CI-0014 makes both the `trust` and `ai-review` jobs assert `version == 2` **before reading any field**. So if `trust_config_repo` were ever pointed here, the config would not become authoritative — the required `ai-review` check would hard-fail, leaving no passing path to merge. This PR takes the issue's Option 1: bring the file to v2 so the documented fallback actually works.

## A second violation the issue did not report

Validating the old file against canon's actual schema (`schemas/ai-review-config-v2.schema.json` @ `ci/v2.14.0`) yields **two** errors, not one:

```
- litellm: Additional properties are not allowed ('_comment' was unexpected)
- version: 2 was expected
```

The v2 schema declares `litellm` with `additionalProperties: false` and `model` as its only property, so the long `_comment` that lived inside `litellm` was invalid **independently of the version key**. Flipping `version` alone would have produced a file that still fails its own schema.

The prose moved to the root `_note` — which the schema explicitly permits (`"_note": {"type": "string"}`) and which is the same slot `aidoc-flow-operations` uses — and now records why it cannot sit inside `litellm`, so it is not moved back.

## Changes

| Key | Before | After |
|---|---|---|
| `$schema` | `https://aidoc-flow.io/schemas/ai-review-config-v1.json` | canon's `ai-review-config-v2.schema.json`, pinned `@ci/v2.14.0` to match this repo's caller pins |
| `version` | `1` | `2` |
| `litellm._comment` | present (schema violation) | moved to root `_note` |
| `litellm.model` | `ai-reviewer` | unchanged |
| `auto_merge._comment` | absent | **new** — states this repo is deliberately omitted from the operations-side `auto_merge.repos` allowlist (spec/governance repo, human-merge always), and that the flags here describe policy rather than opting anything in |

`trust`, `governance`, `composition`, `autofix` are unchanged — they already matched the v2 shape.

## Verification

```
NEW config: VALID against ai-review-config-v2.schema.json
OLD config errors against v2 schema: 2
```

`jsonschema` validation against canon's schema fetched at `ci/v2.14.0`. Full `pre-commit` run green (`check-json`, conformance suite included).

## What is NOT changed

- **No check behaves differently today.** Every `trust_config_repo:` line in every caller here is commented out (`.github/workflows/ai-review.yml:75`), so all jobs resolve the default `vladm3105/aidoc-flow-operations`, whose config is already `version: 2`.
- No spec or platform change; no `VERSION` bump.
- One accuracy note against the issue text: the `version == 2` assertion ships in `ci/v2.15.0`, which is **not yet tagged** — `gh api .../tags` tops out at `ci/v2.14.0`, this repo's pin. At v2.14.0 the read is still `jq -r '.litellm.model // "ai-reviewer"'`, the silent-default shape. That makes this change preparatory rather than corrective, which strengthens the case for landing it now: it is free while nothing depends on it.

## Merge note

This PR touches `.github/` configuration, which `CLAUDE.md` lists as an explicit exception to the AI auto-merge default. **Not auto-merging** — awaiting your call even when green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
