### PR TITLE
fix: one element-hash implementation in the repo; the acceptance harness delegates (#351)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,53 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — one element-hash implementation in the repo; the acceptance harness delegates (#351) (2026-07-26)
+
+**No version moves** — `tests/` plus a docstring inside `tools/sdd_doc_lint/`.
+No `framework/` change, so not a GATE-SPEC change; no platform product change,
+so neither platform `VERSION` moves. Implements
+`plans/IDCOORD-SECOND-HASH-IMPL-PLAN.md`; closes
+[#351](https://github.com/vladm3105/aidoc-flow-framework/issues/351).
+
+- **`_id_coordinator.element_hash()` delegates instead of re-deriving.** It was a
+  second, independent implementation that skipped the D-0062 normalization
+  transform entirely, so any title or description containing uppercase or
+  punctuation hashed differently from the canonical `compute_element_hash()`. The
+  `tools/` `sys.path` insert moved to module scope with it — it previously ran
+  only inside `extract_elements()`, so a module-level import would have raised
+  `ImportError` on the exact call path the new parity test exercises.
+- **A parity test makes silent re-divergence impossible.** Eight cases, one per
+  transform step (casefold, punctuation strip, NFC composition, whitespace
+  collapse, trim, 100-char truncation, combined, empty description), each
+  asserting `element_hash(...) == compute_element_hash(...)[:4]`. A second test
+  guards the guard: every case must hash differently with and without the
+  transform, so no case can silently become one that passes under a wrong
+  implementation.
+- **A latent crash, fixed.** `extract_elements()` used `yaml.safe_load()`, which
+  raises `ComposerError` on a second YAML document — and the three
+  `fullpath/golden_chain/{06_SPEC,07_TDD,08_IPLAN}` goldens carry a frontmatter
+  fence plus a body. Invisible because the only test walking goldens used
+  `layer_NN/valid`. Now `safe_load_all()` taking the last dict document — a
+  key-union merge would promote frontmatter keys into the section namespace,
+  diverging from `_harness.headings()`, which strips frontmatter outright. A
+  `fullpath/` regression test walks all 16 goldens; because no frontmatter in the
+  corpus can mint an element either way, a synthesised artifact pins the
+  body-document contract with the shape that actually discriminates.
+- **The string `section_id` is documented, not silently "fixed".**
+  `element_id()` returns `BRD.01.project_scope.<hash>`, which the registry
+  pattern rejects; the docstring now says so. Making it numeric needs a
+  per-layer heading→ordinal table that exists nowhere in the repo — a new
+  contract, the overreach GD-09 declined for TDD. Tracked as
+  `IDCOORD-NUMERIC-SECTION-ID`.
+- **AS11's docstring named the raw hash input** with no mention of the normative
+  transform (`tools/sdd_doc_lint/__init__.py`); corrected and re-vendored to both
+  platform copies. Documentation only — the implementation 200 lines above was
+  always correct.
+- **Zero golden churn**, as the plan predicted against the issue's stated
+  premise: `git diff --stat tests/acceptance/fixtures/` is empty. `write_registry()`
+  has no callers and `ID_REGISTRY.yaml` is `{}`, so no committed artifact ever
+  carried an ID this code minted.
+
 ### Changed — no authoring surface computes SHA-256 in-prompt; the generator ships (#342) (2026-07-26)
 
 Plugin **`0.23.4 → 0.24.0`** (MINOR), Hermes **`0.11.1 → 0.12.0`** (MINOR).

--- a/plans/DECISIONS.md
+++ b/plans/DECISIONS.md
@@ -10,6 +10,45 @@ graduation.
 
 ---
 
+## D-0069 — A defect fix does not smuggle in a strategy change; and a coverage guard needs a guard of its own
+
+**2026-07-26.** Three decisions from executing IDCOORD-SECOND-HASH-IMPL
+(`plans/IDCOORD-SECOND-HASH-IMPL-PLAN.md`, #351).
+
+- **Keep + fix, not delete — and the question went to the founder first.**
+  `tests/acceptance/_id_coordinator.py` has no product consumer, its registry is
+  `{}`, and `PLUGIN-TEST-SUITE-REVIEW.md:32` **F2** had already offered "remove
+  both files" as a disposition. Deleting it would have closed #351 outright and
+  strictly cheaper. It was still put to the founder as the plan's step 1 rather
+  than decided in-flight, because *whether the suite wants cross-layer ID-closure
+  testing* is a test-strategy question, while *a second wrong implementation of a
+  normative algorithm* is a defect regardless of how that question resolves.
+  **Rule: a defect fix must not be the vehicle for a strategy change.** Answer:
+  keep + fix. The repo now carries a module with no consumer, now correct — a cost
+  stated in the plan before the work, not discovered after it.
+
+- **The string `section_id` was documented, not "fixed."** `element_id()` returns
+  `BRD.01.project_scope.<hash>`, which `LAYER_REGISTRY.yaml:216` rejects. Making
+  it numeric requires a per-layer heading→ordinal table that exists nowhere in the
+  repo — inventing one is a new contract, the same overreach GD-09 declined for
+  TDD field extraction. The docstring now states the limitation and the numeric
+  form is a deferred TODO. **Rule: when the honest fix is a new contract, say what
+  the thing is instead of quietly making it look conformant.**
+
+- **A guard that proves the guard.** The parity table's own check
+  (`test_parity_cases_actually_exercise_the_transform`) asserts each case differs
+  pre/post transform — but it is a property of the *table*, and it cannot see
+  which transform *step* a case covers. A per-step mutation matrix found that
+  **one row covers NFC**, and only while its text stays decomposed: a formatter
+  precomposing the literal would drop that step's coverage to zero with every
+  test still green, because the row's casefold difference alone satisfies the
+  check. **Rule: for a guard over an N-step contract, verify per-step coverage by
+  mutation — a per-case "is it non-trivial" check will report full coverage while
+  a step has none.** This is the same masking class as the
+  `test_no_inprompt_hashing.py` finding recorded in D-0068's session.
+
+---
+
 ## D-0068 — A blocker is only a blocker once verified; and a negative-property guard finds the surfaces a manual census misses
 
 **2026-07-26.** Three decisions from executing IDGEN-NO-GENERATOR

--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -24,31 +24,42 @@
 
 ## Open
 
-### `[conformance]` `IDCOORD-SECOND-HASH-IMPL` — the acceptance harness re-implements the element hash without normalization → [#351](https://github.com/vladm3105/aidoc-flow-framework/issues/351)
+### `[harness]` `IDCOORD-NUMERIC-SECTION-ID` — `_id_coordinator.element_id()` emits a string `section_id`, so its IDs can never be registry-valid
 
-- *Context:* found 2026-07-26 during `ELEMENT-ID-LAYER-CONTRACT-001` Pass 1.
-  `tests/acceptance/_id_coordinator.py:17-19` hashes
-  `f"{doc_id}:{section_id}:{title}:{description}"` raw — no
-  `_normalize_hash_field` — and `element_id()` (`:22-24`) **mints fixture IDs**
-  from it. Its smoke test (`deterministic/test_id_coordinator.py:22-36`) checks
-  determinism and shape only, never parity with `compute_element_hash()`, so a
-  wrong algorithm is indistinguishable from a right one. Second divergence in the
-  same function: `element_id` takes a *string* `section_id` (`"project_scope"`),
-  producing IDs the registry pattern `LAYER_REGISTRY.yaml:216` rejects.
-  Unlike the 30-surface documentation census, this one *executes*.
-- *Fix shape:* delegate to `compute_element_hash`; add a parity test. Fold in the
-  same-class doc defect at `tools/sdd_doc_lint/__init__.py:1131-1132` (AS11
-  docstring states the input with no transform; vendored ×2).
-- *Planned:* `plans/IDCOORD-SECOND-HASH-IMPL-PLAN.md` (2026-07-26).
-  **The "expect fixture-golden churn" premise above is wrong** and the plan
-  corrects it: `write_registry()` has zero callers, `ID_REGISTRY.yaml` is `{}` at
-  3 bytes and unchanged since `f0d08f54`, and no golden carries an ID this code
-  minted — so the fix has **zero** golden churn. The plan also picks up two
-  defects #351 does not mention: `extract_elements()` raises `ComposerError` on
-  the three multi-document `fullpath/golden_chain` YAML goldens (latent — the
-  only walking test uses `layer_NN/valid`), and `PLUGIN-TEST-SUITE-REVIEW.md:32`
-  finding **F2** already recorded the never-imported module + empty registry and
-  was never actioned.
+- *Context:* deferred out of `IDCOORD-SECOND-HASH-IMPL` as plan **D3 option (b)**
+  (2026-07-26). `extract_elements()` derives `section_id` from a normalised
+  heading (`"project_scope"`), so `element_id()` returns
+  `BRD.01.project_scope.<hash>`, which the registry element pattern
+  `^[A-Z]+\.\d{2,}\.\d{2,}\.[a-f0-9]{4,8}$` (`LAYER_REGISTRY.yaml:216`) rejects.
+  The shipped fix documented the limitation (option c) rather than inventing a
+  heading→ordinal mapping — a new contract, the same overreach GD-09 declined
+  for TDD field extraction. Harmless today: the module has no product consumer.
+- *Fix shape:* a per-layer heading→section-ordinal table, which does not exist
+  anywhere in the repo. Only worth building if cross-layer ID-closure testing is
+  actually wired up (the other, still-unactioned half of
+  `PLUGIN-TEST-SUITE-REVIEW.md:32` **F2**); until then the string form is
+  honest about what it is.
+- *Tracker:* **TODO-only** per the GD-10 three-test bar — fails (c) (no consumer
+  is affected: the module has none) and is conditional on prerequisite work
+  nobody has scheduled, i.e. the "already-planned / purely local" carve-out.
+
+### `[harness]` `ACCEPTANCE-TIER-DRIFT-UNTRACKED` — 3 acceptance tests fail on `main`, and no CI job runs the tier → [#365](https://github.com/vladm3105/aidoc-flow-framework/issues/365)
+
+- *Context:* found 2026-07-26 while shipping `IDCOORD-SECOND-HASH-IMPL`, which
+  needed a before/after baseline. `python3 -m unittest discover -s
+  tests/acceptance/deterministic` fails 3 of 58 on `main`: `test_fullpath` and
+  `test_layer_iplan` (ACC01 + COV02 + REFGRAN01), `test_layer_tdd` (COV02 +
+  REFGRAN01), on the `layer_*`/`fullpath` goldens. Not covered by
+  `CORPUS-REFGRAN-RECASCADE`, which is `[example-corpus]`, scoped to
+  `examples/url-shortener/docs/`, and mentions the acceptance suite only for
+  `SPEC-01_golden` REFGRAN01 — nothing about ACC01 or these COV02 findings.
+  **`grep -rn acceptance .github/workflows/` returns nothing**, which is how
+  three red tests sat on `main` unnoticed.
+- *Fix shape:* two independent halves — (1) realign the acceptance fixtures with
+  the coverage rules that have shipped since they were authored (ACC01/COV02
+  element-level coverage, REFGRAN01), and (2) decide whether the tier belongs in
+  CI. Half (2) is the one that keeps this from recurring; it is also the one that
+  needs a call on whether these fixtures are meant to be gate-clean.
 
 ### `[example-corpus]` `SEED-ABSORPTION-001-T7` — 16 BDD scenarios are un-designed (SPEC-coverage gap), not merely un-tested
 
@@ -1053,6 +1064,31 @@
 - *Status:* SHIPPED (spec 0.32.3, 2026-06-29 — BeeLocal docs sweep).
 
 ## Closed
+
+### `[conformance]` `IDCOORD-SECOND-HASH-IMPL` — ✅ CLOSED (2026-07-26) — the acceptance harness re-implemented the element hash without normalization → [#351](https://github.com/vladm3105/aidoc-flow-framework/issues/351)
+
+- *Context:* found 2026-07-26 during `ELEMENT-ID-LAYER-CONTRACT-001` Pass 1.
+  `tests/acceptance/_id_coordinator.py:17-19` hashed
+  `f"{doc_id}:{section_id}:{title}:{description}"` raw — no
+  `_normalize_hash_field`. Its smoke test (`deterministic/test_id_coordinator.py`)
+  checked determinism and shape only, never parity with `compute_element_hash()`,
+  so a wrong algorithm was indistinguishable from a right one.
+- *Shipped:* `plans/IDCOORD-SECOND-HASH-IMPL-PLAN.md` — `element_hash()` now
+  delegates to `compute_element_hash()[:4]` (import hoisted to module scope, since
+  the `tools/` path insert previously ran only inside `extract_elements()`); an
+  8-case parity table covers every transform step, guarded by a second test
+  asserting each case's normalized and un-normalized hashes actually differ;
+  `safe_load` → `safe_load_all` fixes a **latent `ComposerError`** on the three
+  multi-document `fullpath/golden_chain` YAML goldens, with a `fullpath/`
+  regression test closing the coverage gap that hid it; AS11's docstring now names
+  the transform (re-vendored ×2).
+- *Premise correction:* the entry's original "expect fixture-golden churn" claim
+  was **false** — `write_registry()` has zero callers, `ID_REGISTRY.yaml` is `{}`
+  at 3 bytes, and no golden carried an ID this code minted. Verified at ship:
+  `git diff --stat tests/acceptance/fixtures/` empty.
+- *Deferred:* the string-`section_id` half → `IDCOORD-NUMERIC-SECTION-ID` (Open).
+  The keep-or-delete question from `PLUGIN-TEST-SUITE-REVIEW.md:32` **F2** was put
+  to the founder before the work started; answer: **keep + fix**.
 
 ### `[skill]` `IDGEN-NO-GENERATOR` — ✅ CLOSED (2026-07-26) — 19 skill/prompt surfaces instruct LLM-side SHA-256; no callable generator exists → [#342](https://github.com/vladm3105/aidoc-flow-framework/issues/342)
 

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -1,5 +1,54 @@
 # Session Handoff
 
+> **✅ SESSION 2026-07-26 (LATER) — #351 implemented; PR open, closes on merge.**
+>
+> `plans/IDCOORD-SECOND-HASH-IMPL-PLAN.md` executed as written. Its step 1 was a
+> founder keep-or-delete question, put before any code: answer **keep + fix**.
+> `_id_coordinator.element_hash()` now delegates to `compute_element_hash()[:4]`
+> so the repo has **one** element-hash implementation, guarded by an 8-case
+> parity table — plus a test that guards the table itself, asserting each case
+> hashes differently with and without the transform (a case where they coincide
+> would pass under a wrong implementation, which is exactly how the original
+> divergence hid).
+>
+> **The latent `ComposerError` is fixed too**: `safe_load` → `safe_load_all`, with
+> a `fullpath/` regression test that walks all 16 artifacts. Note for anyone
+> re-deriving this — a *leading* `---` is only a document-start marker; all six
+> `fullpath` YAML goldens have one, but only the three under `golden_chain/`
+> carry a *closing* fence and so are genuinely two documents.
+>
+> **No version moved.** `tests/` + one docstring in `tools/sdd_doc_lint/`
+> (re-vendored ×2). **Zero golden churn**, confirming the premise correction.
+>
+> Two things a next session should not re-derive:
+>
+> 1. **The linter's vendoring sync script is `tools/sdd_doc_lint/sync-vendored.sh`**,
+>    not `tools/sync-plugin-framework.sh` — the latter vendors `framework/`
+>    subtrees plus three named tools files and does **not** touch `sdd_doc_lint`.
+>    The plan named the wrong one; `test_doc_lint_vendoring.py:13` names the right
+>    one.
+> 2. **The acceptance deterministic tier has 3 pre-existing failures on `main`**
+>    — `test_fullpath` and `test_layer_iplan` (ACC01 + COV02 + REFGRAN01) and
+>    `test_layer_tdd` (COV02 + REFGRAN01), on the
+>    `tests/acceptance/fixtures/layer_*` goldens. Verified byte-identical before
+>    and after this change; don't mistake them for a regression. **They were not
+>    tracked** — `CORPUS-REFGRAN-RECASCADE` is `[example-corpus]`, covers
+>    `examples/url-shortener/docs/`, and mentions the acceptance suite in one
+>    clause about `SPEC-01_golden` REFGRAN01 only; it says nothing about ACC01 or
+>    the COV02 findings on these fixtures. Now filed as
+>    `ACCEPTANCE-TIER-DRIFT-UNTRACKED` +
+>    [#365](https://github.com/vladm3105/aidoc-flow-framework/issues/365).
+>    **No CI workflow runs this tier** — grep `.github/workflows/` for
+>    "acceptance" returns nothing — which is how three red tests sat on `main`
+>    unnoticed.
+>
+> Still open, deliberately: `IDCOORD-NUMERIC-SECTION-ID` (the string-`section_id`
+> half, plan D3 option b) and the other half of `PLUGIN-TEST-SUITE-REVIEW.md:32`
+> **F2** — wiring `write_registry()` into a real closure test. The module still
+> has no product consumer; it is now merely correct.
+
+---
+
 > **✅ SESSION 2026-07-26 (WRAP) — issue sweep complete: 8 issues triaged, 7
 > closed, 8 PRs merged, framework `0.38.0 → 0.40.0`.**
 >
@@ -23,6 +72,9 @@
 > unchanged at its pinned baseline throughout.
 >
 > ## Only #351 remains, and it is cheaper than it looks
+>
+> *(Superseded by the banner at the top of this file — #351 was implemented later
+> the same day. The rest of this section is the record as it stood at wrap.)*
 >
 > Plan merged (`plans/IDCOORD-SECOND-HASH-IMPL-PLAN.md`), implementation
 > deferred by founder choice. **Its filed premise is false** — `write_registry()`
@@ -133,7 +185,8 @@
 > discharged and would raise a permanent `PROV01` on every artifact.
 >
 > **One issue left open: [#351](https://github.com/vladm3105/aidoc-flow-framework/issues/351)**
-> (plan merged, impl deferred by founder choice). Its filed premise is false —
+> (plan merged, impl deferred by founder choice — *superseded: implemented later
+> the same day; see the banner at the top of this file*). Its filed premise is false —
 > **zero golden churn** — so it is cheaper than it looks. Its plan's step 1 is a
 > keep-or-delete question: `_id_coordinator.py` has no product consumer and
 > `PLUGIN-TEST-SUITE-REVIEW.md:32` F2 already proposed removing it, which would
@@ -190,7 +243,7 @@
 > |---|---|---|
 > | #345 | ✅ **spec half done** — `0.40.0`, **GD-10**, in [#358](https://github.com/vladm3105/aidoc-flow-framework/pull/358) (stacked on #357) | `DOC_GOVERNANCE_CORE.md` Principle 9 + `FRAMEWORK_FEEDBACK_LOG.md` §"Tier 2 → the tracker". `CLAUDE.md`'s "spec counterpart is not yet ratified" caveat was replaced — it had become false |
 > | #342 | 📋 **plan merged** ([#360](https://github.com/vladm3105/aidoc-flow-framework/pull/360)), impl not started | `plans/IDGEN-NO-GENERATOR-PLAN.md`. **Step 1 is a founder decision, not code** — see the blocker below. Depends on #357 landing first |
-> | #351 | 📋 **plan merged** ([#359](https://github.com/vladm3105/aidoc-flow-framework/pull/359)), impl deliberately not started | `plans/IDCOORD-SECOND-HASH-IMPL-PLAN.md`. **Its premise changed** — see below |
+> | #351 | ✅ **SHIPPED later the same day** — see the banner at the top of this file | `plans/IDCOORD-SECOND-HASH-IMPL-PLAN.md`. Founder answered its step-1 keep-or-delete question **keep + fix**. The rest of this row's "not started" framing is the record as it stood at wrap |
 >
 > **#342 carries an unresolved blocker that decides its tier.** The layer
 > templates declare `state: canonical`; instructing five layers to emit
@@ -260,7 +313,7 @@
 >
 > | Issue | Gap |
 > |---|---|
-> | [#351](https://github.com/vladm3105/aidoc-flow-framework/issues/351) | `tests/acceptance/_id_coordinator.py:17` is a **live second implementation** that skips the D-0062 normalization and **mints fixture IDs**; its smoke test never checks parity with `compute_element_hash()`. Also emits string `section_id`s the registry pattern rejects. Fixing it churns committed goldens — hence its own plan |
+> | [#351](https://github.com/vladm3105/aidoc-flow-framework/issues/351) | `tests/acceptance/_id_coordinator.py:17` is a **live second implementation** that skips the D-0062 normalization and **mints fixture IDs**; its smoke test never checks parity with `compute_element_hash()`. Also emits string `section_id`s the registry pattern rejects. ~~Fixing it churns committed goldens~~ — **that premise was false; zero churn, verified at ship** |
 > | [#352](https://github.com/vladm3105/aidoc-flow-framework/issues/352) | `placeholder: "0000"` matches neither available meaning, is defined nowhere in `framework/governance/`, and has no consumer. **#343's "secondary observation" was valid** — an early draft of the plan wrongly rejected it |
 > | [#342 comment](https://github.com/vladm3105/aidoc-flow-framework/issues/342#issuecomment-5084448384) | Scope corrected **9 → 19** surfaces (union — nothing dropped). Highest-value item: `brd-validation-automation.md:179`, a **loaded** reference (`sdd-orchestrator/SKILL.md:836`) shipping runnable code with a **fourth** normalization variant disagreeing with the standard on five of six steps. That is what an agent finds instead of writing its own script |
 >

--- a/plans/IDCOORD-SECOND-HASH-IMPL-PLAN.md
+++ b/plans/IDCOORD-SECOND-HASH-IMPL-PLAN.md
@@ -4,7 +4,7 @@
 | -------------- | ------------------------------------------------------------ |
 | Task           | IDCOORD-SECOND-HASH-IMPL                                     |
 | Type           | test-harness                                                 |
-| Status         | PLANNED — 2026-07-26                                         |
+| Status         | ✅ SHIPPED — 2026-07-26                                      |
 | Depends on     | D-0062 (PROVISIONAL-IDS-002 Phase 1), D-0067 / GD-09         |
 | Closes         | [#351](https://github.com/vladm3105/aidoc-flow-framework/issues/351) |
 | Version impact | **None.** No `framework/` change, no platform change, no `VERSION` bump — `tests/` only |
@@ -334,3 +334,71 @@ now says "no `VERSION` bump" explicitly rather than implying it via "not
 GATE-SPEC" (E touches `tools/`, which a reader could reasonably think is a
 platform surface), and Risk 2 names the concrete failure mode (pytest rootdir)
 rather than "path issues." Converged.
+
+## Implementation notes — 2026-07-26
+
+Step 1 was put to the founder before any code was written; the answer was
+**keep + fix**, so A–E executed as specified. Three corrections to the plan that
+only surfaced against the source:
+
+1. **Step 6 named the wrong sync script.** `tools/sync-plugin-framework.sh`
+   vendors `framework/` subtrees plus three named `tools/` files
+   (`saga_driver.py`, `finding_filter.py`, `playbook_loader.py`) — **not**
+   `sdd_doc_lint`. The script that re-vendors the linter is
+   `tools/sdd_doc_lint/sync-vendored.sh`, which
+   `tests/conformance/platforms/test_doc_lint_vendoring.py:13` names as the fix
+   command. Used that; the three `md5sum`s match.
+2. **"Frontmatter-bearing" is not the same as "multi-document."** A *leading*
+   `---` is only a document-start marker; what `safe_load` rejects is a second
+   document, i.e. a *closing* fence. All six `fullpath` YAML goldens open with
+   `---`, but only the three under `golden_chain/` carry two markers and crash.
+   The regression test counts parsed documents rather than inspecting the first
+   line.
+3. **The parity table needed guards of its own.** A parity case whose raw and
+   normalized forms happen to coincide would pass under the wrong implementation
+   too — the same "passes under any hash function" flaw that let the original
+   divergence hide. `test_parity_cases_actually_exercise_the_transform` asserts
+   every case differs pre/post transform. It is a property of the *table*, not of
+   `element_hash` — it is green on `HEAD` too, by design; the 8 subtests that go
+   red before the fix and green after are
+   `test_element_hash_matches_canonical_prefix`'s.
+
+   Self-review then found the table had a hole the guard could not see. A
+   per-step mutation matrix (drop one transform step, see which rows catch it)
+   showed **exactly one row covers NFC** — and only while its text stays
+   decomposed. A formatter that precomposed the literal would drop NFC coverage
+   to zero with every test still green, since that row's casefold difference
+   alone satisfies the exercise-check. Fixed by writing the row as `é`
+   escapes plus `test_nfc_case_is_decomposed`. Final matrix: nfc←1 row,
+   truncate←1, collapse←3, strip←4, casefold←7. Every step covered.
+
+4. **The same trap caught the YAML fix, twice.** Review found the merge should
+   take the last dict document rather than union the key sets (a union promotes
+   frontmatter keys into the section namespace, diverging from
+   `_harness.headings()`). The `fullpath/` regression test was then asserted to
+   catch that — it does not: mutating the fix back to `data.update(document)`
+   left all tests green, because today's frontmatter is `doc_id` (scalar) and
+   `metadata` (filtered by name). The first replacement test *also* failed to
+   discriminate: `reuse:` (TRACEABILITY.md:141), the one first-class frontmatter
+   block the spec defines, is a flat dict of scalars and mints nothing either
+   way. Only a frontmatter key mapping to a **mapping-of-mappings** — the
+   extractor's own criterion for a walkable section — separates the two
+   implementations, so `test_frontmatter_keys_are_not_walked_as_sections`
+   synthesises exactly that, verified red under the mutation and green after.
+   **Every "this test would catch it" claim in this PR was checked by mutation;
+   two of them were false.**
+
+**Verification at ship** — parity + fullpath tests red before, green after;
+acceptance deterministic tier 62 tests with the **same 3 pre-existing failures**
+as `HEAD`; conformance **253 passed / 688 subtests**; Hermes **570 passed**;
+`git diff --stat tests/acceptance/fixtures/` **empty** (the plan's central claim,
+confirmed); `git diff --stat framework/` empty; both sync scripts idempotent.
+
+**Those 3 pre-existing failures turned out to be untracked**, contrary to a first
+draft of this note that attributed them to `CORPUS-REFGRAN-RECASCADE`. That entry
+is `[example-corpus]`, covers `examples/url-shortener/docs/`, and touches the
+acceptance suite only in one clause about `SPEC-01_golden` REFGRAN01 — it does not
+cover ACC01 (present in 2 of the 3) or the COV02 findings on these fixtures. Filed
+as `ACCEPTANCE-TIER-DRIFT-UNTRACKED` +
+[#365](https://github.com/vladm3105/aidoc-flow-framework/issues/365), together
+with the reason it went unnoticed: **no CI workflow runs the acceptance tier.**

--- a/platforms/claude-code-plugin/sdd_doc_lint/__init__.py
+++ b/platforms/claude-code-plugin/sdd_doc_lint/__init__.py
@@ -1129,7 +1129,11 @@ def _check_id_uniqueness(corpus: list[tuple[str, str]]) -> list[Finding]:
     """AS11 — element-ID hash integrity (definition uniqueness).
 
     Each element ID ``TYPE.NN.SS.xxxx`` carries a 4-hex-char SHA256-prefix of
-    its ``{doc_id}:{section_id}:{title}:{description}`` content. A canonical
+    its content, as computed by ``compute_element_hash()`` — which normalizes
+    ``title`` and ``description`` per ``_normalize_hash_field`` before
+    assembling ``{doc_id}:{section_id}:{norm(title)}:{norm(description)}``. The
+    transform is normative (ID_NAMING_STANDARDS "Normalization transform"); a
+    hash taken over the raw fields is a different hash. A canonical
     invariant is that any given hash defines **one** element — so the same ID
     must not be *defined* in two different files (citations via
     ``@<lower>:`` tags are fine; only standalone definitions count).

--- a/platforms/hermes/sdd_doc_lint/__init__.py
+++ b/platforms/hermes/sdd_doc_lint/__init__.py
@@ -1129,7 +1129,11 @@ def _check_id_uniqueness(corpus: list[tuple[str, str]]) -> list[Finding]:
     """AS11 — element-ID hash integrity (definition uniqueness).
 
     Each element ID ``TYPE.NN.SS.xxxx`` carries a 4-hex-char SHA256-prefix of
-    its ``{doc_id}:{section_id}:{title}:{description}`` content. A canonical
+    its content, as computed by ``compute_element_hash()`` — which normalizes
+    ``title`` and ``description`` per ``_normalize_hash_field`` before
+    assembling ``{doc_id}:{section_id}:{norm(title)}:{norm(description)}``. The
+    transform is normative (ID_NAMING_STANDARDS "Normalization transform"); a
+    hash taken over the raw fields is a different hash. A canonical
     invariant is that any given hash defines **one** element — so the same ID
     must not be *defined* in two different files (citations via
     ``@<lower>:`` tags are fine; only standalone definitions count).

--- a/tests/acceptance/_id_coordinator.py
+++ b/tests/acceptance/_id_coordinator.py
@@ -1,34 +1,65 @@
 """Compute deterministic element IDs for fixture artifacts.
 
-Element ID format: TYPE.NN.SS.xxxx where xxxx = first 4 hex of
-SHA256("{doc_id}:{section_id}:{title}:{description}").
+Element ID format: TYPE.NN.SS.xxxx where xxxx is the first 4 hex chars of the
+canonical element hash — ``sdd_doc_lint.compute_element_hash()``, which applies
+the normative ID_NAMING_STANDARDS transform to ``title`` and ``description``
+before hashing. This module MUST NOT re-derive that hash; it delegates, and
+``deterministic/test_id_coordinator.py`` asserts the delegation holds
+(IDCOORD-SECOND-HASH-IMPL, #351).
 """
 
-import hashlib
 import re
 import sys
 from pathlib import Path
 
 import yaml
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "conformance"))
+# Module scope, not inside extract_elements(): element_hash() is called on its
+# own by the parity test, which would ImportError if the path insert only ran
+# on the extract_elements() code path. (This makes tools/ *available* on the
+# path; it does not by itself decide which copy wins — a combined run that
+# already imported a vendored platforms/*/sdd_doc_lint keeps that one in
+# sys.modules. Harmless: test_doc_lint_vendoring.py holds all three copies
+# byte-identical.)
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+from sdd_doc_lint import _normalise_heading, compute_element_hash
 
 
 def element_hash(doc_id: str, section_id: str, title: str, description: str) -> str:
-    key = f"{doc_id}:{section_id}:{title}:{description}"
-    return hashlib.sha256(key.encode("utf-8")).hexdigest()[:4]
+    """Return the canonical element hash, truncated to the 4-char standard form.
+
+    ``compute_element_hash()`` returns the full 64-char digest and leaves the
+    slice to its caller by design — 4 chars for the standard form, 8 for the
+    collision form. This helper is hard-wired to 4: fixture IDs have no
+    collision-escape path, which is acceptable only because the module has no
+    product consumer.
+    """
+    return compute_element_hash(doc_id, section_id, title, description)[:4]
 
 
 def element_id(doc_type: str, doc_num: int, section_id: str, title: str, description: str) -> str:
+    """Return a fixture-local element identifier — NOT a spec-conformant element ID.
+
+    ``section_id`` is a normalised heading string (``"project_scope"``), because
+    that is all ``extract_elements()`` can derive from an artifact's headings.
+    The spec's element form is ``{TYPE}.{doc_id}.{section_id}.{hash}`` with a
+    two-digit NUMERIC section, and the registry pattern
+    ``^[A-Z]+\\.\\d{2,}\\.\\d{2,}\\.[a-f0-9]{4,8}$``
+    (``framework/registry/LAYER_REGISTRY.yaml``) therefore rejects what this
+    returns. Deliberate: mapping heading → section ordinal would require a
+    per-layer table that does not exist anywhere in the repo, and inventing one
+    is a new contract, not a fixture helper's job (plan D3 option c; the
+    numeric form is tracked as a deferred TODO).
+
+    The **hash** is canonical regardless — only the ``section_id`` segment is
+    fixture-local.
+    """
     doc_id = f"{doc_type}-{doc_num:02d}"
     return f"{doc_type}.{doc_num:02d}.{section_id}.{element_hash(doc_id, section_id, title, description)}"
 
 
 def extract_elements(artifact: Path) -> list[dict]:
     """Walk an artifact and return [{section_id, title, description, element_id}, ...]."""
-    sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
-    from sdd_doc_lint import _normalise_heading
-
     text = artifact.read_text(encoding="utf-8")
     artifact_id_match = re.search(r"^\s*artifact_id:\s*([A-Z]+-\d+)", text, re.MULTILINE)
     if not artifact_id_match:
@@ -65,7 +96,20 @@ def extract_elements(artifact: Path) -> list[dict]:
                     }
                 )
     elif artifact.suffix == ".yaml":
-        data = yaml.safe_load(text) or {}
+        # safe_load_all, not safe_load: YAML goldens may carry a `---`-fenced
+        # frontmatter block ahead of the body, i.e. two YAML documents, which
+        # safe_load rejects with ComposerError. Take the LAST dict document —
+        # the body — rather than merging the two key sets. A key-union would
+        # promote frontmatter keys into the section namespace, diverging from
+        # _harness.headings(), which strips frontmatter outright. No frontmatter
+        # in the corpus today would actually mint an element either way (`doc_id`
+        # is scalar, `metadata` is filtered by name, and `reuse:` is a flat dict
+        # of scalars) — a frontmatter key mapping to a mapping-of-mappings would,
+        # and test_frontmatter_keys_are_not_walked_as_sections pins that.
+        data: dict = {}
+        for document in yaml.safe_load_all(text):
+            if isinstance(document, dict):
+                data = document
         for section_key, section in data.items():
             if section_key.startswith("_") or section_key == "metadata":
                 continue

--- a/tests/acceptance/deterministic/test_id_coordinator.py
+++ b/tests/acceptance/deterministic/test_id_coordinator.py
@@ -1,24 +1,114 @@
 """Deterministic acceptance: _id_coordinator helpers work against committed goldens.
 
-This is a smoke test — it exercises extract_elements + element_id + write_registry
-end-to-end so the helpers don't rot. Strict cross-layer ID closure is still
-deferred (see PLUGIN-TEST-SUITE-REVIEW.md F2): downstream goldens reference
-placeholder upstream IDs that don't reproduce the upstream's actual element hashes.
+The smoke block exercises extract_elements + element_id so the helpers don't rot.
+It does NOT reach write_registry(), which has no caller anywhere in the repo:
+strict cross-layer ID closure is still deferred (see PLUGIN-TEST-SUITE-REVIEW.md
+F2), because downstream goldens reference placeholder upstream IDs that don't
+reproduce the upstream's actual element hashes.
+
+The parity block below is NOT a smoke test — it is the guard that keeps
+``element_hash()`` a delegation to the canonical ``compute_element_hash()``
+instead of a second implementation of the ID_NAMING_STANDARDS transform
+(IDCOORD-SECOND-HASH-IMPL, #351).
 """
 
+import hashlib
 import sys
+import tempfile
+import unicodedata
 import unittest
 from pathlib import Path
 
+import yaml
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from _harness import FIXTURES_ROOT, fixtures_for
+from _harness import FIXTURES_ROOT, fixtures_for, headings
 from _id_coordinator import element_hash, element_id, extract_elements
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "conformance"))
 from _spec import ARTIFACTS
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "tools"))
+from sdd_doc_lint import compute_element_hash
+
+#: Inputs chosen so each row exercises at least one step of the normalization
+#: transform (ID_NAMING_STANDARDS "Normalization transform"): NFC → casefold →
+#: strip to ``[a-z0-9 ]`` → collapse whitespace → trim → first 100 chars. A row
+#: whose raw and normalized forms coincide would pass under any hash function and
+#: so proves nothing; every row here differs pre/post transform.
+PARITY_CASES = [
+    ("casefold", "BRD-01", "07", "User Login", "Users Authenticate"),
+    ("punctuation", "BRD-01", "07", "User Login (P1)", "Users authenticate; then land."),
+    # Explicit escapes, NOT a literal precomposed character: "e" + U+0301
+    # COMBINING ACUTE. This is the ONLY row exercising the NFC step, and it does
+    # so only while the text stays decomposed. An editor or formatter that
+    # precomposed a literal here would silently drop NFC coverage to zero with
+    # every test still green — the row's casefold difference alone satisfies the
+    # exercise-check below. Escapes cannot be normalized away in source, and
+    # test_nfc_case_is_decomposed fails loudly if it happens regardless.
+    ("nfc", "PRD-02", "03", "Caf\u0065\u0301 mode", "S\u0065\u0301lection d\u0065\u0301faut"),
+    ("whitespace_runs", "EARS-01", "04", "Ubiquitous\t\trule", "When  X   then  Y"),
+    ("leading_trailing", "BDD-01", "05", "  Scenario name  ", "\n Given a user \t"),
+    ("truncation", "ADR-01", "02", "d" * 140, "e" * 250),
+    ("all_steps", "SPEC-01", "06", "  API: /v1/Users — LIST  ", "Returns\tthe   User List."),
+    ("empty_description", "TDD-01", "01", "Unit test", ""),
+]
+
+
+class ElementHashParityTests(unittest.TestCase):
+    """``element_hash()`` must BE the canonical hash, not resemble it."""
+
+    def test_element_hash_matches_canonical_prefix(self):
+        for label, doc_id, section_id, title, description in PARITY_CASES:
+            with self.subTest(case=label):
+                self.assertEqual(
+                    element_hash(doc_id, section_id, title, description),
+                    compute_element_hash(doc_id, section_id, title, description)[:4],
+                    f"{label}: _id_coordinator.element_hash diverged from "
+                    "sdd_doc_lint.compute_element_hash",
+                )
+
+    def test_nfc_case_is_decomposed(self):
+        """The NFC row must stay decomposed or it stops testing the NFC step.
+
+        Only this row exercises NFC. If its text were precomposed, the row would
+        still pass every other assertion in this file — including the
+        exercise-check below, which its casefold difference satisfies on its own.
+        Coverage of one normative transform step would vanish silently, which is
+        the same failure mode that let the original divergence hide.
+        """
+        (case,) = [c for c in PARITY_CASES if c[0] == "nfc"]
+        _, _, _, title, description = case
+        for field in (title, description):
+            self.assertFalse(
+                unicodedata.is_normalized("NFC", field),
+                f"{field!r} is already NFC-normalized — the nfc parity case no "
+                "longer exercises the NFC step; restore the \\u0065\\u0301 escapes",
+            )
+
+    def test_parity_cases_actually_exercise_the_transform(self):
+        """Guard the guard: every case must differ from its un-normalized form.
+
+        If a case hashed the same with and without the transform, its parity
+        assertion would hold under a wrong implementation too.
+        """
+        for label, doc_id, section_id, title, description in PARITY_CASES:
+            with self.subTest(case=label):
+                raw = f"{doc_id}:{section_id}:{title}:{description}"
+                unnormalized = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:4]
+                self.assertNotEqual(
+                    unnormalized,
+                    compute_element_hash(doc_id, section_id, title, description)[:4],
+                    f"{label}: normalized and un-normalized hashes coincide — "
+                    "this case cannot detect a missing transform",
+                )
+
 
 class IdCoordinatorSmokeTests(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+
     def test_element_hash_is_deterministic(self):
         a = element_hash("BRD-01", "project_scope", "Scope", "In: A; Out: B")
         b = element_hash("BRD-01", "project_scope", "Scope", "In: A; Out: B")
@@ -58,6 +148,111 @@ class IdCoordinatorSmokeTests(unittest.TestCase):
                     self.assertIn("element_id", elem)
                     self.assertRegex(elem["element_id"], rf"^{name}\.\d+\.\w+\.[0-9a-f]{{4}}$")
 
+    def test_extract_elements_runs_on_every_fullpath_golden(self):
+        """Regression: multi-document YAML goldens must not crash the extractor.
+
+        The layer-tier test above walks ``layer_NN_<name>/valid/`` only, which is
+        why the ``ComposerError`` on the three ``fullpath/golden_chain`` YAML
+        goldens — each carrying a ``---`` frontmatter fence plus a body, i.e. two
+        YAML documents — stayed invisible. Walking ``fullpath/`` closes that gap.
+
+        Three FURTHER multi-document goldens sit under ``layer_07_tdd/valid/`` and
+        ``layer_08_iplan/valid/`` as upstream companions; the per-layer glob above
+        (``{name}-01_golden.*``) does not reach them. Not a second code path —
+        there is one extractor, exercised here — but do not read "3
+        multi-document goldens" as a count of the whole fixture tree.
+        """
+        # Scoped to goldens: an rglob over every .md/.yaml would also count
+        # `*_drift_codes.yaml` manifests, so adding a broken fixture the
+        # documented way would fail this for reasons unrelated to element IDs.
+        artifacts = sorted((FIXTURES_ROOT / "fullpath").rglob("*_golden.*"))
+        self.assertEqual(len(artifacts), 16, "fullpath golden set changed shape")
+        multi_doc_seen = 0
+        for artifact in artifacts:
+            with self.subTest(artifact=str(artifact.relative_to(FIXTURES_ROOT))):
+                elements = extract_elements(artifact)
+                self.assertIsInstance(elements, list)
+                for elem in elements:
+                    self.assertIn("section_id", elem)
+                    self.assertIn("title", elem)
+                    self.assertIn("description", elem)
+                    self.assertRegex(elem["element_id"], r"^[A-Z]+\.\d+\.\w+\.[0-9a-f]{4}$")
+                if artifact.suffix != ".yaml":
+                    continue
+                # Body sections per _harness.headings(), which strips the
+                # optional frontmatter fence independently of the extractor.
+                # NB: this holds under a key-union merge too, because today's
+                # frontmatter is only `doc_id` (scalar) + `metadata` (filtered).
+                # The case that actually discriminates is synthesised in
+                # test_frontmatter_dict_is_not_walked_as_a_section.
+                body_sections = set(headings(artifact))
+                for elem in elements:
+                    self.assertIn(elem["section_id"], body_sections)
+                # A *leading* `---` is only a document-start marker; what
+                # crashed safe_load is a second document, i.e. a closing
+                # frontmatter fence. Count documents rather than guessing
+                # from the first line.
+                documents = list(yaml.safe_load_all(artifact.read_text(encoding="utf-8")))
+                if len(documents) > 1:
+                    multi_doc_seen += 1
+                    self.assertGreater(
+                        len(elements),
+                        0,
+                        f"{artifact.name}: multi-document golden yielded no "
+                        "elements — the body document was not parsed",
+                    )
+        # >= rather than ==: this exists to prove the regression scenario is
+        # actually present in the corpus, so zero must fail. Adding a fourth
+        # multi-document golden is a good change and must not fail.
+        self.assertGreaterEqual(
+            multi_doc_seen, 3, "expected >= 3 multi-document YAML goldens under fullpath/"
+        )
+
+    def test_frontmatter_keys_are_not_walked_as_sections(self):
+        """Elements come from the body document only, never the frontmatter.
+
+        **The committed corpus cannot test this**, which is the whole reason it
+        is synthesised. Today's frontmatter is `doc_id` (scalar → skipped) plus
+        `metadata` (filtered by name), and the one first-class frontmatter block
+        the spec defines — `reuse:` (D-0041, TRACEABILITY.md:141) — is a flat
+        dict of scalars, so it mints nothing either. Over that corpus,
+        last-document-wins and a key-union merge are indistinguishable; both pass
+        every other test in this file.
+
+        The shape that separates them is a frontmatter key whose value is a
+        mapping of mappings (or a list of mappings) — the extractor's own
+        criterion for a section worth walking. No current frontmatter has that
+        shape; this pins the contract before one does.
+        """
+        artifact = Path(self.tmpdir.name) / "SPEC-01_golden.yaml"
+        artifact.write_text(
+            "---\n"
+            "doc_id: SPEC-01\n"
+            "metadata:\n"
+            "  artifact_id: SPEC-01\n"
+            "overrides:\n"
+            "  authservice:\n"
+            "    title: Overridden component\n"
+            "    description: Frontmatter, so it must never become an element\n"
+            "---\n"
+            "\n"
+            "interfaces:\n"
+            "  - name: AuthService\n"
+            "    description: Issues tokens\n",
+            encoding="utf-8",
+        )
+        sections = {elem["section_id"] for elem in extract_elements(artifact)}
+        self.assertEqual(
+            sections,
+            {"interfaces"},
+            "frontmatter keys leaked into the section namespace — extract_elements "
+            "must take the body document, not merge the two key sets",
+        )
+
     def test_registry_path_present(self):
         registry = FIXTURES_ROOT / "fullpath" / "ID_REGISTRY.yaml"
         self.assertTrue(registry.exists(), "ID_REGISTRY.yaml missing")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/sdd_doc_lint/__init__.py
+++ b/tools/sdd_doc_lint/__init__.py
@@ -1129,7 +1129,11 @@ def _check_id_uniqueness(corpus: list[tuple[str, str]]) -> list[Finding]:
     """AS11 — element-ID hash integrity (definition uniqueness).
 
     Each element ID ``TYPE.NN.SS.xxxx`` carries a 4-hex-char SHA256-prefix of
-    its ``{doc_id}:{section_id}:{title}:{description}`` content. A canonical
+    its content, as computed by ``compute_element_hash()`` — which normalizes
+    ``title`` and ``description`` per ``_normalize_hash_field`` before
+    assembling ``{doc_id}:{section_id}:{norm(title)}:{norm(description)}``. The
+    transform is normative (ID_NAMING_STANDARDS "Normalization transform"); a
+    hash taken over the raw fields is a different hash. A canonical
     invariant is that any given hash defines **one** element — so the same ID
     must not be *defined* in two different files (citations via
     ``@<lower>:`` tags are fine; only standalone definitions count).


### PR DESCRIPTION
Implements `plans/IDCOORD-SECOND-HASH-IMPL-PLAN.md`. **Closes #351.**

## What was wrong

`tests/acceptance/_id_coordinator.py:17-19` was a second, independent
implementation of the element-ID hash that skipped the D-0062 normalization
transform entirely. Any title or description containing uppercase or punctuation
— nearly all of them — hashed differently from the canonical
`compute_element_hash()`. Its smoke test asserted determinism and shape but never
parity, so a wrong algorithm was indistinguishable from a right one.

## What changed

| # | Change |
|---|---|
| A | `element_hash()` delegates to `compute_element_hash()[:4]`. The `tools/` `sys.path` insert moved to module scope with it — it previously ran only inside `extract_elements()`, so a module-level import would `ImportError` on the exact call path the parity test exercises |
| B | 8-case parity table, one case per transform step, plus two guards on the table itself (see below) |
| C | The string `section_id` is **documented** as fixture-local, not silently made to look registry-conformant. The numeric form needs a per-layer heading→ordinal table that exists nowhere in the repo — a new contract, the overreach GD-09 declined for TDD. Deferred as `IDCOORD-NUMERIC-SECTION-ID` |
| D | `safe_load` → `safe_load_all` fixes a **latent `ComposerError`** on the three multi-document `fullpath/golden_chain` YAML goldens |
| E | AS11's docstring named the raw hash input with no mention of the normative transform; corrected and re-vendored (×2) |

## The issue's premise was false, and that is confirmed at ship

#351 stated that `element_id()` feeds `write_registry()`, "so committed fixture
IDs derive from the wrong algorithm," and that fixing it needs "a deliberate
golden-update pass" — the stated reason it was deferred out of
ELEMENT-ID-LAYER-CONTRACT-001.

`write_registry()` has zero callers, `ID_REGISTRY.yaml` is `{}` at 3 bytes, and
no golden carries an ID this code minted. **`git diff --stat
tests/acceptance/fixtures/` is empty.**

## Every "this test would catch it" claim was checked by mutation — two were false

This is the part worth reviewing:

1. A **per-step mutation matrix** (drop one transform step, see which parity rows
   catch it) found **exactly one row covers NFC**, and only while its text stays
   decomposed. A formatter precomposing the literal would drop that step's
   coverage to zero with every test still green, because the row's casefold
   difference alone satisfies the "is this case non-trivial" check. Fixed with
   `é` escapes + `test_nfc_case_is_decomposed`. Final matrix: nfc←1,
   truncate←1, collapse←3, strip←4, casefold←7.
2. The `fullpath/` regression test was claimed to catch a frontmatter-winning
   merge. It does not — mutating the fix to `data.update(document)` left all
   tests green. The **first replacement test also failed to discriminate**:
   `reuse:` (TRACEABILITY.md:141), the one first-class frontmatter block the spec
   defines, is a flat dict of scalars and mints nothing either way. Only a
   frontmatter key mapping to a *mapping-of-mappings* separates the two
   implementations, so `test_frontmatter_keys_are_not_walked_as_sections`
   synthesises exactly that — verified red under the mutation, green after.

## Also filed: #365

The before/after baseline surfaced that **3 acceptance tests fail on `main`**
(`test_fullpath`, `test_layer_iplan`, `test_layer_tdd` — ACC01/COV02/REFGRAN01)
and **no CI workflow runs that tier**. Not covered by `CORPUS-REFGRAN-RECASCADE`,
which is `[example-corpus]`-scoped. Filed as #365 + `ACCEPTANCE-TIER-DRIFT-UNTRACKED`.

## Verification

| Check | Result |
|---|---|
| `test_id_coordinator.py` | 10 passed / 40 subtests (parity + fullpath subtests red before the fix) |
| Acceptance deterministic tier | 63 tests, **same 3 pre-existing failures as `HEAD`** (58 → 63 tests) |
| Conformance | 253 passed / 688 subtests |
| Hermes | 570 passed |
| Golden churn | `git diff --stat tests/acceptance/fixtures/` **empty** |
| Spec change | `git diff --stat framework/` **empty** |
| Vendoring | three `sdd_doc_lint/__init__.py` copies byte-identical |

## Version impact: none

`tests/` plus a docstring inside `tools/sdd_doc_lint/`. No `framework/` change, so
**not GATE-SPEC**; no platform product change, so neither platform `VERSION` moves.
The `platforms/*/sdd_doc_lint/` edits are the sync script's output, never hand-edited.

## Notes for the reviewer

- **The plan named the wrong sync script.** `tools/sync-plugin-framework.sh` does
  not vendor `sdd_doc_lint`; `tools/sdd_doc_lint/sync-vendored.sh` does, as
  `test_doc_lint_vendoring.py:13` says. Corrected in the plan's implementation notes.
- **Governance Rule 1 exception, per founder OK** — this PR touches 5 doc
  surfaces against the ≤3 cap. It is an impl PR documenting its own work and all
  5 are doc-currency obligations of this single change; splitting would produce a
  PR whose docs describe unmerged code. Audit line is in the commit message.
- Self-review: 2 multi-agent cycles (code-reviewer + docs-consistency), all
  load-bearing findings folded before push.
