### PR TITLE
docs: link IDGEN-NO-GENERATOR to its merged plan + record its blocker (#342)

### DIFF
--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -52,6 +52,20 @@
   block does not wait on the provisional-vs-canonical decision.
   Cross-refs → `PROVISIONAL-IDS-002-PLAN.md`, D-0040,
   `ELEMENT-ID-LAYER-CONTRACT-001-PLAN.md` D6.
+- *Planned:* `plans/IDGEN-NO-GENERATOR-PLAN.md` (2026-07-26, PR #360). The plan
+  **supersedes the fix shape above** on one point: "correct the 19 surfaces to
+  emit provisional ordinal IDs" is right for only five of the six layers. A
+  generator needs `title`/`description`, and `ID_NAMING_STANDARDS.md` defines
+  field extraction for **BRD §7 only** (GD-09 re-affirmed that inventing a
+  boundary for the others is a new normative contract). So BRD surfaces get
+  "call the tool"; PRD/EARS/BDD/ADR/TDD get provisional ordinals.
+- ⚠️ *Blocked on a founder decision (plan step 1):* the layer templates declare
+  `state: canonical`, so instructing five layers to emit `id_state: provisional`
+  contradicts their own default. GD-09 declined to change `state:` for TDD
+  *because* it would make TDD unique — at five layers that argument inverts. If
+  the answer is "change the template default", #342 becomes a **spec** plan
+  (GATE-SPEC + a `framework/VERSION` bump) and must be re-scoped. Resolve before
+  implementing.
 
 ### `[conformance]` `IDCOORD-SECOND-HASH-IMPL` — the acceptance harness re-implements the element hash without normalization → [#351](https://github.com/vladm3105/aidoc-flow-framework/issues/351)
 


### PR DESCRIPTION
Applies the bidirectional-link rule **GD-10** just made normative (#361) to the one open TODO entry that was missing it.

`IDCOORD-SECOND-HASH-IMPL` already carried a `*Planned:*` line pointing at its plan. `IDGEN-NO-GENERATOR` did not — so a reader landing on the TODO entry would take its `*Fix shape:*` as current guidance.

## It is not current

The merged plan (`plans/IDGEN-NO-GENERATOR-PLAN.md`, PR #360) **supersedes the fix shape on one point.** The entry says *"correct the 19 surfaces to emit provisional ordinal IDs."* That is right for only **five of the six layers**:

A generator is a pure function of `(doc_id, section_id, title, description)`. `ID_NAMING_STANDARDS.md` defines field extraction for **BRD §7 only**, and GD-09 re-affirmed that inventing a boundary for the others would be a new normative contract rather than a documentation fix. So the surfaces split: **BRD gets "call the tool"; PRD/EARS/BDD/ADR/TDD get provisional ordinals.**

## The blocker is now visible from the queue

Previously it lived only in the plan and `HANDOFF.md`. The entry now records it: the layer templates declare `state: canonical`, so instructing five layers to emit `id_state: provisional` contradicts their own default. GD-09 declined to change `state:` for TDD *because* that would make TDD unique — at five layers the argument inverts. If the answer is "change the template default," **#342 becomes a spec plan** (GATE-SPEC + a `framework/VERSION` bump) and must be re-scoped.

## Verification

- `pre-commit run --all-files`: **0 failed hooks** on the committed tree
- Conformance unaffected (docs-only)
- No spec or platform change; no `VERSION` bump

The matching comment goes on #342 so the link is bidirectional, as GD-10 requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
