### PR TITLE
fix: pin the acceptance tier's known warnings and run it in CI (#365)

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,0 +1,55 @@
+# CI runs on GitHub-hosted runners — this is a PUBLIC repo. Do NOT switch to self-hosted:
+# no cost benefit (public-repo Actions minutes are free) + a fork PR could run code on the
+# host. The ephemeral self-hosted runner is for PRIVATE repos only. Ref: aidoc-flow-operations IPLAN-0012.
+name: Acceptance
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+# `cancel-in-progress` is safe HERE because of this workflow's TRIGGER SHAPE, and
+# the reasoning must survive so nobody re-derives it:
+#
+#   push          -> github.ref = refs/heads/<branch>
+#   pull_request  -> github.ref = refs/pull/<N>/merge
+#
+# Two different groups, so the two events on one commit never cancel each other.
+# Cancellation only fires across successive pushes to the SAME ref, which cancels
+# a stale SHA's in-flight run — never the newest SHA's own check-run.
+#
+# That precondition is exactly what ai-review.yml violated (two trigger events
+# collapsing into one group on the same SHA), stranding a CANCELLED required
+# check that blocked PRs #366 and #367 outright; fixed by ci/v2.15.0.
+# DO NOT add a second trigger event here without re-deriving the above.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  acceptance:
+    # This exact string is the required-status-check context (`<job name>`, NOT
+    # the workflow `name:` above). Changing it silently un-satisfies branch
+    # protection, which never fires again — rename only with a matching
+    # required_status_checks update.
+    name: Acceptance tier (deterministic)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      # The tier's only non-stdlib import is PyYAML, already pinned here.
+      # There is no acceptance-specific requirements file.
+      - name: Install dependencies
+        run: pip install -r tests/conformance/requirements.txt
+
+      # `deterministic` only. The `live/` tier needs a plugin runtime and is
+      # gated behind LIVE=1; it is not part of this check.
+      - name: Run deterministic acceptance tier
+        run: python -m unittest discover -s tests/acceptance/deterministic -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,50 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — the acceptance tier is green, pinned, and runs in CI (#365) (2026-07-27)
+
+**No version moves** — `tests/` + `.github/workflows/` only. No `framework/`
+change, so not a GATE-SPEC change. Implements
+`plans/ACCEPTANCE-TIER-DRIFT-UNTRACKED-PLAN.md`; closes
+[#365](https://github.com/vladm3105/aidoc-flow-framework/issues/365).
+
+- **The suite asserted a standard stricter than the framework's own gate.** Three
+  tests failed on `main` while the linter *passed* every fixture directory
+  (`rc=0`) — all 13 findings were `severity: warning`. The failing assertion
+  demanded zero findings of **any** severity, so each newly-shipped advisory rule
+  reddened the tier on contact: `REFGRAN01`, then `ACC01` (2026-07-24, against
+  fixtures authored 2026-05-31). Fixing the fixtures would have cleared 13
+  findings and left the mechanism intact for the next rule.
+- **`assert_golden_passes_lint` now asserts what it means**: `rc == 0` first
+  (a registry-unavailable exit produces empty stdout, which would otherwise read
+  as "every entry is stale"), then zero `error` findings, then the warning
+  **multiset** against a per-target manifest.
+- **Matching is bidirectional, so the manifest cannot rot.** An unpinned warning
+  fails (drift); a pinned warning that stops firing **also** fails (delete the
+  entry). Clearing a fixture therefore tells you to shrink the manifest — the
+  deferred fixture-authoring work is self-verifying.
+- **The match key is a multiset of `(code, file, ref)` + `count`.** Counts alone
+  cannot detect substitution (ACC01/COV02 report against the *host* doc, so
+  re-pairing one element while orphaning another leaves the count unchanged), and
+  an exact set silently dedups genuinely distinct findings (`SPEC-01_golden.yaml`
+  emits two `REFGRAN01` with the same cited tag). `ref` is per-code: the element
+  ID for ACC01/COV02, the cited tag for REFGRAN01 — which exposes no element ID
+  at all, only a literal `TYPE.NN.SS.xxxx` placeholder.
+- **Manifests live outside `fixtures/`.** Inside a `NN_LAYER/` directory the
+  linter ingests a manifest as an artifact — measured on the chain: **13 → 31
+  findings and `rc` 0 → 1**, i.e. it manufactures errors, not just warnings — and
+  `live/_live_harness.py` copies `valid/` contents into exactly such a directory.
+  Structural avoidance, not a convention contributors must remember.
+- **The tier now runs in CI** (`.github/workflows/acceptance.yml`). Nothing ran
+  it before — which is how three red tests sat on `main` unnoticed, and why
+  `tests/acceptance/README.md`'s "runs in every PR" claim was false. It is true
+  now. **Promotion to a *required* check is a branch-protection change, not in
+  this diff** — tracked as `ACCEPTANCE-TIER-REQUIRED-CHECK`.
+- **Verified by mutation, not by inspection**: a bogus entry, a deleted entry, an
+  element-ID substitution, a cited-tag substitution, and deleting one of two
+  duplicate-key findings each **fail**; rewording a rule's message prose while
+  preserving the quoted token **passes**.
+
 ### Fixed — one element-hash implementation in the repo; the acceptance harness delegates (#351) (2026-07-26)
 
 **No version moves** — `tests/` plus a docstring inside `tools/sdd_doc_lint/`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,7 @@ Together they handle: mechanical sync is invisible (just commit; the right files
 | **User-visible policy/rule** | `CLAUDE.md` §"Durable conventions"; auto-memory entry; `README.md` if status-line affected | — | rule prose; memory note |
 | **Hermes follow-on created** | `plans/HERMES-BACKLOG.md` new `H-N` entry in the same PR | — | backlog entry (Source / Plugin status / Substantive work / Dependency) |
 | **Session milestone reached** | `plans/HANDOFF.md` prepend new current-state header | — | handoff narrative (PRs landed, next item) |
+| **New advisory (warning) lint rule** | the affected manifests under `tests/acceptance/expected_warnings/` — the rule fires on the acceptance fixtures and reddens the tier until each new warning is pinned with a `reason` (or the fixture is cleared) | — | `reason` prose naming what would clear each pinned warning |
 | **Trivial / typo / internal refactor** | (none) | — | — |
 
 If your change spans categories, do all the updates. The hooks above flag misses on commit; an explicit checklist in your PR description naming the touched docs helps reviewers.
@@ -74,6 +75,15 @@ The hook exits 0 regardless — it's a reminder, not a gate. If your change genu
 ## How to add a test, a skill, a lint check
 
 See [`tests/CONTRIBUTING.md`](tests/CONTRIBUTING.md) (test-suite contribution guidance).
+
+**Adding an advisory (warning-severity) lint rule?** It will fire on the
+acceptance fixtures, so the deterministic acceptance tier goes red until you
+update the affected manifests under `tests/acceptance/expected_warnings/` **in
+the same PR** (and blocks merges once that check is required). That is deliberate: the
+tier previously asserted zero findings of any severity, so each new advisory rule
+silently reddened it (`REFGRAN01`, then `ACC01`). Pin the new warnings with a
+`reason`, or clear the fixtures. See
+[`tests/acceptance/README.md`](tests/acceptance/README.md#accepted-warnings-expected_warnings).
 
 ## How to add a governance file or change a framework spec section
 

--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -24,6 +24,47 @@
 
 ## Open
 
+### `[ci]` `ACCEPTANCE-TIER-REQUIRED-CHECK` — promote the acceptance gate to a required status check
+
+- *Context:* `ACCEPTANCE-TIER-DRIFT-UNTRACKED` (2026-07-27) added
+  `.github/workflows/acceptance.yml`, which runs the deterministic tier on every
+  push/PR. Making it **required** is a branch-protection change — repo settings,
+  not a file — so it cannot ship in the same diff, and until it lands the tier
+  can go red without blocking a merge.
+- *Fix shape:* **GET → append → PATCH.**
+  `PATCH /repos/{owner}/{repo}/branches/main/protection/required_status_checks`
+  is **full-replace**: a payload carrying only the new context silently drops the
+  others. Read the live `checks` array, append
+  `{"context": "Acceptance tier (deterministic)", "app_id": 15368}`, preserve
+  `strict: false`, PATCH the union, then read back and assert set equality against
+  `observed ∪ {new}`. Confirm `main` is under classic protection first (under
+  rulesets the endpoint 404s and the step is a silent no-op), and rebase any PR
+  opened before the workflow file existed — it cannot produce the context.
+- *Precondition:* the tier must be green on `main` first, and worth a soak run —
+  a reviewer observed two non-reproducible failures in ~45 runs that could not be
+  isolated. A flaky required check blocks everything.
+
+### `[harness]` `ACCEPTANCE-FIXTURE-WARNING-DEBT` — 13 distinct advisory findings pinned across the acceptance fixtures (30 manifest warnings / 27 entries)
+
+- *Context:* deferred from `ACCEPTANCE-TIER-DRIFT-UNTRACKED` (2026-07-27). The
+  fixtures carry 5 `REFGRAN01` (doc-level `@adr:`/`@tdd:` tags predating GD-03),
+  4 `COV02` (elements realized by nothing) and 4 `ACC01` (BDD scenarios paired to
+  no TDD test case). The three manifests hold **30 warnings across 27 entries** —
+  the layer dirs reuse byte-identical goldens, so the 13 are the distinct debt.
+  Pinned is
+  not acceptable — each entry's `reason` names what would clear it.
+- *Fix shape:* author the missing element-level citations and paired TDD test
+  cases. Self-verifying: the match is bidirectional, so clearing a fixture fails
+  the suite until its manifest entry is deleted.
+- *Caveat:* the pinned set reflects **trace-graph visibility**, not total debt.
+  `layer_06_spec/valid/SPEC-01_golden.yaml`,
+  `layer_07_tdd/valid/TDD-01_golden.yaml` and
+  `layer_08_iplan/valid/IPLAN-01_golden.yaml` each have one `---` and no
+  `doc_id`, so they are invisible to the graph; adding a closing fence is a
+  benign repair that ADDS findings and moves the manifest. (Three MORE share the
+  shape under `fullpath/broken_chain/` — six in the tree; the three above are the
+  ones inside `valid/` dirs that a manifest covers.)
+
 ### `[harness]` `IDCOORD-NUMERIC-SECTION-ID` — `_id_coordinator.element_id()` emits a string `section_id`, so its IDs can never be registry-valid
 
 - *Context:* deferred out of `IDCOORD-SECOND-HASH-IMPL` as plan **D3 option (b)**
@@ -42,24 +83,6 @@
 - *Tracker:* **TODO-only** per the GD-10 three-test bar — fails (c) (no consumer
   is affected: the module has none) and is conditional on prerequisite work
   nobody has scheduled, i.e. the "already-planned / purely local" carve-out.
-
-### `[harness]` `ACCEPTANCE-TIER-DRIFT-UNTRACKED` — 3 acceptance tests fail on `main`, and no CI job runs the tier → [#365](https://github.com/vladm3105/aidoc-flow-framework/issues/365)
-
-- *Context:* found 2026-07-26 while shipping `IDCOORD-SECOND-HASH-IMPL`, which
-  needed a before/after baseline. `python3 -m unittest discover -s
-  tests/acceptance/deterministic` fails 3 of 58 on `main`: `test_fullpath` and
-  `test_layer_iplan` (ACC01 + COV02 + REFGRAN01), `test_layer_tdd` (COV02 +
-  REFGRAN01), on the `layer_*`/`fullpath` goldens. Not covered by
-  `CORPUS-REFGRAN-RECASCADE`, which is `[example-corpus]`, scoped to
-  `examples/url-shortener/docs/`, and mentions the acceptance suite only for
-  `SPEC-01_golden` REFGRAN01 — nothing about ACC01 or these COV02 findings.
-  **`grep -rn acceptance .github/workflows/` returns nothing**, which is how
-  three red tests sat on `main` unnoticed.
-- *Fix shape:* two independent halves — (1) realign the acceptance fixtures with
-  the coverage rules that have shipped since they were authored (ACC01/COV02
-  element-level coverage, REFGRAN01), and (2) decide whether the tier belongs in
-  CI. Half (2) is the one that keeps this from recurring; it is also the one that
-  needs a call on whether these fixtures are meant to be gate-clean.
 
 ### `[example-corpus]` `SEED-ABSORPTION-001-T7` — 16 BDD scenarios are un-designed (SPEC-coverage gap), not merely un-tested
 
@@ -211,44 +234,6 @@
 > COV01/COV02 upgrade** — SHIPPED (ELEMENT-COVERAGE-001, `0.30.0`; the deferred
 > payoff — catches the 16 orphaned BDD scenarios);
 > (c) `CORPUS-REFGRAN-RECASCADE` (below) — now just the 5 SPEC/TDD/IPLAN edges.
-
-### `[ci]` `AIDOC-CI-COMPOSITION-CHECK-PRHEAD` — required `call / composition` check never lands on a PR head → every PR needs `--admin` to merge
-
-- *Discovered:* 2026-06-29 (PR #219; confirmed byte-identical state on #218,
-  merged ~1h earlier by `vladm3105` via admin). Branch protection on `main`
-  requires the `call / composition` context, but it is **structurally
-  unsatisfiable on a PR head**: `ai-review.yml` runs on `pull_request_target`,
-  whose run `head_sha` is the **base** (main HEAD), not the PR head. The
-  `workflow_run`-triggered `composition.yml` keys off that `head_sha` and posts
-  `call / composition` to main's HEAD — never to the PR's head commit. The PR's
-  combined status therefore stays `pending` on that context indefinitely.
-- *Impact:* the OPS-0062 green-path `gh pr merge` is `BLOCKED` even when all real
-  checks are green; every PR (incl. doc-only) is closed via `--admin` override.
-  This defeats the auto-merge default's normal path for this repo. **A
-  `skip-ai-review` label-cycle does NOT help** — it re-fires the same
-  `pull_request_target` → main-SHA composition.
-- *Fix locus:* **aidoc-flow-ci** `composition.yml` reusable — post the
-  `call / composition` status to
-  `github.event.workflow_run.pull_requests[0].head.sha` (the PR head) instead of
-  the run `head_sha`; OR make the required context conditional. Cross-repo (CI
-  library + operations auto-merge enforcer backlog); track the fix upstream.
-  Logged here for next-session merge-flow awareness.
-- *Escalation (2026-07-11, pre-prod audit):* a **second, distinct** failure mode
-  now compounds this — `composition` (and the `pull_request`-triggered
-  `audit-trail`) `startup_failure` **repo-wide** (on `main` too) since
-  **2026-07-10 ~20:49** (last success 18:43). The caller
-  `.github/workflows/composition.yml` is valid and pins the immutable `@ci/v1.8.1`
-  tag (unchanged sha); the callee `composition.yml` is byte-identical at
-  `ci/v1.8.1` and `ci/v1.9.0`; no relevant merge to `main` in the break window.
-  Only **aidoc-flow-ci reusable-workflow callers** fail (local-job checks +
-  `pull_request`-triggered reusable `lint` still pass), pointing to a **GitHub
-  Actions access/visibility change on the `aidoc-flow-ci` repo** (ci commit #120 at
-  19:54 = "private repos use self-hosted runners by default") making its reusable
-  workflows unresolvable from this repo → `startup_failure` ("workflow file
-  issue"). *Fix:* an **org/repo Actions-settings / ci-repo-visibility change
-  (founder/CI-owner)**, NOT a repo-file edit; a caller re-pin won't help (callee is
-  identical across tags). Until fixed, all PRs land via `--admin` (#305/#306/#307/
-  #308 did). Founder-owned.
 
 ### `[lint]` `STRUCT01-INDEX-EXEMPTION-NESTED` — ✅ CLOSED (2026-06-30) — index/registry templates never hit the STRUCT01/trace `-INDEX` exemption
 
@@ -1064,6 +1049,87 @@
 - *Status:* SHIPPED (spec 0.32.3, 2026-06-29 — BeeLocal docs sweep).
 
 ## Closed
+
+### `[ci]` `AIDOC-CI-COMPOSITION-CHECK-PRHEAD` — ✅ CLOSED (2026-07-27, stale — mechanism no longer occurs) — required `call / composition` check never landed on a PR head
+
+- *Status (2026-07-27): **STALE — the described mechanism no longer occurs.***
+  Verified on the four most recent PRs: `call / composition` reports **success on
+  the PR head** every time (#366 `[success,success]`, #363, #361, #356). The
+  `ci/v2.x` canon migration fixed it. **A reviewer read this entry as proof that
+  required checks gate nothing here, which nearly killed a correct plan** — hence
+  this note. PRs #366/#367 *did* need `--admin`, but for an unrelated cause: the
+  `ai-review.yml` self-cancel (`aidoc-flow-ci#322`), fixed by pinning
+  `ci/v2.15.0` in PR #369. Retained for history; do not act on the body below.
+
+- *Discovered:* 2026-06-29 (PR #219; confirmed byte-identical state on #218,
+  merged ~1h earlier by `vladm3105` via admin). Branch protection on `main`
+  requires the `call / composition` context, but it is **structurally
+  unsatisfiable on a PR head**: `ai-review.yml` runs on `pull_request_target`,
+  whose run `head_sha` is the **base** (main HEAD), not the PR head. The
+  `workflow_run`-triggered `composition.yml` keys off that `head_sha` and posts
+  `call / composition` to main's HEAD — never to the PR's head commit. The PR's
+  combined status therefore stays `pending` on that context indefinitely.
+- *Impact:* the OPS-0062 green-path `gh pr merge` is `BLOCKED` even when all real
+  checks are green; every PR (incl. doc-only) is closed via `--admin` override.
+  This defeats the auto-merge default's normal path for this repo. **A
+  `skip-ai-review` label-cycle does NOT help** — it re-fires the same
+  `pull_request_target` → main-SHA composition.
+- *Fix locus:* **aidoc-flow-ci** `composition.yml` reusable — post the
+  `call / composition` status to
+  `github.event.workflow_run.pull_requests[0].head.sha` (the PR head) instead of
+  the run `head_sha`; OR make the required context conditional. Cross-repo (CI
+  library + operations auto-merge enforcer backlog); track the fix upstream.
+  Logged here for next-session merge-flow awareness.
+- *Escalation (2026-07-11, pre-prod audit):* a **second, distinct** failure mode
+  now compounds this — `composition` (and the `pull_request`-triggered
+  `audit-trail`) `startup_failure` **repo-wide** (on `main` too) since
+  **2026-07-10 ~20:49** (last success 18:43). The caller
+  `.github/workflows/composition.yml` is valid and pins the immutable `@ci/v1.8.1`
+  tag (unchanged sha); the callee `composition.yml` is byte-identical at
+  `ci/v1.8.1` and `ci/v1.9.0`; no relevant merge to `main` in the break window.
+  Only **aidoc-flow-ci reusable-workflow callers** fail (local-job checks +
+  `pull_request`-triggered reusable `lint` still pass), pointing to a **GitHub
+  Actions access/visibility change on the `aidoc-flow-ci` repo** (ci commit #120 at
+  19:54 = "private repos use self-hosted runners by default") making its reusable
+  workflows unresolvable from this repo → `startup_failure` ("workflow file
+  issue"). *Fix:* an **org/repo Actions-settings / ci-repo-visibility change
+  (founder/CI-owner)**, NOT a repo-file edit; a caller re-pin won't help (callee is
+  identical across tags). Until fixed, all PRs land via `--admin` (#305/#306/#307/
+  #308 did). Founder-owned.
+
+### `[harness]` `ACCEPTANCE-TIER-DRIFT-UNTRACKED` — ✅ CLOSED (2026-07-27) — 3 acceptance tests failed on `main`, and no CI job ran the tier → [#365](https://github.com/vladm3105/aidoc-flow-framework/issues/365)
+
+- *Context:* found 2026-07-26 while shipping `IDCOORD-SECOND-HASH-IMPL`, which
+  needed a before/after baseline. `python3 -m unittest discover -s
+  tests/acceptance/deterministic` fails 3 of 63 on `main`: `test_fullpath` and
+  `test_layer_iplan` (ACC01 + COV02 + REFGRAN01), `test_layer_tdd` (COV02 +
+  REFGRAN01), on the `layer_*`/`fullpath` goldens. Not covered by
+  `CORPUS-REFGRAN-RECASCADE`, which is `[example-corpus]`, scoped to
+  `examples/url-shortener/docs/`, and mentions the acceptance suite only for
+  `SPEC-01_golden` REFGRAN01 — nothing about ACC01 or these COV02 findings.
+  **`grep -rn acceptance .github/workflows/` returns nothing**, which is how
+  three red tests sat on `main` unnoticed.
+- *Fix shape:* two independent halves — (1) realign the acceptance fixtures with
+  the coverage rules that have shipped since they were authored (ACC01/COV02
+  element-level coverage, REFGRAN01), and (2) decide whether the tier belongs in
+  CI. Half (2) is the one that keeps this from recurring; it is also the one that
+  needs a call on whether these fixtures are meant to be gate-clean.
+- *Shipped:* 2026-07-27, `plans/ACCEPTANCE-TIER-DRIFT-UNTRACKED-PLAN.md`.
+  **The premise in this entry was wrong and the plan corrected it:** the goldens
+  PASS the lint gate (`rc=0` everywhere) and all 13 findings are
+  `severity: warning`. What failed was a second assertion demanding zero findings
+  of *any* severity — stricter than any gate the framework defines, so every new
+  advisory rule reddened the tier on contact. Fixed by asserting `rc == 0` + zero
+  errors + a **bidirectional multiset** match against
+  `tests/acceptance/expected_warnings/<target>.yaml`, and by adding
+  `.github/workflows/acceptance.yml`, which runs the tier on every push/PR.
+  Tier: **64 tests, 0 failures.** Promotion to a *required* check is a
+  branch-protection change, not in the diff → `ACCEPTANCE-TIER-REQUIRED-CHECK`.
+- *Deferred:* the 13 pinned warnings are real advisory debt →
+  `ACCEPTANCE-FIXTURE-WARNING-DEBT` (Open). Note the pinned set measures what the
+  **trace graph can see**: three goldens carry an unterminated frontmatter fence
+  and are invisible to it, so repairing one is a benign edit that MOVES the
+  manifest.
 
 ### `[conformance]` `IDCOORD-SECOND-HASH-IMPL` — ✅ CLOSED (2026-07-26) — the acceptance harness re-implemented the element hash without normalization → [#351](https://github.com/vladm3105/aidoc-flow-framework/issues/351)
 

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -1,5 +1,56 @@
 # Session Handoff
 
+> **✅ SESSION 2026-07-27 — #365 implemented: the acceptance tier is green and
+> gated. The tracker is empty once this merges.**
+>
+> `plans/ACCEPTANCE-TIER-DRIFT-UNTRACKED-PLAN.md` executed. Tier goes **3
+> failures / 63 → 0 failures / 64**, and `.github/workflows/acceptance.yml` runs
+> it on every push/PR — nothing ran it before, which is how three red tests sat
+> on `main` unnoticed. **It is not yet a *required* check**: that is a
+> branch-protection change, tracked as `ACCEPTANCE-TIER-REQUIRED-CHECK`.
+>
+> **The issue's premise was wrong and I wrote it.** #365 said "realign the
+> fixtures with the coverage rules." The goldens *pass* the lint gate (`rc=0`
+> everywhere); all 13 findings are `severity: warning`. What failed was a second
+> assertion demanding zero findings of **any** severity — stricter than any gate
+> the framework defines, so every new advisory rule reddens the tier on contact
+> (`REFGRAN01`, then `ACC01`). Realigning fixtures would have cleared 13 findings
+> and left the mechanism for rule #3.
+>
+> **Four things a next session must not re-derive:**
+>
+> 1. **Manifests live OUTSIDE `fixtures/`** (`tests/acceptance/expected_warnings/`).
+>    Inside a `NN_LAYER/` dir the linter ingests one as an artifact — measured on
+>    the chain, **13 → 31 findings and `rc` 0 → 1**, i.e. it manufactures errors —
+>    and `live/_live_harness.py:stage_upstreams_into` copies `valid/` contents
+>    into exactly such a dir. Latent, since live is `skipUnless(LIVE=1)`.
+> 2. **The pinned set measures trace-graph visibility, not fixture debt.** Three
+>    goldens *inside `valid/` dirs* have an unterminated frontmatter fence (one
+>    `---`, no `doc_id`) and are invisible to `build_edge_graph`; three more share
+>    the shape under `fullpath/broken_chain/`, six in the tree. Repairing one is
+>    benign and **moves the manifest** — adding the fence to `layer_06_spec/valid`
+>    takes it 0 → 6.
+> 3. **`ELEM_FORM` cannot search a message** — it is fully anchored. Extraction is
+>    two-step: take the single-quoted token, then validate. And the linter's
+>    `file` key is CWD-relative (or absolute), so the loader **must** normalize to
+>    target-relative or every entry mismatches.
+> 4. **`AIDOC-CI-COMPOSITION-CHECK-PRHEAD` is stale** and is now annotated as
+>    such. A reviewer read it as proof that required checks gate nothing here,
+>    which nearly killed this plan. `call / composition` reports success on PR
+>    heads; the real blocker was the `ai-review` self-cancel, fixed in #369 by
+>    pinning `ci/v2.15.0`.
+>
+> **One post-merge step remains, and it is not in any diff:** add
+> `Acceptance tier (deterministic)` to `required_status_checks` via
+> **GET → append → PATCH** (the endpoint is full-replace; a naive PATCH drops the
+> other required contexts). Verify by read-back asserting `observed ∪ {new}`.
+>
+> Deferred: `ACCEPTANCE-FIXTURE-WARNING-DEBT` — the 13 pinned warnings are real
+> advisory debt, self-verifying to clear (bidirectional matching means a fixed
+> fixture fails until its entry is deleted).
+
+---
+
 > **✅ SESSION 2026-07-26 (LATER) — #351 implemented; PR open, closes on merge.**
 >
 > `plans/IDCOORD-SECOND-HASH-IMPL-PLAN.md` executed as written. Its step 1 was a

--- a/tests/acceptance/README.md
+++ b/tests/acceptance/README.md
@@ -2,7 +2,10 @@
 
 **Path:** `tests/acceptance/`
 **Pyramid tier:** 3 + 4
-**Runs:** deterministic in every PR; live in nightly + release
+**Runs:** deterministic in every PR (`.github/workflows/acceptance.yml`); live
+in nightly + release
+**Gating:** the workflow runs on every push/PR. Promotion to a *required* check
+is a branch-protection change, tracked as `ACCEPTANCE-TIER-REQUIRED-CHECK`
 **Determinism:** deterministic (default) | live (`LIVE=1`)
 
 ## What this suite covers
@@ -18,6 +21,55 @@ exercise the actual `doc-<layer>` skills via `claude -p`.
 cd framework && python3 -m unittest discover tests/acceptance -v
 LIVE=1 python3 -m unittest discover tests/acceptance/live -v
 ```
+
+## Accepted warnings (`expected_warnings/`)
+
+A golden directory must be **gate-clean** (`rc == 0`, zero `error` findings) and
+emit **exactly** the warnings pinned in `expected_warnings/<target>.yaml`. The
+match is a multiset on `(code, file, ref)` + `count`, and it runs **both ways**:
+
+- an emitted warning that is not pinned **fails** — that is new drift;
+- a pinned warning that no longer fires **also fails** — delete the entry.
+
+So clearing a fixture tells you to shrink the manifest; the file cannot rot into
+a permanent excuse list. Every entry carries a `reason` naming what would clear
+it. Manifests live here, **not** under `fixtures/`: a manifest inside a
+`NN_LAYER/` directory is ingested by the linter as an artifact, and the live
+harness copies `valid/` contents into exactly such a directory.
+
+**Adding a new advisory lint rule?** It will fire on these fixtures and turn this
+check red until the manifests are updated in the same PR (and block merges once
+the check is required). That is intended — it is what stops the tier from
+silently reddening — but budget for it.
+
+### Manifest schema
+
+Filename is the lint target's path relative to `fixtures/` with `/` → `__`:
+`layer_07_tdd/valid` → `expected_warnings/layer_07_tdd__valid.yaml`.
+
+```yaml
+target: layer_07_tdd/valid       # must match the filename; the loader asserts it
+expected_warnings:
+  - code: REFGRAN01
+    file: SPEC-01_golden.yaml    # relative to `target` (the linter emits
+                                 # CWD-relative or absolute; the loader normalizes)
+    ref: "@adr: ADR-01"          # per-code discriminator, see below
+    count: 2                     # multiplicity of this exact key
+    reason: >                    # required and non-empty; say what would clear it
+      ...
+```
+
+`ref` identifies *which* finding, since counts alone cannot detect substitution:
+
+| code | `ref` | why |
+|---|---|---|
+| `ACC01`, `COV02` | the element ID (`BDD.01.04.bbbb`) | taken as the single-quoted token, then validated with `ELEM_FORM` |
+| `REFGRAN01` | the cited tag (`@adr: ADR-01`) | its message carries no element ID, only a literal `TYPE.NN.SS.xxxx` placeholder |
+
+A code exposing neither makes the loader **raise** rather than degrade to
+counting. Extend `_finding_ref()` in `_harness.py` deliberately.
+
+Origin: `plans/ACCEPTANCE-TIER-DRIFT-UNTRACKED-PLAN.md`, [#365](https://github.com/vladm3105/aidoc-flow-framework/issues/365).
 
 ## Environment
 

--- a/tests/acceptance/_harness.py
+++ b/tests/acceptance/_harness.py
@@ -11,7 +11,186 @@ import yaml
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "conformance"))
 from _spec import ARTIFACTS, plugin_bundle_root, template_path
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+from sdd_doc_lint.trace_graph import ELEM_FORM
+
 FIXTURES_ROOT = Path(__file__).resolve().parent / "fixtures"
+
+#: Manifests of KNOWN, accepted lint warnings per lint target — deliberately
+#: OUTSIDE `fixtures/`. A manifest inside the fixture tree is ingested by the
+#: linter as an artifact when it lands in a `NN_LAYER/` directory, and
+#: `live/_live_harness.py:stage_upstreams_into` copies every item of a `valid/`
+#: dir into exactly such a directory. See ACCEPTANCE-TIER-DRIFT-UNTRACKED plan D1.
+EXPECTED_WARNINGS_ROOT = Path(__file__).resolve().parent / "expected_warnings"
+
+
+def _manifest_path(target: Path) -> Path:
+    """Return the manifest file for a lint target (may not exist)."""
+    rel = target.resolve().relative_to(FIXTURES_ROOT.resolve()).as_posix()
+    return EXPECTED_WARNINGS_ROOT / f"{rel.replace('/', '__')}.yaml"
+
+
+def _finding_ref(finding: dict) -> str:
+    """Return the per-code discriminator that identifies WHICH finding this is.
+
+    Counts alone cannot detect substitution: ACC01/COV02 report against the host
+    document, so re-pairing one element while orphaning another leaves the count
+    unchanged. The discriminator is per-code because the codes expose different
+    machine-readable handles:
+
+    * ``ACC01`` / ``COV02`` — the element ID, taken as the single-quoted token
+      and then VALIDATED with the canonical ``ELEM_FORM``. Two steps, because
+      ``ELEM_FORM`` is fully anchored and cannot *search* a message.
+    * ``REFGRAN01`` — the cited tag; its message carries no element ID at all,
+      only a literal ``TYPE.NN.SS.xxxx`` placeholder.
+
+    A code exposing neither raises rather than silently degrading to a countable
+    blob: an un-pinnable rule must be handled deliberately.
+    """
+    message = finding["message"]
+    for token in re.findall(r"'([^']+)'", message):
+        if ELEM_FORM.match(token):
+            return token
+    tag = re.search(r"@(\w+):\s*([A-Z]+-\d+)", message)
+    if tag:
+        return f"@{tag.group(1)}: {tag.group(2)}"
+    raise AssertionError(
+        f"cannot derive a stable discriminator for {finding['code']} in "
+        f"{finding['file']}: {message!r}. Extend _finding_ref() deliberately — "
+        "do not fall back to counting, which cannot detect substitution."
+    )
+
+
+def _finding_key(finding: dict, target: Path) -> tuple[str, str, str]:
+    """Return ``(code, target-relative file, ref)`` for a linter finding.
+
+    The linter reports ``file`` relative to CWD, or absolute when the target is
+    outside CWD (`sdd_doc_lint/__init__.py` ``_collect``). Neither is stable, so
+    normalize to target-relative before comparing against a committed manifest.
+    """
+    emitted = Path(finding["file"])
+    resolved = (Path.cwd() / emitted).resolve()
+    try:
+        rel = resolved.relative_to(target.resolve()).as_posix()
+    except ValueError as exc:
+        # Reachable, not hypothetical: the coverage/granularity rules report
+        # `rel_by_doc.get(host, host)`, which is a BARE DOC ID (e.g. "BDD-01")
+        # when the host is absent from the path map. The raw ValueError names a
+        # path that does not exist and mentions neither the code nor the cause.
+        raise AssertionError(
+            f"{finding['code']}: cannot place {finding['file']!r} inside "
+            f"{target}. The linter reports a bare doc id rather than a path when "
+            "a cited host document is missing from the corpus — add the host to "
+            "the fixture, or extend _finding_key() to handle doc-id references."
+        ) from exc
+    return (finding["code"], rel, _finding_ref(finding))
+
+
+def expected_warnings(target: Path) -> dict[tuple[str, str, str], int]:
+    """Return the accepted-warning multiset for a lint target.
+
+    No manifest → empty multiset, which reproduces the historical
+    "zero findings" contract exactly for every target that has none.
+    """
+    path = _manifest_path(target)
+    if not path.exists():
+        return {}
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    declared = str(data.get("target", "")).strip()
+    derived = target.resolve().relative_to(FIXTURES_ROOT.resolve()).as_posix()
+    # Explicit raises, NOT `assert`: these validate COMMITTED DATA, not a test
+    # outcome, and `python -O` strips assert statements — which would let a
+    # manifest with a mismatched target, a missing reason, or duplicate keys load
+    # silently. `-O` must not weaken a data contract.
+    if declared != derived:
+        raise ValueError(
+            f"{path.name}: `target: {declared}` does not match the target its "
+            f"filename encodes ({derived}) — a renamed manifest must not silently "
+            "pin a different directory"
+        )
+    out: dict[tuple[str, str, str], int] = {}
+    for entry in data.get("expected_warnings") or []:
+        key = (entry["code"], entry["file"], entry["ref"])
+        if key in out:
+            raise ValueError(f"{path.name}: duplicate entry {key} — use `count:` for multiplicity")
+        if not str(entry.get("reason", "")).strip():
+            raise ValueError(
+                f"{path.name}: {key} has no `reason`. Every pinned warning must "
+                "state what would clear it, or the manifest becomes an excuse list"
+            )
+        out[key] = int(entry["count"])
+    return out
+
+
+def assert_no_orphan_manifests(case) -> None:
+    """Every manifest must name a lint target that exists.
+
+    Bidirectional matching makes a STALE ENTRY fail, but nothing makes a stale
+    FILE fail: a manifest orphaned by a fixture rename would sit forever pinning
+    warnings nothing emits. This closes that gap at the file level.
+    """
+    for path in sorted(EXPECTED_WARNINGS_ROOT.glob("*.yaml")):
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        target = FIXTURES_ROOT / str(data.get("target", "")).strip()
+        case.assertTrue(
+            target.is_dir(),
+            f"{path.name}: `target: {data.get('target')}` is not a directory — "
+            "orphaned by a fixture rename? Delete the manifest or fix the target",
+        )
+
+
+def assert_lint_matches_manifest(case, target: Path) -> None:
+    """Assert a lint target is gate-clean and emits exactly its pinned warnings.
+
+    Three assertions, in this order:
+
+    1. ``rc == 0`` FIRST — a registry-unavailable exit produces empty stdout,
+       which would otherwise surface as the nonsense "every entry is stale".
+    2. zero ``error`` findings — the framework's own gate.
+    3. the ``warning`` multiset equals the manifest's, BOTH directions. A new
+       warning fails (drift); a pinned warning that no longer fires also fails
+       (the manifest must shrink), so it cannot rot into an excuse list.
+    """
+    rc, findings = run_lint(target)
+    case.assertEqual(rc, 0, f"{target.name}: lint exited {rc}:\n{findings}")
+
+    errors = [f for f in findings if f["severity"] == "error"]
+    case.assertEqual([], errors, f"{target.name}: lint errors:\n{errors}")
+
+    # A finding at any OTHER severity would be gated by neither check — the error
+    # assertion filters `== "error"` and the multiset filters `== "warning"`, so a
+    # third value falls through both and a whole new rule could ship unnoticed.
+    # That is precisely the failure this contract exists to prevent, one severity
+    # string to the left. The plan's Pass 4 relied on "the linter emits only error
+    # and warning"; this asserts it instead of assuming it.
+    unhandled = sorted({f["severity"] for f in findings} - {"error", "warning"})
+    case.assertEqual(
+        [],
+        unhandled,
+        f"{target.name}: findings at unhandled severity {unhandled} are neither "
+        "gated as errors nor pinned as warnings. Decide which they are and extend "
+        "this contract — do not let them fall through.",
+    )
+
+    actual: dict[tuple[str, str, str], int] = {}
+    for finding in findings:
+        if finding["severity"] != "warning":
+            continue
+        key = _finding_key(finding, target)
+        actual[key] = actual.get(key, 0) + 1
+
+    expected = expected_warnings(target)
+    if actual != expected:
+        new = {k: v for k, v in actual.items() if expected.get(k) != v}
+        gone = {k: v for k, v in expected.items() if actual.get(k) != v}
+        case.fail(
+            f"{target.name}: emitted warnings do not match "
+            f"{_manifest_path(target).name}.\n"
+            f"  unpinned / changed count (new drift — fix the fixture, or pin it "
+            f"with a reason): {new or '{}'}\n"
+            f"  pinned but not emitted (stale — delete the manifest entry): "
+            f"{gone or '{}'}"
+        )
 
 
 def fixtures_for(layer_index: int, kind: str) -> Path:
@@ -151,17 +330,13 @@ class LayerHarness:
     LAYER_NAME: str  # subclass sets this
 
     def assert_golden_passes_lint(self, golden: Path):
-        rc, findings = run_lint(golden.parent)
-        self.assertEqual(
-            rc,
-            0,  # type: ignore
-            f"golden {golden.name} lint failed:\n{findings}",
-        )
-        self.assertEqual(
-            [],
-            findings,  # type: ignore
-            f"golden {golden.name} emitted findings:\n{findings}",
-        )
+        """The golden's directory must be gate-clean and emit only pinned warnings.
+
+        Delegates to the module-level `assert_lint_matches_manifest` so
+        `test_fullpath.py` — which does not inherit this mix-in — enforces the
+        identical contract.
+        """
+        assert_lint_matches_manifest(self, golden.parent)
 
     def assert_broken_fixture_emits_expected_codes(self, broken_dir: Path):
         for codes_file in broken_dir.glob("*_drift_codes.yaml"):

--- a/tests/acceptance/deterministic/test_fullpath.py
+++ b/tests/acceptance/deterministic/test_fullpath.py
@@ -5,7 +5,14 @@ import unittest
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from _harness import FIXTURES_ROOT, headings, run_lint, subtype_of, template_sections  # noqa: E402
+from _harness import (  # noqa: E402
+    FIXTURES_ROOT,
+    assert_lint_matches_manifest,
+    assert_no_orphan_manifests,
+    headings,
+    subtype_of,
+    template_sections,
+)
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "conformance"))
 from _spec import ARTIFACTS  # noqa: E402
@@ -16,9 +23,12 @@ BROKEN_CHAIN = FIXTURES_ROOT / "fullpath" / "broken_chain"
 
 class FullpathChainTests(unittest.TestCase):
     def test_chain_lint_passes(self):
-        rc, findings = run_lint(CHAIN)
-        self.assertEqual(rc, 0, f"fullpath chain lint failed:\n{findings}")
-        self.assertEqual([], findings, f"chain emitted findings:\n{findings}")
+        """The chain must be gate-clean and emit exactly its pinned warnings."""
+        assert_lint_matches_manifest(self, CHAIN)
+
+    def test_no_orphan_expected_warnings_manifests(self):
+        """Every manifest must point at a target that still exists."""
+        assert_no_orphan_manifests(self)
 
     def test_every_layer_has_one_artifact(self):
         for idx, name in enumerate(ARTIFACTS, start=1):

--- a/tests/acceptance/expected_warnings/fullpath__golden_chain.yaml
+++ b/tests/acceptance/expected_warnings/fullpath__golden_chain.yaml
@@ -1,0 +1,117 @@
+# Accepted lint warnings for this target — see
+# plans/ACCEPTANCE-TIER-DRIFT-UNTRACKED-PLAN.md.
+#
+# Matching is a MULTISET and BIDIRECTIONAL: an unpinned warning fails, and a
+# pinned warning that no longer fires ALSO fails. Clearing a fixture therefore
+# tells you to delete its entry here. Do not add an entry without a `reason`
+# stating what would clear it.
+target: fullpath/golden_chain
+expected_warnings:
+  - code: ACC01
+    file: 04_BDD/BDD-01_golden.md
+    ref: "BDD.01.04.aaaa"
+    count: 1
+    reason: >
+      `BDD.01.04.aaaa` is paired to no TDD test case. The fixture predates ACC01
+      (SEED-ABSORPTION-001, shipped 2026-07-24 against fixtures authored
+      2026-05-31); clearing it means authoring the paired test case. Pinned so
+      it cannot mask a new unpaired scenario.
+  - code: ACC01
+    file: 04_BDD/BDD-01_golden.md
+    ref: "BDD.01.04.bbbb"
+    count: 1
+    reason: >
+      `BDD.01.04.bbbb` is paired to no TDD test case. The fixture predates ACC01
+      (SEED-ABSORPTION-001, shipped 2026-07-24 against fixtures authored
+      2026-05-31); clearing it means authoring the paired test case. Pinned so
+      it cannot mask a new unpaired scenario.
+  - code: ACC01
+    file: 04_BDD/BDD-01_golden.md
+    ref: "BDD.01.04.cccc"
+    count: 1
+    reason: >
+      `BDD.01.04.cccc` is paired to no TDD test case. The fixture predates ACC01
+      (SEED-ABSORPTION-001, shipped 2026-07-24 against fixtures authored
+      2026-05-31); clearing it means authoring the paired test case. Pinned so
+      it cannot mask a new unpaired scenario.
+  - code: ACC01
+    file: 04_BDD/BDD-01_golden.md
+    ref: "BDD.01.04.dddd"
+    count: 1
+    reason: >
+      `BDD.01.04.dddd` is paired to no TDD test case. The fixture predates ACC01
+      (SEED-ABSORPTION-001, shipped 2026-07-24 against fixtures authored
+      2026-05-31); clearing it means authoring the paired test case. Pinned so
+      it cannot mask a new unpaired scenario.
+  - code: COV02
+    file: 03_EARS/EARS-01_golden.md
+    ref: "EARS.01.03.cccc"
+    count: 1
+    reason: >
+      `EARS.01.03.cccc` is realized by no downstream element. The fixture
+      predates element-level COV01/COV02 (ELEMENT-COVERAGE-001); clearing it
+      means authoring the missing downstream citation. Pinned so it cannot mask
+      a new coverage gap.
+  - code: COV02
+    file: 04_BDD/BDD-01_golden.md
+    ref: "BDD.01.04.bbbb"
+    count: 1
+    reason: >
+      `BDD.01.04.bbbb` is realized by no downstream element. The fixture
+      predates element-level COV01/COV02 (ELEMENT-COVERAGE-001); clearing it
+      means authoring the missing downstream citation. Pinned so it cannot mask
+      a new coverage gap.
+  - code: COV02
+    file: 04_BDD/BDD-01_golden.md
+    ref: "BDD.01.04.cccc"
+    count: 1
+    reason: >
+      `BDD.01.04.cccc` is realized by no downstream element. The fixture
+      predates element-level COV01/COV02 (ELEMENT-COVERAGE-001); clearing it
+      means authoring the missing downstream citation. Pinned so it cannot mask
+      a new coverage gap.
+  - code: COV02
+    file: 04_BDD/BDD-01_golden.md
+    ref: "BDD.01.04.dddd"
+    count: 1
+    reason: >
+      `BDD.01.04.dddd` is realized by no downstream element. The fixture
+      predates element-level COV01/COV02 (ELEMENT-COVERAGE-001); clearing it
+      means authoring the missing downstream citation. Pinned so it cannot mask
+      a new coverage gap.
+  - code: REFGRAN01
+    file: 06_SPEC/SPEC-01_golden.yaml
+    ref: "@adr: ADR-01"
+    count: 2
+    reason: >
+      Doc-level `@adr: ADR-01` predates GD-03 element granularity (CFB-PR-3).
+      Clearing it means re-cascading the tag to a specific element; pinned so it
+      cannot mask a new REFGRAN01 elsewhere. Tracked as deferred
+      fixture-authoring work.
+  - code: REFGRAN01
+    file: 07_TDD/TDD-01_golden.yaml
+    ref: "@adr: ADR-01"
+    count: 1
+    reason: >
+      Doc-level `@adr: ADR-01` predates GD-03 element granularity (CFB-PR-3).
+      Clearing it means re-cascading the tag to a specific element; pinned so it
+      cannot mask a new REFGRAN01 elsewhere. Tracked as deferred
+      fixture-authoring work.
+  - code: REFGRAN01
+    file: 08_IPLAN/IPLAN-01_golden.yaml
+    ref: "@adr: ADR-01"
+    count: 1
+    reason: >
+      Doc-level `@adr: ADR-01` predates GD-03 element granularity (CFB-PR-3).
+      Clearing it means re-cascading the tag to a specific element; pinned so it
+      cannot mask a new REFGRAN01 elsewhere. Tracked as deferred
+      fixture-authoring work.
+  - code: REFGRAN01
+    file: 08_IPLAN/IPLAN-01_golden.yaml
+    ref: "@tdd: TDD-01"
+    count: 1
+    reason: >
+      Doc-level `@tdd: TDD-01` predates GD-03 element granularity (CFB-PR-3).
+      Clearing it means re-cascading the tag to a specific element; pinned so it
+      cannot mask a new REFGRAN01 elsewhere. Tracked as deferred
+      fixture-authoring work.

--- a/tests/acceptance/expected_warnings/layer_07_tdd__valid.yaml
+++ b/tests/acceptance/expected_warnings/layer_07_tdd__valid.yaml
@@ -1,0 +1,54 @@
+# Accepted lint warnings for this target — see
+# plans/ACCEPTANCE-TIER-DRIFT-UNTRACKED-PLAN.md.
+#
+# Matching is a MULTISET and BIDIRECTIONAL: an unpinned warning fails, and a
+# pinned warning that no longer fires ALSO fails. Clearing a fixture therefore
+# tells you to delete its entry here. Do not add an entry without a `reason`
+# stating what would clear it.
+target: layer_07_tdd/valid
+expected_warnings:
+  - code: COV02
+    file: BDD-01_golden.md
+    ref: "BDD.01.04.bbbb"
+    count: 1
+    reason: >
+      `BDD.01.04.bbbb` is realized by no downstream element. The fixture
+      predates element-level COV01/COV02 (ELEMENT-COVERAGE-001); clearing it
+      means authoring the missing downstream citation. Pinned so it cannot mask
+      a new coverage gap.
+  - code: COV02
+    file: BDD-01_golden.md
+    ref: "BDD.01.04.cccc"
+    count: 1
+    reason: >
+      `BDD.01.04.cccc` is realized by no downstream element. The fixture
+      predates element-level COV01/COV02 (ELEMENT-COVERAGE-001); clearing it
+      means authoring the missing downstream citation. Pinned so it cannot mask
+      a new coverage gap.
+  - code: COV02
+    file: BDD-01_golden.md
+    ref: "BDD.01.04.dddd"
+    count: 1
+    reason: >
+      `BDD.01.04.dddd` is realized by no downstream element. The fixture
+      predates element-level COV01/COV02 (ELEMENT-COVERAGE-001); clearing it
+      means authoring the missing downstream citation. Pinned so it cannot mask
+      a new coverage gap.
+  - code: COV02
+    file: EARS-01_golden.md
+    ref: "EARS.01.03.cccc"
+    count: 1
+    reason: >
+      `EARS.01.03.cccc` is realized by no downstream element. The fixture
+      predates element-level COV01/COV02 (ELEMENT-COVERAGE-001); clearing it
+      means authoring the missing downstream citation. Pinned so it cannot mask
+      a new coverage gap.
+  - code: REFGRAN01
+    file: SPEC-01_golden.yaml
+    ref: "@adr: ADR-01"
+    count: 2
+    reason: >
+      Doc-level `@adr: ADR-01` predates GD-03 element granularity (CFB-PR-3).
+      Clearing it means re-cascading the tag to a specific element; pinned so it
+      cannot mask a new REFGRAN01 elsewhere. Tracked as deferred
+      fixture-authoring work.

--- a/tests/acceptance/expected_warnings/layer_08_iplan__valid.yaml
+++ b/tests/acceptance/expected_warnings/layer_08_iplan__valid.yaml
@@ -1,0 +1,99 @@
+# Accepted lint warnings for this target — see
+# plans/ACCEPTANCE-TIER-DRIFT-UNTRACKED-PLAN.md.
+#
+# Matching is a MULTISET and BIDIRECTIONAL: an unpinned warning fails, and a
+# pinned warning that no longer fires ALSO fails. Clearing a fixture therefore
+# tells you to delete its entry here. Do not add an entry without a `reason`
+# stating what would clear it.
+target: layer_08_iplan/valid
+expected_warnings:
+  - code: ACC01
+    file: BDD-01_golden.md
+    ref: "BDD.01.04.aaaa"
+    count: 1
+    reason: >
+      `BDD.01.04.aaaa` is paired to no TDD test case. The fixture predates ACC01
+      (SEED-ABSORPTION-001, shipped 2026-07-24 against fixtures authored
+      2026-05-31); clearing it means authoring the paired test case. Pinned so
+      it cannot mask a new unpaired scenario.
+  - code: ACC01
+    file: BDD-01_golden.md
+    ref: "BDD.01.04.bbbb"
+    count: 1
+    reason: >
+      `BDD.01.04.bbbb` is paired to no TDD test case. The fixture predates ACC01
+      (SEED-ABSORPTION-001, shipped 2026-07-24 against fixtures authored
+      2026-05-31); clearing it means authoring the paired test case. Pinned so
+      it cannot mask a new unpaired scenario.
+  - code: ACC01
+    file: BDD-01_golden.md
+    ref: "BDD.01.04.cccc"
+    count: 1
+    reason: >
+      `BDD.01.04.cccc` is paired to no TDD test case. The fixture predates ACC01
+      (SEED-ABSORPTION-001, shipped 2026-07-24 against fixtures authored
+      2026-05-31); clearing it means authoring the paired test case. Pinned so
+      it cannot mask a new unpaired scenario.
+  - code: ACC01
+    file: BDD-01_golden.md
+    ref: "BDD.01.04.dddd"
+    count: 1
+    reason: >
+      `BDD.01.04.dddd` is paired to no TDD test case. The fixture predates ACC01
+      (SEED-ABSORPTION-001, shipped 2026-07-24 against fixtures authored
+      2026-05-31); clearing it means authoring the paired test case. Pinned so
+      it cannot mask a new unpaired scenario.
+  - code: COV02
+    file: BDD-01_golden.md
+    ref: "BDD.01.04.bbbb"
+    count: 1
+    reason: >
+      `BDD.01.04.bbbb` is realized by no downstream element. The fixture
+      predates element-level COV01/COV02 (ELEMENT-COVERAGE-001); clearing it
+      means authoring the missing downstream citation. Pinned so it cannot mask
+      a new coverage gap.
+  - code: COV02
+    file: BDD-01_golden.md
+    ref: "BDD.01.04.cccc"
+    count: 1
+    reason: >
+      `BDD.01.04.cccc` is realized by no downstream element. The fixture
+      predates element-level COV01/COV02 (ELEMENT-COVERAGE-001); clearing it
+      means authoring the missing downstream citation. Pinned so it cannot mask
+      a new coverage gap.
+  - code: COV02
+    file: BDD-01_golden.md
+    ref: "BDD.01.04.dddd"
+    count: 1
+    reason: >
+      `BDD.01.04.dddd` is realized by no downstream element. The fixture
+      predates element-level COV01/COV02 (ELEMENT-COVERAGE-001); clearing it
+      means authoring the missing downstream citation. Pinned so it cannot mask
+      a new coverage gap.
+  - code: COV02
+    file: EARS-01_golden.md
+    ref: "EARS.01.03.cccc"
+    count: 1
+    reason: >
+      `EARS.01.03.cccc` is realized by no downstream element. The fixture
+      predates element-level COV01/COV02 (ELEMENT-COVERAGE-001); clearing it
+      means authoring the missing downstream citation. Pinned so it cannot mask
+      a new coverage gap.
+  - code: REFGRAN01
+    file: SPEC-01_golden.yaml
+    ref: "@adr: ADR-01"
+    count: 2
+    reason: >
+      Doc-level `@adr: ADR-01` predates GD-03 element granularity (CFB-PR-3).
+      Clearing it means re-cascading the tag to a specific element; pinned so it
+      cannot mask a new REFGRAN01 elsewhere. Tracked as deferred
+      fixture-authoring work.
+  - code: REFGRAN01
+    file: TDD-01_golden.yaml
+    ref: "@adr: ADR-01"
+    count: 1
+    reason: >
+      Doc-level `@adr: ADR-01` predates GD-03 element granularity (CFB-PR-3).
+      Clearing it means re-cascading the tag to a specific element; pinned so it
+      cannot mask a new REFGRAN01 elsewhere. Tracked as deferred
+      fixture-authoring work.


### PR DESCRIPTION
Implements the merged plan `plans/ACCEPTANCE-TIER-DRIFT-UNTRACKED-PLAN.md`. **Closes #365.**

Tier: **3 failures / 63 → 0 failures / 64.** No `framework/` change, no `VERSION` bump, no golden churn.

## The issue's premise was wrong, and I wrote it

#365 said "realign the acceptance fixtures with the coverage rules." It isn't that:

| Claim in #365 | Reality |
|---|---|
| the fixtures fail the lint rules | **`rc=0` for all 8 layer dirs AND the chain** — the linter passes every one |
| genuine findings against stale fixtures | Genuine, but **all 13 are `severity: warning`**; zero errors |
| fix = realign the fixtures | The weakest option: clears today's 13, leaves the mechanism for rule #3 |

The failing assertion demanded zero findings of **any** severity — stricter than any gate the framework defines. So each new advisory rule reddened the tier on contact: `REFGRAN01`, then `ACC01` (2026-07-24, against fixtures authored 2026-05-31).

## What changed

- **`assert_golden_passes_lint` asserts what it means**: `rc == 0` first, then zero `error` findings, then the warning **multiset** against a per-target manifest. `test_fullpath` uses the same contract via a module-level helper (it doesn't inherit the mix-in).
- **Bidirectional matching** — an unpinned warning fails (drift); a pinned warning that stops firing **also** fails (delete the entry). The manifest can't rot, and the deferred fixture work self-verifies.
- **Key is a multiset of `(code, file, ref)` + `count`.** Counts alone can't detect substitution (ACC01/COV02 report against the *host* doc); an exact set silently dedups distinct findings (`SPEC-01_golden.yaml` emits two REFGRAN01 with the same cited tag). `ref` is per-code — element ID for ACC01/COV02, cited tag for REFGRAN01, which exposes no element ID at all.
- **Manifests live outside `fixtures/`.** Inside a `NN_LAYER/` dir the linter ingests one as an artifact — measured on the chain: **13 → 31 findings, `rc` 0 → 1**. And `live/_live_harness.py` copies `valid/` contents into exactly such a dir (latent: live is `skipUnless(LIVE=1)`).
- **`.github/workflows/acceptance.yml`** runs the tier on every push/PR. Nothing ran it before — which is how three red tests sat on `main`.

## ⚠️ One step is deliberately NOT in this diff

Promotion to a **required** check is a branch-protection change. Tracked as `ACCEPTANCE-TIER-REQUIRED-CHECK`, with the mechanics recorded: `required_status_checks` is **full-replace**, so it must be **GET → append → PATCH** and the read-back must assert set equality against `observed ∪ {new}`. A naive PATCH silently drops the other five required contexts.

Four docs previously claimed "required check" as present fact; that's corrected to future tense throughout.

## Verified by mutation, not inspection

Each of these **FAILS**: a bogus manifest entry · a deleted entry · an element-ID substitution at constant count · a cited-tag substitution at constant count · deleting one of two duplicate-key findings · **a rule injected at `severity="info"`** · a manifest whose `target` mismatches its filename (under `python -O`) · an entry with an empty `reason` (under `-O`) · an orphan manifest.

Rewording a rule's message prose while preserving the quoted token **PASSES**. 12 consecutive full-tier runs: **OK**.

## Self-review found one CRITICAL defect

Worth calling out, because it was the exact failure this work exists to prevent, one severity string to the left:

**Findings at any severity other than `error`/`warning` fell through BOTH assertions** — the error check filters `== "error"`, the multiset filters `== "warning"`, and nothing owned the remainder. A rule shipped at `severity="info"` left the suite green. The plan's Pass 4 had *identified* the invariant ("the linter emits only error and warning") and the code **assumed** it. It is now asserted.

Eight further defects fixed before push: three data-contract guards used bare `assert` (stripped by `python -O`, so a duplicate-key or reason-less manifest would load silently); `relative_to` raised an unactionable `ValueError` on the linter's bare-doc-id output shape; orphan manifests were silently ignored; the README gave the wrong manifest filename and documented no schema; an unreconcilable `12 → 23` measurement; "three goldens" undercounted six; and `AIDOC-CI-COMPOSITION-CHECK-PRHEAD` was annotated but left in **Open** with a heading asserting the claim its own note disproves — now Closed.

Reviewers: `code-reviewer` + a docs-consistency reviewer, per OPS-0065.
