### PR TITLE
ci: bump ai-review to ci/v2.15.0 — stop the self-cancel that blocks every PR

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -51,7 +51,17 @@ permissions:
   issues: write          # gh api label create/apply paths
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/ai-review.yml@ci/v2.14.0
+    # ci/v2.15.0 — the CI-0025 self-cancel fix (aidoc-flow-ci#322). At v2.14.0 the
+    # reusable's concurrency group used a DENYLIST of self-emitted actions, so the
+    # review this workflow posts fired `pull_request_review: submitted`, which
+    # landed in the same group and cancelled the `pull_request_target` run that had
+    # just posted it — stranding a CANCELLED `call / ai-review` check on the head
+    # SHA. A cancelled required context is not success, so EVERY PR blocked and
+    # merged only via `--admin` (observed on #366 and #367). v2.15.0 replaces the
+    # denylist with an ALLOWLIST of the two code-changing actions (`synchronize`,
+    # `opened`); every other subscribed event fires at the current head and must
+    # not cancel. Do not pin back below v2.15.0.
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/ai-review.yml@ci/v2.15.0
     with:
       # Model selection is CONFIG-DRIVEN: the reusable reads `litellm.model`
       # from the trusted .github/ai-review/config.json. Uncomment to override:


### PR DESCRIPTION
## ⚠️ This PR needs a manual merge — it is the one that unblocks all the others

**Merge this by hand.** It cannot merge itself, for the reason it fixes (see "Chicken-and-egg" below). Every PR merged after it should go green normally.

## The defect

At `ci/v2.14.0` the reusable's concurrency group uses a **denylist** of self-emitted actions:

```yaml
cancel-in-progress: action != 'labeled' && action != 'unlabeled'
```

This workflow **posts its own review** → that fires `pull_request_review: submitted` → same concurrency group → it **cancels the `pull_request_target` run that just posted it**. The cancelled run strands a `CANCELLED` `call / ai-review` check-run on the head SHA. A cancelled required context is not success, so the PR is `BLOCKED` — even with the newest run of all five required contexts green.

Observed twice, on **#366** and **#367**:

| SHA `0197643d` (PR #367) | event | result |
|---|---|---|
| run 30269581995 | `pull_request_target` | **CANCELLED** |
| run 30269631961 | `pull_request_review` | success |

**An empty commit does not escape it.** I tried on #367 — the cancel is caused by the run's own output, so it reproduces on every SHA. That is why every recent PR here has merged via `--admin`.

## The fix

`ci/v2.15.0` — upstream [aidoc-flow-ci#322](https://github.com/vladm3105/aidoc-flow-ci/issues/322), already closed. It replaces the denylist with an **allowlist** of the two code-changing actions:

```yaml
cancel-in-progress: event_name == 'pull_request_target'
                    && contains(fromJSON('["opened","synchronize"]'), action)
```

Only those move the head SHA. Every other subscribed event fires at the *current* head, so cancelling on it strands a check there. (The upstream comment notes the denylist also failed **unsafe**: where the `github` context resolves empty, every `!=` is true and it cancels everything.)

## Chicken-and-egg — why this one needs a human

`ai-review.yml` runs on `pull_request_target`, which loads the workflow **from the base ref**. So this PR is still evaluated by `main`'s `v2.14.0` copy and will block identically. The fix only takes effect once it is *on* `main`. Exactly one merge has to escape by hand; after that, no intervention is needed.

## Scope

`ai-review.yml` only. The other ten `aidoc-flow-ci` call sites stay at `ci/v2.14.0` — a selective bump per the documented "local always wins" override model, not a fleet migration.

## Verification (adversarial self-review, per OPS-0065)

Verified against both tags rather than assumed:

- **Interface**: the `workflow_call` inputs/secrets block is **identical** except one description string. All three inputs this caller passes (`runner_labels_routine`, `runner_labels_review`, `litellm_allow_insecure_http`) are unchanged in type, default and semantics.
- **Permissions**: job-level `permissions:` blocks are byte-identical and already covered by this caller's ceiling.
- **Context name unchanged** — `call / ai-review`. A renamed context would silently un-satisfy branch protection, which is the exact failure class this repo is already fighting.
- **Caller `types:` needs no change** — this caller's 8 `(event, action)` pairs already equal the classified set the fix was validated against.
- **`autofix` job body is byte-identical**; the FT-43/R3 fail-closed guards are unchanged (only their comments were corrected upstream).
- **Cross-workflow**: `composition.yml` and `auto-merge-ai-prs.yml` (still at v2.14.0) key off the workflow `name:` and labels, both unchanged. The fix strictly reduces noise for them.
- The two other behaviour changes in the tag — CI-0014 (trust-config schema assert) and CI-0022 (prompt grounding) — are already satisfied by the `aidoc-flow-operations` config this repo consumes (`"version": 2`, `litellm.model` set).

Verdict: **safe as-is.**
