### PR TITLE
docs: the acceptance tier is now a required check (#365)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,8 +49,10 @@ change, so not a GATE-SPEC change. Implements
 - **The tier now runs in CI** (`.github/workflows/acceptance.yml`). Nothing ran
   it before — which is how three red tests sat on `main` unnoticed, and why
   `tests/acceptance/README.md`'s "runs in every PR" claim was false. It is true
-  now. **Promotion to a *required* check is a branch-protection change, not in
-  this diff** — tracked as `ACCEPTANCE-TIER-REQUIRED-CHECK`.
+  now. **It is also a required status check on `main`** as of 2026-07-27 —
+  context `Acceptance tier (deterministic)`, added via GET → append → PATCH
+  because `required_status_checks` is full-replace and a naive PATCH would have
+  dropped the other five.
 - **Verified by mutation, not by inspection**: a bogus entry, a deleted entry, an
   element-ID substitution, a cited-tag substitution, and deleting one of two
   duplicate-key findings each **fail**; rewording a rule's message prose while

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,9 +77,9 @@ The hook exits 0 regardless — it's a reminder, not a gate. If your change genu
 See [`tests/CONTRIBUTING.md`](tests/CONTRIBUTING.md) (test-suite contribution guidance).
 
 **Adding an advisory (warning-severity) lint rule?** It will fire on the
-acceptance fixtures, so the deterministic acceptance tier goes red until you
-update the affected manifests under `tests/acceptance/expected_warnings/` **in
-the same PR** (and blocks merges once that check is required). That is deliberate: the
+acceptance fixtures, and the deterministic acceptance tier is a **required
+check**, so it blocks every merge until you update the affected manifests under
+`tests/acceptance/expected_warnings/` **in the same PR**. That is deliberate: the
 tier previously asserted zero findings of any severity, so each new advisory rule
 silently reddened it (`REFGRAN01`, then `ACC01`). Pin the new warnings with a
 `reason`, or clear the fixtures. See

--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -24,26 +24,6 @@
 
 ## Open
 
-### `[ci]` `ACCEPTANCE-TIER-REQUIRED-CHECK` — promote the acceptance gate to a required status check
-
-- *Context:* `ACCEPTANCE-TIER-DRIFT-UNTRACKED` (2026-07-27) added
-  `.github/workflows/acceptance.yml`, which runs the deterministic tier on every
-  push/PR. Making it **required** is a branch-protection change — repo settings,
-  not a file — so it cannot ship in the same diff, and until it lands the tier
-  can go red without blocking a merge.
-- *Fix shape:* **GET → append → PATCH.**
-  `PATCH /repos/{owner}/{repo}/branches/main/protection/required_status_checks`
-  is **full-replace**: a payload carrying only the new context silently drops the
-  others. Read the live `checks` array, append
-  `{"context": "Acceptance tier (deterministic)", "app_id": 15368}`, preserve
-  `strict: false`, PATCH the union, then read back and assert set equality against
-  `observed ∪ {new}`. Confirm `main` is under classic protection first (under
-  rulesets the endpoint 404s and the step is a silent no-op), and rebase any PR
-  opened before the workflow file existed — it cannot produce the context.
-- *Precondition:* the tier must be green on `main` first, and worth a soak run —
-  a reviewer observed two non-reproducible failures in ~45 runs that could not be
-  isolated. A flaky required check blocks everything.
-
 ### `[harness]` `ACCEPTANCE-FIXTURE-WARNING-DEBT` — 13 distinct advisory findings pinned across the acceptance fixtures (30 manifest warnings / 27 entries)
 
 - *Context:* deferred from `ACCEPTANCE-TIER-DRIFT-UNTRACKED` (2026-07-27). The
@@ -1049,6 +1029,36 @@
 - *Status:* SHIPPED (spec 0.32.3, 2026-06-29 — BeeLocal docs sweep).
 
 ## Closed
+
+### `[ci]` `ACCEPTANCE-TIER-REQUIRED-CHECK` — ✅ CLOSED (2026-07-27) — promote the acceptance gate to a required status check
+
+- *Context:* `ACCEPTANCE-TIER-DRIFT-UNTRACKED` (2026-07-27) added
+  `.github/workflows/acceptance.yml`, which runs the deterministic tier on every
+  push/PR. Making it **required** is a branch-protection change — repo settings,
+  not a file — so it cannot ship in the same diff, and until it lands the tier
+  can go red without blocking a merge.
+- *Fix shape:* **GET → append → PATCH.**
+  `PATCH /repos/{owner}/{repo}/branches/main/protection/required_status_checks`
+  is **full-replace**: a payload carrying only the new context silently drops the
+  others. Read the live `checks` array, append
+  `{"context": "Acceptance tier (deterministic)", "app_id": 15368}`, preserve
+  `strict: false`, PATCH the union, then read back and assert set equality against
+  `observed ∪ {new}`. Confirm `main` is under classic protection first (under
+  rulesets the endpoint 404s and the step is a silent no-op), and rebase any PR
+  opened before the workflow file existed — it cannot produce the context.
+- *Precondition:* the tier must be green on `main` first, and worth a soak run —
+  a reviewer observed two non-reproducible failures in ~45 runs that could not be
+  isolated. A flaky required check blocks everything.
+- *Done:* 2026-07-27. `Acceptance tier (deterministic)` is now the **6th** required
+  context on `main` (was 5). Executed as GET → append → PATCH against the live
+  `checks` array; `strict: false` preserved; `app_id: 15368` (GitHub Actions) to
+  match the existing entries. Read-back asserted **set equality** against
+  `observed ∪ {new}` — not mere inclusion, which would have passed even if the
+  full-replace endpoint had dropped the other five. Preconditions checked first:
+  `main` is under classic protection (rulesets would 404 the endpoint), and the
+  context had already reported **success on `main` HEAD**, so no PR hangs on a
+  context that never arrives. No open PR predated the workflow file, so no rebase
+  was needed.
 
 ### `[ci]` `AIDOC-CI-COMPOSITION-CHECK-PRHEAD` — ✅ CLOSED (2026-07-27, stale — mechanism no longer occurs) — required `call / composition` check never landed on a PR head
 

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -1,7 +1,7 @@
 # Session Handoff
 
-> **✅ SESSION 2026-07-27 — #365 implemented: the acceptance tier is green and
-> gated. The tracker is empty once this merges.**
+> **✅ SESSION 2026-07-27 — #365 CLOSED: the acceptance tier is green, pinned,
+> and a required check. Tracker empty — 0 open issues.**
 >
 > `plans/ACCEPTANCE-TIER-DRIFT-UNTRACKED-PLAN.md` executed. Tier goes **3
 > failures / 63 → 0 failures / 64**, and `.github/workflows/acceptance.yml` runs
@@ -40,10 +40,16 @@
 >    heads; the real blocker was the `ai-review` self-cancel, fixed in #369 by
 >    pinning `ci/v2.15.0`.
 >
-> **One post-merge step remains, and it is not in any diff:** add
-> `Acceptance tier (deterministic)` to `required_status_checks` via
-> **GET → append → PATCH** (the endpoint is full-replace; a naive PATCH drops the
-> other required contexts). Verify by read-back asserting `observed ∪ {new}`.
+> **Done 2026-07-27 — the gate is required.** `Acceptance tier (deterministic)`
+> is the **6th** required context on `main` (was 5), added via
+> **GET → append → PATCH** because `required_status_checks` is full-replace; a
+> naive PATCH sending only the new context would have silently dropped the other
+> five and left `main` less protected while appearing to succeed. Read-back
+> asserted **set equality** against `observed ∪ {new}` — an inclusion check would
+> have passed after exactly that mistake. `strict: false` preserved.
+>
+> So the recurrence fix is now fully installed: the tier cannot go red on `main`
+> without blocking merges, which is the failure that let three tests sit broken.
 >
 > Deferred: `ACCEPTANCE-FIXTURE-WARNING-DEBT` — the 13 pinned warnings are real
 > advisory debt, self-verifying to clear (bidirectional matching means a fixed

--- a/tests/acceptance/README.md
+++ b/tests/acceptance/README.md
@@ -4,8 +4,8 @@
 **Pyramid tier:** 3 + 4
 **Runs:** deterministic in every PR (`.github/workflows/acceptance.yml`); live
 in nightly + release
-**Gating:** the workflow runs on every push/PR. Promotion to a *required* check
-is a branch-protection change, tracked as `ACCEPTANCE-TIER-REQUIRED-CHECK`
+**Gating:** required status check on `main` — context
+`Acceptance tier (deterministic)` (2026-07-27)
 **Determinism:** deterministic (default) | live (`LIVE=1`)
 
 ## What this suite covers
@@ -37,9 +37,8 @@ it. Manifests live here, **not** under `fixtures/`: a manifest inside a
 `NN_LAYER/` directory is ingested by the linter as an artifact, and the live
 harness copies `valid/` contents into exactly such a directory.
 
-**Adding a new advisory lint rule?** It will fire on these fixtures and turn this
-check red until the manifests are updated in the same PR (and block merges once
-the check is required). That is intended — it is what stops the tier from
+**Adding a new advisory lint rule?** It will fire on these fixtures and **block
+every merge** until the manifests are updated in the same PR. That is intended — it is what stops the tier from
 silently reddening — but budget for it.
 
 ### Manifest schema


### PR DESCRIPTION
Records the branch-protection change made today, which could not ship in #371 because it is a repo setting, not a file. Refs #365 (already closed by #371).

## The change

`Acceptance tier (deterministic)` is now the **6th** required context on `main` (was 5):

```
  Acceptance tier (deterministic)      <- NEW
  Framework + platform conformance
  call / Lint / format / security hooks
  call / ai-review
  call / composition
  call / verify
```

## How, and why it matters

`PATCH .../branches/main/protection/required_status_checks` is **full-replace**. A payload carrying only the new context would have **silently dropped the other five** and left `main` less protected while returning success. So: **GET → append → PATCH** against the live `checks` array, never a hardcoded list.

The read-back asserts **set equality** against `observed ∪ {new}` — not inclusion. An inclusion check passes even *after* the mistake it is supposed to catch:

| assertion | result |
|---|---|
| set equality vs `observed ∪ {new}` | PASS |
| none of the original five dropped | PASS |
| new context present | PASS |
| `strict: false` preserved | PASS |
| count | 5 → 6 |

**Preconditions verified before the PATCH**, not after:

- `main` is under **classic** branch protection — under rulesets the endpoint 404s and the whole step is a silent no-op whose read-back would misreport.
- The context had already reported **success on `main` HEAD**. A required context that has never reported leaves every PR stuck at "Expected — waiting for status to be reported", indefinitely.
- No open PR predated the workflow file, so no rebase was needed.

## Why docs change

#371 deliberately said "not yet required" in four places, because it wasn't. Leaving them would now be false in the other direction, so they move to present tense: `tests/acceptance/README.md` (gating line + the advisory-rule warning), `CONTRIBUTING.md`, `CHANGELOG.md`, plus `FRAMEWORK-TODO.md` (`ACCEPTANCE-TIER-REQUIRED-CHECK` → Closed) and `HANDOFF.md`.

## What this completes

The recurrence fix is now fully installed. Before today the tier could go red on `main` without blocking anything — which is exactly how three tests sat broken while `tests/acceptance/README.md` claimed the suite "runs in every PR". It now cannot.

Still open by design: `ACCEPTANCE-FIXTURE-WARNING-DEBT` — the 13 findings are pinned, not cleared. Bidirectional matching makes that self-verifying: a fixed fixture fails the suite until its manifest entry is deleted.

No code change. No `framework/` change. No `VERSION` bump.
