### PR TITLE
test: scratch PR for CI-CANON-V2.16 verification #8 — DO NOT MERGE

### DIFF
--- a/tests/.b2-smoke/README.md
+++ b/tests/.b2-smoke/README.md
@@ -7,3 +7,6 @@ triggers can be exercised by hand.
 
 This PR is closed unmerged. If you are reading this on `main`, something
 went wrong.
+
+Second commit: establishes an all-green SHA so the skipped-check test runs
+without a retained failure confusing the rollup.

--- a/tests/.b2-smoke/README.md
+++ b/tests/.b2-smoke/README.md
@@ -1,0 +1,9 @@
+# B2 smoke-test scaffold — DELETE, never merge
+
+Throwaway artifact for verification #8 of
+`plans/CI-CANON-V2.16-MIGRATION-PLAN.md`. Its only purpose is to give a
+scratch PR a diff so the `audit-trail` caller's new `labeled` / `unlabeled`
+triggers can be exercised by hand.
+
+This PR is closed unmerged. If you are reading this on `main`, something
+went wrong.


### PR DESCRIPTION
**Throwaway. Do not merge. Will be closed unmerged.**

Runs verification #8 of [`plans/CI-CANON-V2.16-MIGRATION-PLAN.md`](https://github.com/vladm3105/aidoc-flow-framework/blob/main/plans/CI-CANON-V2.16-MIGRATION-PLAN.md), which #375 shipped but could not exercise.

**Why it is needed.** B2 gave `.github/workflows/audit-trail.yml` the `labeled, unlabeled` triggers. On #375 that trigger never fired: every label write there was made by `github-actions[bot]` (`GITHUB_TOKEN`), and a `GITHUB_TOKEN` event creates no workflow run. So the assumption B2 rests on — **a job skipped by `if:` reports success to branch protection on a required context** — is still unexercised, and `call / verify` is a required context. This PR applies labels **by hand** so the trigger actually fires.

**What is being measured, in order:**

1. **Baseline.** The commit body carries the `[skip-audit-trail]` marker but *not* the OPS-0069 phrase. The two-signal override needs both, so `call / verify` must **fail**.
2. **The hatch (B2's actual fix).** Hand-apply `skip-audit-trail`. Before B2 this fired no event at all. It should now start an `audit-trail` run whose `verify` job **runs** (canon re-runs for that label specifically), finds both signals, and passes.
3. **Failure-then-pass at one SHA.** Does the PR become mergeable, given a `failure` check-run and a later `success` on the same head? This is the retained-alongside vs latest-run-wins question ([`aidoc-flow-ci#330`](https://github.com/vladm3105/aidoc-flow-ci/issues/330)).
4. **Skipped ⇒ success.** Apply an unrelated label. Canon deliberately re-runs for `skip-audit-trail` only, so `verify` should be **skipped** — adding a skipped check-run for a required context. Does the PR stay mergeable?

Findings go to `plans/DECISIONS.md` D-0070 and the plan's verification table.
