### PR TITLE
ci: bring every canon caller to ci/v2.16.0 and adopt the body changes a re-pin cannot deliver

### DIFF
--- a/.github/ai-review/config.json
+++ b/.github/ai-review/config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/vladm3105/aidoc-flow-ci/ci/v2.14.0/schemas/ai-review-config-v2.schema.json",
+  "$schema": "https://raw.githubusercontent.com/vladm3105/aidoc-flow-ci/ci/v2.16.0/schemas/ai-review-config-v2.schema.json",
   "version": 2,
   "_note": "NOT load-bearing for model resolution on this repo. The ci/v2.x ai-review reusable resolves the alias from the config it FETCHES from trust_config_repo (vladm3105/aidoc-flow-operations@main), not from this file — see canon ai-review.yml 'Resolve LiteLLM model'. Operations already sets model 'ai-reviewer'. This file is kept because it documents the expected policy at the point a reader looks for it, and because it becomes authoritative if trust_config_repo is ever pointed at this repo. It is declared at schema v2 so that path actually works: canon asserts version == 2 before reading any field (CI-0014), so a v1 file pointed at would hard-fail the required ai-review check rather than become authoritative. This _note sits at the root, not inside litellm, because the v2 schema declares litellm additionalProperties:false. Declared per MIGRATION_v2.0.0.md §3.",
   "litellm": {

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -10,23 +10,27 @@ on:
 permissions:
   contents: read
 
-# `cancel-in-progress` is safe HERE because of this workflow's TRIGGER SHAPE, and
-# the reasoning must survive so nobody re-derives it:
-#
-#   push          -> github.ref = refs/heads/<branch>
-#   pull_request  -> github.ref = refs/pull/<N>/merge
-#
-# Two different groups, so the two events on one commit never cancel each other.
-# Cancellation only fires across successive pushes to the SAME ref, which cancels
-# a stale SHA's in-flight run — never the newest SHA's own check-run.
-#
-# That precondition is exactly what ai-review.yml violated (two trigger events
-# collapsing into one group on the same SHA), stranding a CANCELLED required
-# check that blocked PRs #366 and #367 outright; fixed by ci/v2.15.0.
-# DO NOT add a second trigger event here without re-deriving the above.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # CI-0025 / REPO_STANDARDS §23: ALLOWLIST of the code-changing events.
+  # This workflow feeds a REQUIRED context. Every event other than a push or a
+  # code-changing PR action fires at the CURRENT head SHA, and a cancelled required
+  # check is not success — it is retained alongside any later success from a
+  # separate run, so the rollup stays FAILURE and the PR is --admin-only. Here the
+  # untyped `pull_request` trigger admits `reopened`, which lands in the SAME group
+  # at the SAME head SHA as an in-flight `synchronize` run. Expressed as `==` so an
+  # empty `github` context yields false and cancels nothing; a `!=` denylist would
+  # cancel everything in that degraded state.
+  #
+  # An earlier version of this comment argued blanket cancellation was safe here
+  # because `push` (refs/heads/<branch>) and `pull_request` (refs/pull/<N>/merge)
+  # resolve to different groups. That is true and irrelevant — the collision is
+  # WITHIN `pull_request`. It was written while this workflow was still
+  # non-required; it became the 6th required context on 2026-07-27.
+  cancel-in-progress: >-
+    ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+      || ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target')
+          && contains(fromJSON('["opened","synchronize"]'), github.event.action)) }}
 
 jobs:
   acceptance:

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -25,9 +25,19 @@ name: ai-review
 on:
   pull_request_target:
     # FT-43 (ci/v2.12.0, filed as a SECURITY fix): `ready_for_review` +
-    # `converted_to_draft` so a draft→ready transition triggers a real review,
-    # and a ready→draft is seen by the fail-closed guard. Without them a PR whose
-    # code changed while it was a draft could reach merge un-reviewed.
+    # `converted_to_draft` so a draft→ready transition triggers a real review
+    # (and a ready→draft still gets a real review while unarmed — #331 removed
+    # the fail-closed step that used to intercept it), rather than a
+    # code-changed-while-draft PR going straight to merge un-reviewed.
+    #
+    # Keep the `while unarmed` qualifier: THIS repo is armed
+    # (`vars.APP_REVIEWER_1_BOT_ID` is set), so a `converted_to_draft` still
+    # job-skips here — but by ONE mechanism, not two. Only the TRUST job's `if:`
+    # carries `draft == false` on its armed disjunct (canon ai-review.yml:148);
+    # the review job's `if:` has no `draft` term at all — it skips transitively
+    # because it is `needs: trust`, so `needs.trust.outputs.ai_review_ok` is
+    # empty when trust skips. Do not read the review job as independently
+    # draft-gated. #331 is a no-op on this repo.
     types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review, converted_to_draft]
   pull_request_review:
     types: [submitted]
@@ -51,7 +61,9 @@ permissions:
   issues: write          # gh api label create/apply paths
 jobs:
   call:
-    # ci/v2.15.0 — the CI-0025 self-cancel fix (aidoc-flow-ci#322). At v2.14.0 the
+    # ci/v2.15.0 SHIPPED the CI-0025 self-cancel fix (aidoc-flow-ci#322) — this
+    # annotation names the tag that fixed it, not the tag pinned below, so it
+    # stays true across later bumps. At v2.14.0 the
     # reusable's concurrency group used a DENYLIST of self-emitted actions, so the
     # review this workflow posts fired `pull_request_review: submitted`, which
     # landed in the same group and cancelled the `pull_request_target` run that had
@@ -61,7 +73,7 @@ jobs:
     # denylist with an ALLOWLIST of the two code-changing actions (`synchronize`,
     # `opened`); every other subscribed event fires at the current head and must
     # not cancel. Do not pin back below v2.15.0.
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/ai-review.yml@ci/v2.15.0
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/ai-review.yml@ci/v2.16.0
     with:
       # Model selection is CONFIG-DRIVEN: the reusable reads `litellm.model`
       # from the trusted .github/ai-review/config.json. Uncomment to override:

--- a/.github/workflows/audit-trail.yml
+++ b/.github/workflows/audit-trail.yml
@@ -2,10 +2,24 @@
 name: audit-trail
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    # `labeled, unlabeled` are load-bearing, not cosmetic: the reusable's
+    # documented escape hatch is the two-signal override (the `skip-audit-trail`
+    # LABEL + a commit-body marker). Without a `labeled` trigger, applying the
+    # label fires no event, so the check never re-runs and the red check never
+    # clears — the operator is told to apply a label that cannot take effect and
+    # has to push an empty commit instead. ai-review's callers already include
+    # these; audit-trail was the outlier. This repo hit exactly that failure —
+    # see plans/DECISIONS.md D-0065.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+# Deliberately NO top-level `concurrency:` block in this file. Canon's template
+# carries one, but it is the #329 ALLOWLIST rather than `cancel-in-progress:
+# true`; this caller has never had a block, and no block at all is strictly safer
+# than an allowlist. Nothing to cancel, so nothing to fix. Recorded here, at the
+# level a `concurrency:` sweep actually greps, per D-0070.
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/audit-trail-check.yml@ci/v2.15.0
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/audit-trail-check.yml@ci/v2.16.0
     with:
       runner_labels: '"ubuntu-latest"'
     permissions:

--- a/.github/workflows/auto-merge-ai-prs.yml
+++ b/.github/workflows/auto-merge-ai-prs.yml
@@ -5,7 +5,7 @@
 # The reusable is the server-side enforcer for AI-opened PRs
 # (OPS-0062 deferred companion). It detects stuck-green PRs
 # (label=ai:review-passed + mergeStateStatus=CLEAN + autoMergeRequest
-# is null + updatedAt > 2 min) + re-arms `gh pr merge --auto --merge`
+# is null + updatedAt > 2 min) + re-arms `gh pr merge --auto --squash`
 # under the reviewer App's token. Narrow scope cases 1+2 per plan §1.
 #
 # Trigger architecture per IPLAN-0030 §2.2 + Pass-2 C1 finding:
@@ -50,7 +50,7 @@ jobs:
     # failed ai-review or composition), but this saves the runner slot
     # entirely (per OPS-0065 security-auditor recommendation).
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/auto-merge-ai-prs.yml@ci/v2.14.0
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/auto-merge-ai-prs.yml@ci/v2.16.0
     with:
       # `||` fallback per Workflow-tool expression semantics: returns
       # the first truthy operand. workflow_run path resolves the LHS;

--- a/.github/workflows/composition.yml
+++ b/.github/workflows/composition.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/composition.yml@ci/v2.15.0
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/composition.yml@ci/v2.16.0
     with:
       runner_labels: '"ubuntu-latest"'
     secrets: inherit  # pragma: allowlist secret

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -12,7 +12,19 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # CI-0025 / REPO_STANDARDS §23: ALLOWLIST of the code-changing events.
+  # This workflow feeds a REQUIRED context. Every event other than a push or a
+  # code-changing PR action fires at the CURRENT head SHA, and a cancelled required
+  # check is not success — it is retained alongside any later success from a
+  # separate run, so the rollup stays FAILURE and the PR is --admin-only. Here the
+  # untyped `pull_request` trigger admits `reopened`, which lands in the SAME group
+  # at the SAME head SHA as an in-flight `synchronize` run. Expressed as `==` so an
+  # empty `github` context yields false and cancels nothing; a `!=` denylist would
+  # cancel everything in that degraded state.
+  cancel-in-progress: >-
+    ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+      || ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target')
+          && contains(fromJSON('["opened","synchronize"]'), github.event.action)) }}
 
 jobs:
   conformance:

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -1,4 +1,4 @@
-# Caller for aidoc-flow-ci's reusable docs-sync workflow (@ci/v2.14.0).
+# Caller for aidoc-flow-ci's reusable docs-sync workflow (@ci/v2.16.0).
 # DRY-RUN rollout: computes proposed mechanical doc-fixes post-merge and
 # comments them on the PR — no push-back, no bot App needed (bot secrets are
 # only referenced by the live-mode Apply step, gated by dry_run != true).
@@ -12,32 +12,26 @@ on:
 
 permissions:
   contents: read
-  # PREREQUISITE ONLY — this alone does NOT fix the failing dry-run comment.
-  #
   # Dry-run's "Post dry-run comment" step posts to the merge's PR and needs
   # pull-requests: write; with `read` it dies on
   # `GraphQL: Resource not accessible by integration (addComment)` under
   # `set -euo pipefail`. The step is gated on `proposed != 0`, so it never ran —
   # and the workflow reported green — until a merge finally produced a proposal.
   #
-  # But GitHub intersects caller and callee permissions for reusable workflows,
-  # and the callee declares `pull-requests: read` at its own workflow level, with
-  # no job-level override. So the effective token stays `read` until THAT
-  # declaration is raised upstream.
+  # MECHANISM (keep this — it is why the caller-side grant alone was never
+  # enough): GitHub INTERSECTS caller and callee permissions for reusable
+  # workflows, so the effective token is the weaker of the two. This grant is one
+  # half; the callee's own workflow-level declaration is the other.
   #
-  # STILL NOT RAISED AT ci/v2.14.0 (verified 2026-07-25, CI-CANON-V2-001):
-  # canon docs-sync.yml declares `contents: read` + `pull-requests: read` at
-  # lines 59-61 and its `sync` job sets no `permissions:` block, while the
-  # "Post dry-run comment" step runs `gh pr comment` (line 244). Re-pinning this
-  # caller to v2.14.0 therefore does NOT fix the dry-run comment — an earlier
-  # version of this comment assumed the upstream half would ship alongside the
-  # re-pin, and it has not. This block remains pre-positioning only; the fix must
-  # land in canon. Track upstream before graduating docs-sync out of dry-run.
+  # BOTH HALVES ARE NOW IN PLACE. CI-0015 raised the callee to
+  # `pull-requests: write` at ci/v2.15.0 (canon docs-sync.yml:77, verified at
+  # ci/v2.16.0 — the pin below). The intersection therefore resolves to `write`
+  # and the dry-run comment can post. Nothing upstream is outstanding.
   #
   # `contents` stays `read`: dry-run never pushes, and live mode uses the bot App.
   pull-requests: write
 
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/docs-sync.yml@ci/v2.14.0
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/docs-sync.yml@ci/v2.16.0
     secrets: inherit  # pragma: allowlist secret

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -36,7 +36,7 @@ concurrency:
 
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/labeler.yml@ci/v2.15.0
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/labeler.yml@ci/v2.16.0
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,4 +1,4 @@
-# Caller for aidoc-flow-ci's reusable links workflow (@ci/v2.14.0).
+# Caller for aidoc-flow-ci's reusable links workflow (@ci/v2.16.0).
 # internal = PR-blocking (offline; internal/relative links only);
 # external = weekly cron, non-blocking. See aidoc-flow-ci docs/REPO_STANDARDS §4.3.
 name: links
@@ -22,7 +22,7 @@ jobs:
   internal:
     name: internal links (blocking)
     if: github.event_name != 'schedule'
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/links.yml@ci/v2.14.0
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/links.yml@ci/v2.16.0
     with:
       mode: internal
       fail-on-error: true
@@ -30,7 +30,7 @@ jobs:
   external:
     name: external links (non-blocking)
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/links.yml@ci/v2.14.0
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/links.yml@ci/v2.16.0
     with:
       mode: external
       fail-on-error: false

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,11 +20,21 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
+  # CI-0025 / REPO_STANDARDS §23: ALLOWLIST of the code-changing events.
+  # This caller feeds a REQUIRED context. Every event here other than a push or a
+  # code-changing PR action fires at the CURRENT head SHA, and a cancelled required
+  # check is not success — it is retained alongside any later success from a
+  # separate run, so the rollup stays FAILURE and the PR is --admin-only. A label
+  # write (audit-trail's documented `skip-audit-trail` hatch) or a reopen would do
+  # it. Expressed as `==` so an empty `github` context yields false and cancels
+  # nothing; a `!=` denylist would cancel everything in that degraded state.
+  cancel-in-progress: >-
+    ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+      || ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target')
+          && contains(fromJSON('["opened","synchronize"]'), github.event.action)) }}
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/pre-commit.yml@ci/v2.15.0
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/pre-commit.yml@ci/v2.16.0
     with:
       python-version: '3.12'
       # Override examples:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -9,7 +9,7 @@ permissions:
   security-events: write
 jobs:
   call:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/secret-scan.yml@ci/v2.14.0
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/secret-scan.yml@ci/v2.16.0
     with:
       # REQUIRED from ci/v2.0.0. The v1.x reusable shipped a default allowlist
       # for tests/ fixtures/ vectors/ and .secrets.baseline; v2 removed it, so

--- a/.github/workflows/standards-drift.yml
+++ b/.github/workflows/standards-drift.yml
@@ -56,7 +56,7 @@ permissions:
 
 jobs:
   drift:
-    uses: vladm3105/aidoc-flow-ci/.github/workflows/standards-drift.yml@ci/v2.15.0
+    uses: vladm3105/aidoc-flow-ci/.github/workflows/standards-drift.yml@ci/v2.16.0
     with:
       tier: governance
       strict: ${{ github.event.inputs.strict == 'true' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,47 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed — every CI caller is at `ci/v2.16.0`, and the body changes a re-pin cannot deliver (2026-07-29)
+
+**No version moves** — `.github/` only. CI infrastructure; no `framework/`
+change, so not a GATE-SPEC change. Implements
+`plans/CI-CANON-V2.16-MIGRATION-PLAN.md`; records `plans/DECISIONS.md` **D-0070**.
+
+- **All eleven `aidoc-flow-ci` call sites → `@ci/v2.16.0`** (ten files). They sat
+  at two tags — six at `ci/v2.15.0`, five at `ci/v2.14.0` — since 2026-07-27.
+  Applied with canon's `--repin` semantics (tag string only), never `--update`,
+  which would have replaced whole caller bodies and clobbered this repo's
+  self-hosted `runner_labels_*`, `config-path: .gitleaks.toml`, and `docs-sync`
+  permission grant.
+- **`pre-commit.yml`, `conformance.yml`, `acceptance.yml`: `cancel-in-progress:
+  true` → canon's #329 allowlist.** All three feed required contexts under an
+  untyped `pull_request` trigger, so a `reopened` could cancel a required check
+  at the current head SHA — and a cancelled required check is not success, it is
+  retained alongside any later success, leaving the PR `--admin`-only. The
+  behavioral delta is `reopened` alone; `push`, `opened` and `synchronize` still
+  cancel as before. The latter two are locally owned — the rule is scoped by
+  required-context, not by ownership.
+- **`acceptance.yml`'s "two different groups" comment was wrong and is
+  rewritten.** It argued cancellation was safe because `push` and `pull_request`
+  resolve to different `github.ref` values. True and irrelevant: the collision is
+  *within* `pull_request`. It was written while the workflow was still
+  non-required.
+- **`audit-trail.yml` gains `labeled, unlabeled` triggers.** Without them,
+  applying the `skip-audit-trail` label fires no event at all, so the documented
+  two-signal escape hatch on the required `call / verify` context was
+  unreachable — a failure this repo had already hit (D-0065). It makes the hatch
+  *fire*; it does not make an already-red check go green by labelling.
+- **Four comments the bump falsified, corrected:** `docs-sync.yml`'s "STILL NOT
+  RAISED" verdict (CI-0015 raised the callee to `pull-requests: write` at
+  `ci/v2.15.0`, so the dry-run comment can now post); `ai-review.yml`'s FT-43
+  note (#331 removed the fail-closed step — canon's `while unarmed` qualifier
+  kept, because this repo *is* armed); `auto-merge-ai-prs.yml`'s claim that the
+  enforcer re-arms `--merge` (it has always run `--squash`); and the `@ci/v2.14.0`
+  tags in two file headers.
+- **`.github/ai-review/config.json`'s `$schema` → `ci/v2.16.0`** — currency, not
+  breakage. No CI check validates against it, and no canon tool would ever bump
+  it.
+
 ### Fixed — the acceptance tier is green, pinned, and runs in CI (#365) (2026-07-27)
 
 **No version moves** — `tests/` + `.github/workflows/` only. No `framework/`

--- a/plans/CI-CANON-V2.16-MIGRATION-PLAN.md
+++ b/plans/CI-CANON-V2.16-MIGRATION-PLAN.md
@@ -4,7 +4,7 @@
 | -------------- | --------------------------------------------------------------------------------- |
 | Task           | CI-CANON-V2.16-001                                                                 |
 | Type           | chore                                                                              |
-| Status         | Draft — 2026-07-29                                                                 |
+| Status         | In Progress — 2026-07-29 (PR 0 merged as #374; PR 1 open; PR 2 pending)             |
 | Depends on     | nothing blocking; canon `ci/v2.16.0` is cut (2026-07-27)                            |
 | Feeds          | a single-tag fleet position for this repo's workflow callers; unblocks the next canon bump being mechanical |
 | Version impact | none — no `VERSION` stream moves (CI infrastructure only)                           |

--- a/plans/CI-CANON-V2.16-MIGRATION-PLAN.md
+++ b/plans/CI-CANON-V2.16-MIGRATION-PLAN.md
@@ -189,6 +189,17 @@ here — `call / ai-review` is job-skipped on every `ai:review-*` label event to
 and PRs still merge — but it is the difference between B2 being harmless noise
 and B2 bricking the gate, so it is stated rather than assumed.
 
+> **⚠️ CORRECTED AT IMPLEMENTATION — the two preceding sentences are wrong; see
+> `plans/DECISIONS.md` D-0070.** Measured on PR #375: `labeler` and `ai-review`
+> write labels with `GITHUB_TOKEN` (actor `github-actions[bot]`), and a
+> `GITHUB_TOKEN`-triggered event creates no workflow run. No `audit-trail` run on
+> that branch was label-triggered — both came from `pull_request`. So it is **not**
+> *every* label write, only a **human** or App-token one; and `call / ai-review`
+> job-skipping on its own `ai:review-*` writes **is not evidence** for
+> skipped⇒success, because no run is created to skip. The assumption remains
+> **unexercised**, which makes verification #8 the only way to settle it — and it
+> must apply the label **by hand**.
+
 ⚠️ **Add no `concurrency:` block when taking B2** — but not for the reason a first
 draft of this plan gave. Canon's template block is the #329 **allowlist**, not
 `cancel-in-progress: true`, so copying it would introduce only same-ref

--- a/plans/DECISIONS.md
+++ b/plans/DECISIONS.md
@@ -60,17 +60,40 @@ graduation.
   benefit is precisely that the override becomes usable on the next push instead
   of being unreachable — this repo had already hit the unreachable case (D-0065).
   B2 also rests on an assumption worth stating: a job skipped by `if:` reports
-  success to branch protection. It holds empirically here (`call / ai-review`
-  job-skips on every `ai:review-*` label event and PRs still merge), and it is
-  the difference between B2 being harmless noise and B2 bricking a required gate.
-  The sharpest case it has to cover is *failure-then-skip*: `call / verify` is
-  red at SHA X, someone applies an unrelated label, and a fresh run job-skips at
-  that same SHA. Under the retained-alongside/worst-wins model these files assert
-  throughout, the earlier `failure` still governs and the gate holds. The shape
-  is not novel here — `call / ai-review` has subscribed to `labeled`/`unlabeled`
-  and job-skipped the same way for months — but if
-  [ci#330](https://github.com/vladm3105/aidoc-flow-ci/issues/330) resolves toward
-  latest-run-wins, B2 is where this repo would feel it first.
+  success to branch protection. It is the difference between B2 being harmless
+  noise and B2 bricking a required gate. The sharpest case is *failure-then-skip*:
+  `call / verify` is red at SHA X, someone applies an unrelated label, and a fresh
+  run job-skips at that same SHA. Under the retained-alongside/worst-wins model
+  these files assert throughout, the earlier `failure` still governs and the gate
+  holds; if [ci#330](https://github.com/vladm3105/aidoc-flow-ci/issues/330)
+  resolves toward latest-run-wins instead, B2 is where this repo would feel it
+  first.
+
+- **B2's blast radius is much narrower than the plan assumed, and the assumption
+  above is still UNEXERCISED — measured on PR #375, this change's own PR.** The
+  plan asserted that after B2 "*every* label write in this repo (`labeler`'s path
+  labels, `ai-review`'s own `ai:review-*` writes, the `skip-ai-review`
+  label-cycle) starts an `audit-trail` run whose `verify` job is skipped." **It
+  does not.** All four label writes on #375 (`documentation`, `ci`, `plans`,
+  `ai:review-passed`) were made by `github-actions[bot]` — i.e. `GITHUB_TOKEN` —
+  and a `GITHUB_TOKEN`-triggered event does not create a workflow run (the
+  documented exceptions, `workflow_dispatch` and `repository_dispatch`, are not
+  in play for a label write). **No `audit-trail` run on that branch was created
+  by a label event** — every one came from `pull_request`. State it as provenance,
+  not as a count: the count moves with the next push. So routine bot labelling
+  starts nothing; only a **human** label write, or one made under an App token,
+  reaches the new trigger. The second `call / ai-review` run on #375 came from
+  `pull_request_review` (the reviewer App `aidoc-reviewer[bot]` submitting its
+  review — a different identity from `github-actions[bot]`, which is itself the
+  corroboration), not from a label.
+
+  Two consequences. First, the earlier empirical support offered for
+  skipped⇒success — "`call / ai-review` job-skips on every `ai:review-*` label
+  event and PRs still merge" — **is not evidence at all**: no run is created, so
+  nothing job-skips. Do not cite it. Second, the plan's verification #8 (the
+  post-merge scratch-PR smoke test) is now the *only* way to settle the
+  assumption, and it must apply the label **by hand** — a bot-applied label will
+  reproduce nothing.
 
 - **A byte-exact copy is worth keeping even when the copied comment is wrong —
   file the defect upstream instead.** Canon's `pre-commit.yml` allowlist comment

--- a/plans/DECISIONS.md
+++ b/plans/DECISIONS.md
@@ -10,6 +10,102 @@ graduation.
 
 ---
 
+## D-0070 — A re-pin is not a migration; and an exemption from a required-context rule is a snapshot, not a property
+
+**2026-07-29.** Decisions from executing CI-CANON-V2.16-001
+(`plans/CI-CANON-V2.16-MIGRATION-PLAN.md`), which took all eleven
+`aidoc-flow-ci` call sites from a mixed `ci/v2.14.0` / `ci/v2.15.0` state to
+`ci/v2.16.0`.
+
+- **Dependabot cannot deliver a caller-body change, so a pin bump is never the
+  whole migration.** It rewrites `uses:` lines and nothing else. Two of the four
+  changes in this PR live in caller bodies (`pre-commit.yml`'s concurrency
+  allowlist, `audit-trail.yml`'s `labeled, unlabeled` triggers) and a third class
+  — comments the bump *falsifies* — is invisible to it entirely. The mixed-pin
+  state itself was Dependabot residue: PR #369 bumped one caller by hand and the
+  group PR #370 carried five reusables, leaving four behind. **Treat a canon bump
+  as a migration with a plan, not as a dependency update.**
+
+- **`--repin`, never `--update`.** `install.sh --update` replaces the whole body
+  of all sixteen `safe_to_replace` surfaces and would clobber every local
+  customization this repo depends on — `ai-review`'s dual self-hosted
+  `runner_labels_*` plus `litellm_allow_insecure_http: true`, `secret-scan`'s
+  `config-path: .gitleaks.toml` (without which the scan reports 27 synthetic
+  findings and goes red), `docs-sync`'s `pull-requests: write`, `links`'s
+  two-job split. The four body changes were applied by hand, per file, quoted
+  from canon. Canon's own guide says default to `--repin`.
+
+- **The #329 allowlist is scoped by *context*, not by ownership.** `conformance.yml`
+  and `acceptance.yml` call no canon reusable, so no pin moved in them — but both
+  feed required contexts and both carried `cancel-in-progress: true` under an
+  untyped `pull_request` trigger, which is the same defect `pre-commit.yml` had.
+  A cancelled required check is not success; it is retained alongside any later
+  success from a separate run, leaving the PR `--admin`-only. Shipping the fix
+  for one of three affected required contexts would have been worse than the
+  scope creep.
+
+- **Seven local workflows still carry the shape and are exempt only because they
+  are not required — that exemption is a snapshot, not a property.** `codeql`,
+  `chg-gate`, `doc-review`, `hermes`, `plugin`, `labeler` and `links` all carry
+  `cancel-in-progress: true`. `acceptance` was exempt by exactly that reasoning,
+  and defended by a comment arguing the cancellation was safe here, until
+  2026-07-27 made it the sixth required context and turned the comment into a
+  defect. **Any future change that makes one of these seven a required context
+  must take the allowlist in the same PR.**
+
+- **B2 makes the escape hatch fire; it does not make a red check go green.** The
+  `skip-audit-trail` override is two-signal (the label **plus** a commit-body
+  marker), and per §23.1 a label event starts a *separate* run whose check-run is
+  retained alongside the earlier one with the rollup keeping the worst. So the
+  benefit is precisely that the override becomes usable on the next push instead
+  of being unreachable — this repo had already hit the unreachable case (D-0065).
+  B2 also rests on an assumption worth stating: a job skipped by `if:` reports
+  success to branch protection. It holds empirically here (`call / ai-review`
+  job-skips on every `ai:review-*` label event and PRs still merge), and it is
+  the difference between B2 being harmless noise and B2 bricking a required gate.
+  The sharpest case it has to cover is *failure-then-skip*: `call / verify` is
+  red at SHA X, someone applies an unrelated label, and a fresh run job-skips at
+  that same SHA. Under the retained-alongside/worst-wins model these files assert
+  throughout, the earlier `failure` still governs and the gate holds. The shape
+  is not novel here — `call / ai-review` has subscribed to `labeled`/`unlabeled`
+  and job-skipped the same way for months — but if
+  [ci#330](https://github.com/vladm3105/aidoc-flow-ci/issues/330) resolves toward
+  latest-run-wins, B2 is where this repo would feel it first.
+
+- **A byte-exact copy is worth keeping even when the copied comment is wrong —
+  file the defect upstream instead.** Canon's `pre-commit.yml` allowlist comment
+  cites "a label write (audit-trail's documented `skip-audit-trail` hatch)" as a
+  motivating case, but that template's `pull_request:` is **untyped**, so it never
+  receives a `labeled` event; only the `reopened` half is live. The same paragraph
+  ships over the same untyped trigger in six templates (`pre-commit`,
+  `markdown-lint`, `secret-scan` × public/private). Correcting it locally would
+  have cost the byte-exactness that verification #3's pass condition turns on, and
+  `check-drift.sh` would then warn permanently *for being right*. So this repo
+  keeps canon's text verbatim in `pre-commit.yml` and filed
+  [ci#348](https://github.com/vladm3105/aidoc-flow-ci/issues/348). The trim WAS
+  applied to `conformance.yml` and `acceptance.yml` — those are locally owned,
+  have no canon counterpart, and so carry no drift cost.
+
+- **#329 is narrowed, not closed.** GitHub cancels a *pending* run when a newer
+  one queues in the same group, independently of `cancel-in-progress`. Canon does
+  not claim closure and neither does this repo.
+
+- **`.github/ai-review/config.json`'s `$schema` was bumped for currency, not
+  breakage.** Nothing in CI validates against it, and neither `--repin`
+  (workflows only) nor `check-pin-currency.sh` (`.github/workflows` only) would
+  ever touch it — so it would have silently stayed two minors behind the
+  single-tag position this migration claims. One line, kept because leaving it
+  makes the claim false.
+
+- **Cross-repo feedback filed, not recorded locally.**
+  [`aidoc-flow-ci#347`](https://github.com/vladm3105/aidoc-flow-ci/issues/347) —
+  `docs/UPDATE_GUIDE.md:88` states that `framework`'s ai-review caller pins
+  `runner_labels_routine: '"ubuntu-latest"'`, false since PLAN-013; the live
+  caller pins the self-hosted array. Blast radius is any adopter reading the
+  guide's worked example for this repo.
+
+---
+
 ## D-0069 — A defect fix does not smuggle in a strategy change; and a coverage guard needs a guard of its own
 
 **2026-07-26.** Three decisions from executing IDCOORD-SECOND-HASH-IMPL

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -1,7 +1,87 @@
 # Session Handoff
 
+> **🔄 SESSION 2026-07-29 — CI-CANON-V2.16-001 in flight. PR 0 merged (#374);
+> PR 1 open; PR 2 (`CLAUDE.md` + plan → `Completed`) still to come.**
+>
+> `plans/CI-CANON-V2.16-MIGRATION-PLAN.md`, Status **In Progress**. PR 1 takes
+> all eleven `aidoc-flow-ci` call sites to `@ci/v2.16.0` and applies the four
+> body changes a re-pin structurally cannot deliver (B1–B4), plus the comments
+> the bump falsifies. Records `plans/DECISIONS.md` **D-0070**.
+>
+> **PR 1 carries four doc surfaces against governance Rule 1's ≤3 cap** —
+> `DECISIONS.md` + `HANDOFF.md` + `CHANGELOG.md` + the plan file (whose `Status`
+> must move in the same change as the state change). Founder OK granted
+> 2026-07-29 and **re-confirmed at execution time**; the commit message carries
+> the audit-trail line naming the fourth surface. It is founder-merged regardless
+> — it touches `ai-review.yml`.
+>
+> **Four things a next session must not re-derive:**
+>
+> 1. **The `--repin`/`--update` distinction is load-bearing, not stylistic.**
+>    `install.sh --update` replaces the whole body of all sixteen
+>    `safe_to_replace` surfaces. This repo's callers carry customizations that
+>    would not survive it: `ai-review`'s dual self-hosted `runner_labels_*` +
+>    `litellm_allow_insecure_http: true`, `secret-scan`'s `config-path:
+>    .gitleaks.toml` (without it the scan reports 27 synthetic findings and goes
+>    red), `docs-sync`'s `pull-requests: write`, `links`'s two-job split.
+> 2. **`check-drift.sh` cannot tell you a pin is stale**, because it frames each
+>    caller against the template *at the tag that caller declares* — a stale pin
+>    is self-consistent and silent. That is `check-pin-currency.sh`'s job, and
+>    this repo runs it **nowhere**, which is how the mixed-pin state accumulated.
+>    Filed as `NO-PIN-CURRENCY-CHECK` in `FRAMEWORK-TODO.md` (TODO-only).
+> 3. **Reading the drift output: count `::warning::drift-check:`, not
+>    `::warning::`.** A bare grep returns 12 for 10 annotations —
+>    `standards-drift.yml`'s canon header quotes the literal string, so its own
+>    drift body reproduces it twice. Measured before and after this change: **10
+>    both times**. And `secret-scan.yml`'s diff body legitimately *grows* by ~13
+>    lines after the bump — its template is one of the eight that gained the #329
+>    allowlist at v2.16.0, and this repo deliberately adds no `concurrency:` block
+>    there. Do not "fix" it; that is `--update` by hand.
+> 4. **Seven local workflows still carry `cancel-in-progress: true` and are exempt
+>    only because they are not required contexts** (`codeql`, `chg-gate`,
+>    `doc-review`, `hermes`, `plugin`, `labeler`, `links`). That is a snapshot,
+>    not a property — `acceptance` was exempt by the same reasoning, complete with
+>    a comment arguing it was safe, until 2026-07-27 made it required and turned
+>    the comment into the B4 defect. **Any change that makes one of the seven
+>    required must take the allowlist in the same PR.**
+>
+> **Verified at execution:** pins 11/11 at `@ci/v2.16.0`; `check-pin-currency.sh
+> --canon ci/v2.16.0` → "all pins current"; drift before/after shows only pin
+> strings, B1–B4, the Step-4 comment edits, and the expected `secret-scan`
+> baseline-move growth, with `pre-commit.yml`'s `concurrency:` region now
+> byte-exact against canon; runners **2.335.1** (≥ the 2.327.1 node24 floor);
+> `APP_REVIEWER_1_BOT_ID` present, i.e. **armed** — which is why #331 and §23.4
+> are no-ops here and why `ai-review.yml`'s FT-43 comment keeps canon's
+> `while unarmed` qualifier.
+>
+> **Author-side review found one real defect, and all three agents found the same
+> one.** The `ai-review.yml` FT-43 comment as first written said "both job `if:`s
+> require `draft == false`" — false. Only the **trust** job's `if:` carries a
+> `draft` term (canon `ai-review.yml:148`); the review job has none and skips
+> transitively via `needs: trust`. The conclusion held, the mechanism did not —
+> the exact defect class B4 exists to delete, nearly re-introduced by the PR that
+> deletes it. Fixed before push.
+>
+> **Cross-repo, two issues on `aidoc-flow-ci`:**
+> [#347](https://github.com/vladm3105/aidoc-flow-ci/issues/347) —
+> `docs/UPDATE_GUIDE.md:88`'s worked example for *this* repo names
+> `runner_labels_routine: '"ubuntu-latest"'`, false since PLAN-013.
+> [#348](https://github.com/vladm3105/aidoc-flow-ci/issues/348) — the #329
+> allowlist comment cites a label write in six templates whose `pull_request:` is
+> untyped and which therefore never receive one. **This repo deliberately keeps
+> canon's wrong wording** in `pre-commit.yml`: correcting it would forfeit the
+> byte-exactness verification #3 turns on and earn a permanent drift warning for
+> being right. `conformance.yml` / `acceptance.yml` are locally owned, so they got
+> the trim.
+
+---
+
 > **✅ SESSION 2026-07-27 — #365 CLOSED: the acceptance tier is green, pinned,
-> and a required check. Tracker empty — 0 open issues.**
+> and a required check. ~~Tracker empty — 0 open issues.~~ *(Superseded
+> 2026-07-29: the tracker holds
+> [#373](https://github.com/vladm3105/aidoc-flow-framework/issues/373),
+> `CODEQL-FLOATING-ACTION-PIN`, filed by CI-CANON-V2.16-001's own PR 0. It was
+> empty when this banner was written.)***
 >
 > `plans/ACCEPTANCE-TIER-DRIFT-UNTRACKED-PLAN.md` executed. Tier goes **3
 > failures / 63 → 0 failures / 64**, and `.github/workflows/acceptance.yml` runs

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -54,6 +54,28 @@
 > are no-ops here and why `ai-review.yml`'s FT-43 comment keeps canon's
 > `while unarmed` qualifier.
 >
+> **B2's blast radius is far smaller than the plan claimed — measured on PR #375
+> itself, and the correction is in D-0070.** The plan said *every* label write
+> would now start an `audit-trail` run whose `verify` job skips. It does not: all
+> four label writes on #375 were `github-actions[bot]` (`GITHUB_TOKEN`), and a
+> `GITHUB_TOKEN` event creates no workflow run (bar `workflow_dispatch` /
+> `repository_dispatch`, irrelevant to a label). **No `audit-trail` run on that
+> branch was label-triggered** — all came from `pull_request`. Say provenance,
+> not a count; the count moves with the next push. Only a **human** (or App-token)
+> label write reaches the new trigger. Two follow-ons: the skipped⇒success
+> assumption B2 rests on is **still unexercised** — the plan's verification #8
+> smoke test is the only way to settle it, and the label must be applied **by
+> hand**; and the support previously offered for it (`call / ai-review`
+> job-skipping on `ai:review-*` writes) is **not evidence**, because no run is
+> ever created. The retracted sentences are annotated in place in the plan's §B2.
+>
+> **CI-0025 is confirmed fixed, but read the right run for it.** Under the defect
+> the `pull_request_review` run was the *canceller*, not the victim — it killed
+> the `pull_request_target` run that had just posted the review. So the evidence
+> is that #375's **first** run (17:45:57, `pull_request_target`) concluded
+> `success` rather than `cancelled`; the second run would have survived either
+> way (ci#322).
+>
 > **Author-side review found one real defect, and all three agents found the same
 > one.** The `ai-review.yml` FT-43 comment as first written said "both job `if:`s
 > require `draft == false`" — false. Only the **trust** job's `if:` carries a


### PR DESCRIPTION
Implements [`plans/CI-CANON-V2.16-MIGRATION-PLAN.md`](https://github.com/vladm3105/aidoc-flow-framework/blob/main/plans/CI-CANON-V2.16-MIGRATION-PLAN.md) — **PR 1 of 3** (plan PR merged as #374; PR 2 propagates `CLAUDE.md` and moves the plan to `Completed`).

**No `VERSION` stream moves.** `.github/` + four documents of record only. Not a GATE-SPEC change.

## What this does

The eleven `aidoc-flow-ci` call sites sat at **two tags** since 2026-07-27 — six at `ci/v2.15.0`, five at `ci/v2.14.0` — because #369 bumped one caller by hand and the Dependabot group PR #370 carried five reusables and left four behind. All eleven now sit at `ci/v2.16.0`.

The pin bump is the smaller half. Dependabot rewrites `uses:` lines and nothing else, so it can never deliver a caller-**body** change and never notices that a comment it falsified is now misdirecting the next reader. Both failure modes were live here.

### The four body changes

| | File | Change |
|---|---|---|
| **B1** | `pre-commit.yml` | `cancel-in-progress: true` → canon's #329 allowlist |
| **B2** | `audit-trail.yml` | `types:` gains `labeled, unlabeled` |
| **B3** | `conformance.yml` | same allowlist |
| **B4** | `acceptance.yml` | same allowlist + rewrite of a comment arguing the cancellation was safe |

B1/B3/B4 all feed **required contexts** under an untyped `pull_request` trigger, so a `reopened` fires at the current head SHA and can cancel a required check — and a cancelled required check is not success: it is retained alongside any later success from a separate run, leaving the PR `--admin`-only. The behavioral delta is `reopened` alone; `push`, `opened` and `synchronize` still cancel as before.

`conformance.yml` and `acceptance.yml` call no canon reusable, so no pin moves in them. They are in scope because **the #329 rule is scoped by required-context, not by ownership**. `acceptance.yml` additionally carried a comment reasoning that cancellation was safe because `push` and `pull_request` resolve to different `github.ref` values — true, and irrelevant, since the collision is *within* `pull_request`. It was written while the workflow was still non-required; 2026-07-27 made it the sixth required context.

**B2 is necessary, not sufficient — the PR does not claim more.** Without a `labeled` trigger, applying `skip-audit-trail` fires no event at all, so the documented two-signal escape hatch on the required `call / verify` context was unreachable (this repo already hit that — `plans/DECISIONS.md` D-0065). B2 makes the hatch *fire*; the override still needs its commit-body marker, and a label event still starts a separate run.

### Prose the bump falsified

`docs-sync.yml`'s "STILL NOT RAISED" verdict (CI-0015 raised the callee to `pull-requests: write` at `ci/v2.15.0`, so the dry-run comment can now post — the mechanism paragraph is kept, the verdict and the "track upstream" instruction are discharged); `ai-review.yml`'s FT-43 note; `auto-merge-ai-prs.yml`'s claim that the enforcer re-arms `--merge` (it has always run `--squash`); two `@ci/v2.14.0` header tags; and `.github/ai-review/config.json`'s `$schema`, which no canon tool would ever bump.

## Verification

| # | Check | Result |
|---|---|---|
| 1 | 11 `uses:` sites | all `@ci/v2.16.0` |
| 2 | `check-pin-currency.sh --canon ci/v2.16.0` | `all pins current ✅` |
| 3 | `check-drift.sh` before/after diff | **10** `::warning::drift-check:` both runs. Diff shows only pin strings, B1–B4, the Step-4 comment edits, and the expected `secret-scan` baseline-move growth (its template gained the +13/−3 allowlist at v2.16.0 and this repo deliberately adds no block there). `pre-commit.yml`'s `concurrency:` region is now **byte-exact** against canon |
| 4 | `pre-commit run --all-files` | green |
| 5 | Runner versions | `2.335.1` × 2 — above the node24 floor of 2.327.1 |
| 6 | `APP_REVIEWER_1_BOT_ID` | present → **armed**, which is why #331 and §23.4 are no-ops here |
| 7 | This PR's own required checks | the real integration test — all six execute their changed form here |

## Governance

**Founder merge required** — this touches `.github/workflows/ai-review.yml`, named in `CLAUDE.md` as both a governance-PR surface and an explicit exception to the AI auto-merge default. Not auto-merged.

**Rule 1 — four doc surfaces, with founder OK.** `plans/DECISIONS.md` + `plans/HANDOFF.md` + `CHANGELOG.md` = three, **plus the plan file**, whose `Status` must move `Draft → In Progress` in the same change as the state change. Granted 2026-07-29 and re-confirmed at execution; the commit message carries the audit-trail line naming the fourth surface, per the plan's §Governance resolution.

**Rule 2 — adversarial self-review, one fold cycle (OPS-0067).** Three `code-reviewer` agents in parallel: workflow-YAML correctness, dead-refs/consistency, scope/governance. **All three independently found the same load-bearing defect** — my first draft of the `ai-review.yml` FT-43 comment claimed "both job `if:`s require `draft == false`". Only the **trust** job's does (canon `ai-review.yml:148`); the review job has no `draft` term and skips *transitively* via `needs: trust`. The conclusion held; the mechanism did not. That is precisely the defect class B4 exists to delete — nearly re-introduced by the PR that deletes it. Fixed before push, along with two smaller finds (the audit-trail no-`concurrency:` note moved to the level a sweep actually greps; the retained 2026-07-27 handoff banner's "tracker empty" claim annotated as superseded by #373).

## Deliberately out of scope

`install.sh --update` body adoption (it would clobber every local customization — see D-0070); graduating `docs-sync` out of dry-run (now *possible*, not *due*); SHA-pinning `codeql.yml`'s floating `github/codeql-action@v4` (→ #373); adopting `markdown-lint`; adding `concurrency:` blocks to callers that have none; and the #329 allowlist on the five locally-owned workflows that carry the shape but feed **no** required context. **That last exemption is a snapshot, not a property** — `acceptance` was exempt by exactly that reasoning until it became required. D-0070 records the standing rule: any change that makes one of those seven a required context must take the allowlist in the same PR.

## Cross-repo

- [`aidoc-flow-ci#347`](https://github.com/vladm3105/aidoc-flow-ci/issues/347) — `docs/UPDATE_GUIDE.md:88`'s worked example for *this* repo names `runner_labels_routine: '"ubuntu-latest"'`, false since PLAN-013.
- [`aidoc-flow-ci#348`](https://github.com/vladm3105/aidoc-flow-ci/issues/348) — the #329 allowlist comment cites a label write in six templates whose `pull_request:` is untyped and which therefore never receive one. **This repo deliberately keeps canon's wrong wording in `pre-commit.yml`**: correcting it locally would forfeit the byte-exactness verification #3 turns on, and `check-drift.sh` would then warn permanently for being right. `conformance.yml` / `acceptance.yml` are locally owned, so they got the trim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
