### PR TITLE
docs: propagate the ci/v2.16.0 position and close CI-CANON-V2.16-001

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,10 +389,37 @@ future company projects; it ships independently semver-tagged
 `ops/iplans/IPLAN-0017_unified-ci-flows.md` +
 `ops/iplans/IPLAN-0017-CHARTER_aidoc-flow-ci.md`.
 
-**Per-repo state (2026-07-25):** **public repo, but NOT purely
+**Per-repo state (2026-07-29):** **public repo, but NOT purely
 GitHub-hosted.** All eleven `aidoc-flow-ci` call sites are pinned
-`@ci/v2.14.0` (CI-CANON-V2-001; plan `plans/CI-CANON-V2-MIGRATION-PLAN.md`,
-PRs #334/#335; decisions `plans/DECISIONS.md` D-0066).
+`@ci/v2.16.0` (CI-CANON-V2.16-001; plan
+`plans/CI-CANON-V2.16-MIGRATION-PLAN.md`, PRs #374/#375; decisions
+`plans/DECISIONS.md` D-0070 — which supersedes D-0066's `@ci/v2.14.0`
+position from CI-CANON-V2-001, PRs #334/#335).
+
+**A canon bump is a migration, not a dependency update — do not leave it to
+Dependabot.** It rewrites `uses:` lines and nothing else, so it can never
+deliver a caller-**body** change and never notices a comment it falsified.
+Both failure modes were live here: the eleven sites had drifted into **two**
+tags because one caller was bumped by hand and a Dependabot group PR carried
+five of the ten distinct reusables, leaving four behind. Use canon's
+`--repin` — `CI_TAG=ci/vX.Y.Z bash install/install.sh <repo> --repin`, which
+rewrites the tag string only; **never `--update`**, which replaces whole caller
+bodies and would clobber this repo's
+self-hosted `runner_labels_*`, `litellm_allow_insecure_http`, `secret-scan`'s
+`config-path: .gitleaks.toml`, `docs-sync`'s `pull-requests: write`, and
+`links`'s two-job split.
+
+**The #329 concurrency allowlist is scoped by required-context, not by
+ownership.** `pre-commit`, `conformance` and `acceptance` all carry it: a
+cancelled required check is not success, and an untyped `pull_request` admits
+`reopened`, which fires at the current head. The last two are locally owned and
+call no reusable. **Seven local workflows still carry
+`cancel-in-progress: true` and are exempt only because they feed no required
+context** (`codeql`, `chg-gate`, `doc-review`, `hermes`, `plugin`, `labeler`,
+`links`) — a snapshot, not a property. `acceptance` was exempt by that same
+reasoning, defended by a comment arguing it was safe, until it became required
+on 2026-07-27. **Any change that makes one of the seven required must take the
+allowlist in the same PR.**
 
 Runner split — deliberate, do not "normalize":
 
@@ -407,16 +434,34 @@ Runner split — deliberate, do not "normalize":
 - **Everything else stays on `ubuntu-latest`**, including the
   fork-code-executing lint callers (`links`, `pre-commit`).
 
-Two operational facts that cost a session when unrecorded:
+Four operational facts that cost a session when unrecorded:
 
 - **`LITELLM_BASE_URL` must be the Docker-bridge address**
   (`http://172.17.0.1:4001/v1`), never loopback — jobs run inside a
   container, where `localhost` is the container. LiteLLM publishes host
   4001 → container 4000, and is a different service from `llm_router`.
 - **`secret-scan` at v2 scans full git history** (`gitleaks git`), not the
-  working tree (`gitleaks dir`, which is what canon's own header comment
-  still claims). Validate locally with `git`, or a clean local run will
-  still fail CI. Suppressions live in `.gitleaks.toml`.
+  working tree (`gitleaks dir`). Validate locally with `git`, or a clean local
+  run will still fail CI. Suppressions live in `.gitleaks.toml`. *(The rider
+  that canon's own header comment "still claims `dir`" was true at
+  `ci/v2.14.0` and is **no longer**. The scope change itself landed at
+  `ci/v2.0.0` (CI-0016); what `ci/v2.16.0` fixed is the header that had gone on
+  describing the old behaviour. Upstream `aidoc-flow-ci#307` is closed.)*
+- **A `GITHUB_TOKEN`-triggered event creates no workflow run** (the documented
+  exceptions are `workflow_dispatch` and `repository_dispatch`), which is why
+  `labeler`'s and `ai-review`'s own label writes start nothing. Only a
+  **human** or App-token label write reaches a `labeled` trigger. Measured on
+  PR #375; do not reason about label-driven CI without it (D-0070).
+- **Check-runs are retained alongside each other with the rollup keeping the
+  worst, and a job skipped by `if:` does not degrade a **required** context that
+  already succeeded at that SHA.** Measured on scratch PR #376, not assumed: a `skipped`
+  `call / verify` alongside an earlier success left the PR `CLEAN`, while a
+  `failure` and a later `success` for that context at one SHA left it `BLOCKED`.
+  **So labelling cannot clear a red required check** — on this repo's branch
+  protection; canon settled the general mechanism in `REPO_STANDARDS` §23.1
+  (`aidoc-flow-ci#330`, closed). ⚠️ **Not tested: a required context whose
+  *only* run at a SHA job-skips.** A workflow that never triggers at all is a
+  different and worse case — it stays pending and blocks forever (D-0065).
 
 ### Local overrides shared — the foundational rule
 

--- a/plans/CI-CANON-V2.16-MIGRATION-PLAN.md
+++ b/plans/CI-CANON-V2.16-MIGRATION-PLAN.md
@@ -4,7 +4,7 @@
 | -------------- | --------------------------------------------------------------------------------- |
 | Task           | CI-CANON-V2.16-001                                                                 |
 | Type           | chore                                                                              |
-| Status         | In Progress — 2026-07-29 (PR 0 merged as #374; PR 1 open; PR 2 pending)             |
+| Status         | Completed — 2026-07-29 (PR 0 #374, PR 1 #375, PR 2 this; verification #8 run on scratch PR #376) |
 | Depends on     | nothing blocking; canon `ci/v2.16.0` is cut (2026-07-27)                            |
 | Feeds          | a single-tag fleet position for this repo's workflow callers; unblocks the next canon bump being mechanical |
 | Version impact | none — no `VERSION` stream moves (CI infrastructure only)                           |
@@ -61,6 +61,14 @@ Three reasons, each independently sufficient:
 - **PR 2 — the propagation.** `CLAUDE.md` §"Unified CI" per-repo-state paragraph,
   **plus this plan's final `Status` → `Completed`**. Split out to respect the
   ≤3-doc-surface governance rule (see §Governance for the per-PR Status table).
+  **As executed it also carried `plans/DECISIONS.md` and `plans/HANDOFF.md`** —
+  verification #8 falsified D-0070's "still unexercised" wording *and* the
+  HANDOFF banner's live status, and the per-PR doc-of-record rule requires the
+  PR that falsifies a doc of record to correct it in the same change. Four
+  surfaces; founder OK granted 2026-07-29, audit-trail line in the commit
+  message. The ≤3 split this bullet originally described did not survive contact
+  with a plan whose own completion falsifies three other documents — worth
+  knowing before planning the next one.
 
 **Out (named, not silently dropped):**
 
@@ -196,9 +204,9 @@ and B2 bricking the gate, so it is stated rather than assumed.
 > that branch was label-triggered — both came from `pull_request`. So it is **not**
 > *every* label write, only a **human** or App-token one; and `call / ai-review`
 > job-skipping on its own `ai:review-*` writes **is not evidence** for
-> skipped⇒success, because no run is created to skip. The assumption remains
-> **unexercised**, which makes verification #8 the only way to settle it — and it
-> must apply the label **by hand**.
+> skipped⇒success, because no run is created to skip. That left verification #8
+> as the only way to settle it — **run on scratch PR #376; see §Step 6, the
+> verification #8 results table.** It had to apply the label **by hand**.
 
 ⚠️ **Add no `concurrency:` block when taking B2** — but not for the reason a first
 draft of this plan gave. Canon's template block is the #329 **allowlist**, not
@@ -342,7 +350,55 @@ queues in the same group, independently of `cancel-in-progress`.
 | 5 | `gh api repos/vladm3105/aidoc-flow-framework/actions/runners --jq '.runners[].version'` | every runner ≥ 2.327.1 — re-measure at execution time; do not trust this plan's snapshot |
 | 6 | `gh variable list -R vladm3105/aidoc-flow-framework` | `APP_REVIEWER_1_BOT_ID` present — this is what "armed" means to the reusable, **not** the presence of the `APP_REVIEWER_1_*` secrets |
 | 7 | The PR's own required checks | all six green. This is the real integration test: `ai-review`, `composition`, `pre-commit`, `audit-trail`, `conformance` and `acceptance` all execute their changed form on this very PR |
-| 8 | B2 smoke (post-merge, optional) | On a scratch PR: (a) apply `skip-audit-trail` → `call / verify` **re-runs**; before B2 it fired on neither add nor remove. (b) apply any *other* label → an `audit-trail` run starts and its `verify` job is **skipped**, and the PR remains mergeable — this is what confirms the skipped⇒success assumption B2 rests on |
+| 8 | B2 smoke (post-merge, ~~optional~~ **RUN — scratch PR #376, closed unmerged**) | On a scratch PR: (a) apply `skip-audit-trail` → `call / verify` **re-runs**; before B2 it fired on neither add nor remove. (b) apply any *other* label → an `audit-trail` run starts and its `verify` job is **skipped**, and the PR remains mergeable — this is what confirms the skipped⇒success assumption B2 rests on. **Results below.** It was reclassified from optional to required once #375 showed the assumption had never been exercised at all |
+
+**Verification #8 — run 2026-07-29 on scratch PR #376 (closed unmerged).** The
+labels were applied **by hand**; a bot label write uses `GITHUB_TOKEN` and
+creates no run, so it would have proved nothing.
+
+| Question | Answer | Evidence |
+| --- | --- | --- |
+| (a) Does the hatch now fire? | **Yes** | Hand-applied `skip-audit-trail` started an `audit-trail` run (18:47:45Z) whose `verify` job **ran** and passed on the two-signal override. Removing the label fired `unlabeled` and re-ran it too. Before B2, neither add nor remove fired anything |
+| (b) Does a `skipped` job degrade a **required** context? | **No** | At the clean SHA `dd2d6046`, hand-applying an unrelated label (`ci`) produced `skipped` check-runs on **two** required contexts — `call / verify` and `call / ai-review` — alongside their earlier successes. `mergeStateStatus` stayed **CLEAN**. (`call / trust` also skipped, but it is **not** a required context, so it evidences nothing here) |
+| (c) Are check-runs retained alongside, with the rollup keeping the worst? | **Yes** | At SHA `c9fcb5eb`, `call / verify` carried **both** a `failure` (18:47:02Z) and a later `success` (18:47:47Z); the PR read **BLOCKED**. It is why B2 cannot green a red check by labelling |
+
+**Read (b) precisely — it proves less than "skipped ⇒ success."** The skipped
+runs landed *alongside earlier successes* for the same contexts. Under (c)'s
+worst-wins rule, `CLEAN` is consistent with both "`skipped` counts as success"
+and "`skipped` is ignored while the earlier success governs." What is proven is
+that **a `skipped` run does not degrade a required context that has already
+succeeded at that SHA** — which is exactly and only what B2 needs, because
+`audit-trail` always has a prior `pull_request` run at any SHA a label event can
+reach. Strictly the narrowed claim wants a prior *success*, not merely a prior
+run; the gap is closed by (c) rather than by the trigger set — if that prior run
+failed or was cancelled the context is already red, and under worst-wins a later
+skip cannot improve it. **The untested case is a required context whose *only*
+run at a SHA job-skips**; nothing here speaks to it.
+
+**Provenance for (c), stated so it can be audited.** Three `call / verify`
+check-runs exist at `c9fcb5eb`, not two: `failure` 18:47:02Z, `success`
+18:47:47Z, and a second `failure` at 18:49:31Z from the `unlabeled` event. The
+`BLOCKED` reading was taken in the window **18:48:21Z–18:49:31Z** — after
+`call / Lint / format / security hooks` completed at 18:48:21Z (so no required
+context was still pending) and before the third run's check-run appeared at
+18:49:31Z (the check-run query taken at the same moment returned exactly two
+`call / verify` entries; the run itself was *created* two seconds earlier, at
+18:49:29Z). In that window every one of the other five required contexts had
+completed successfully, `required_approving_review_count` is 0 and `strict` is
+false — so nothing but `call / verify`'s retained `failure` can explain
+`BLOCKED`, and it is explainable neither by a pending check nor by
+latest-run-wins.
+
+**(c) corroborates canon rather than settling anything.**
+[ci#330](https://github.com/vladm3105/aidoc-flow-ci/issues/330) was **closed
+2026-07-27**, and `ci/v2.16.0` — the tag this plan adopts — already publishes the
+answer at `docs/REPO_STANDARDS.md` §23.1 ("Scope, settled (#330)"): an in-place
+**re-run replaces** a check-run, while a **separate run adds a second alongside**
+and both are retained. #376 reproduced that independently on this repo. Recording
+it as corroboration, not as a resolution.
+
+**Conclusion: B2 is safe as shipped.** The escape hatch is reachable, and the
+extra runs a human label write now starts are benign.
 
 ## Risks
 
@@ -428,7 +484,7 @@ sequence, not one edit, and PR 2 is in scope, so PR 1 cannot legitimately write
 | --- | --- | --- |
 | PR 0 | stays `Draft` (authored, not started) | this plan + `FRAMEWORK-TODO.md` = 2 |
 | PR 1 | `Draft` → **`In Progress`** | `DECISIONS.md` + `HANDOFF.md` + `CHANGELOG.md` + this plan = **4** (founder OK) |
-| PR 2 | `In Progress` → **`Completed`** | `CLAUDE.md` + this plan = 2 |
+| PR 2 | `In Progress` → **`Completed`** | planned: `CLAUDE.md` + this plan = 2. **As executed: 4** — + `DECISIONS.md` (verification #8 falsified D-0070's wording) + `HANDOFF.md` (its live-status banner asserted `In Progress`, "PR 1 open", and "still unexercised", all falsified by this PR). **Founder OK granted 2026-07-29**, audit-trail line in the commit message |
 
 Without PR 2 carrying the final transition the plan ends life stuck at
 `In Progress` — the stale-status defect the governance rule explicitly names. Note
@@ -665,7 +721,10 @@ argument for the second pass.
    copying it would not "introduce cancellation into a required context." The
    action (add no block) survives; the reason was replaced — precisely the class of
    inline reasoning B4 exists to delete from `acceptance.yml`.
-4. **B2 rested on an unstated load-bearing assumption.** After B2, every label
+4. **B2 rested on an unstated load-bearing assumption.** *(This finding's
+   premise was later retracted — a `GITHUB_TOKEN` label write starts nothing;
+   see D-0070 and §B2's corrected block. Kept verbatim as the Pass-N record.)*
+   After B2, every label
    write in the repo starts an `audit-trail` run whose `verify` job is skipped,
    adding a `skipped` check-run to a *required* context; B2 is benign only under
    skipped⇒success. Now stated, cited (`audit-trail-check.yml:84`), and made

--- a/plans/DECISIONS.md
+++ b/plans/DECISIONS.md
@@ -17,6 +17,21 @@ graduation.
 `aidoc-flow-ci` call sites from a mixed `ci/v2.14.0` / `ci/v2.15.0` state to
 `ci/v2.16.0`.
 
+**Supersession scope.** This **supersedes D-0066 in one part only** — its
+`@ci/v2.14.0` pin position (CI-CANON-V2-001, "Target `ci/v2.14.0`", shipped in
+PRs `#334`/`#335`). Everything else in D-0066 is **carried forward unchanged**, in
+particular its second half — *a shared trust config makes a partial fleet
+migration a breaking change* — which is a standing rule about fleet
+coordination, not a statement about any one tag, and its diagnosis of the
+nine-day `ai-review` outage. D-0066 is superseded **in scope**, not retired.
+
+One exception to "unchanged": D-0066's gitleaks bullet observes that "canon's own
+header comment still says `dir`". That was true at `ci/v2.14.0` and is **not** at
+`ci/v2.16.0`, which documents the CI-0016 scope change (upstream `aidoc-flow-ci`
+issue 307, closed 2026-07-26). The bullet's *rule* — a header comment is not the
+contract, so validate against what the job runs — stands; only that one
+observation is spent.
+
 - **Dependabot cannot deliver a caller-body change, so a pin bump is never the
   whole migration.** It rewrites `uses:` lines and nothing else. Two of the four
   changes in this PR live in caller bodies (`pre-commit.yml`'s concurrency
@@ -59,18 +74,35 @@ graduation.
   retained alongside the earlier one with the rollup keeping the worst. So the
   benefit is precisely that the override becomes usable on the next push instead
   of being unreachable — this repo had already hit the unreachable case (D-0065).
-  B2 also rests on an assumption worth stating: a job skipped by `if:` reports
-  success to branch protection. It is the difference between B2 being harmless
-  noise and B2 bricking a required gate. The sharpest case is *failure-then-skip*:
-  `call / verify` is red at SHA X, someone applies an unrelated label, and a fresh
-  run job-skips at that same SHA. Under the retained-alongside/worst-wins model
-  these files assert throughout, the earlier `failure` still governs and the gate
-  holds; if [ci#330](https://github.com/vladm3105/aidoc-flow-ci/issues/330)
-  resolves toward latest-run-wins instead, B2 is where this repo would feel it
-  first.
+  B2 rests on an assumption that is now **measured, not assumed** — scratch PR
+  #376, verification #8, run before this plan was marked Completed. **A job
+  skipped by `if:` does not degrade a required context that already succeeded at
+  that SHA**: `skipped` check-runs for `call / verify` and `call / ai-review`
+  (both required) landed alongside their earlier successes and the PR stayed
+  `CLEAN`. **And check-runs are retained alongside each other with the rollup
+  keeping the worst**: at another SHA, a `failure` and a later `success` for
+  `call / verify` coexisted and the PR read `BLOCKED`. The second result is what
+  makes the first safe rather than merely observed — labelling cannot green a red
+  required check. **B2 is safe as shipped.**
 
-- **B2's blast radius is much narrower than the plan assumed, and the assumption
-  above is still UNEXERCISED — measured on PR #375, this change's own PR.** The
+  **Three precision notes, because this is the kind of table that gets cited
+  later.** (1) `call / trust` also skipped, and an earlier draft counted it as a
+  third required context — **it is not required**; the required set is
+  `Framework + platform conformance`, `call / composition`, `call / Lint /
+  format / security hooks`, `call / ai-review`, `call / verify`, `Acceptance tier
+  (deterministic)`. (2) The measurement does **not** establish the general
+  "skipped ⇒ success" claim, because every skip observed landed beside an
+  existing success; the untested case is a required context whose *only* run at a
+  SHA job-skips. B2 does not need that case — `audit-trail` always has a prior
+  `pull_request` run at any SHA a label event can reach. (3) It **corroborates**
+  rather than settles: [ci#330](https://github.com/vladm3105/aidoc-flow-ci/issues/330)
+  closed 2026-07-27, and `ci/v2.16.0` already publishes the mechanism at
+  `docs/REPO_STANDARDS.md` §23.1 — an in-place re-run *replaces* a check-run, a
+  separate run *adds one alongside*. An earlier draft of this bullet said #330
+  "leaves open"; it did not.
+
+- **B2's blast radius is much narrower than the plan assumed — measured on
+  PR #375, this change's own PR.** The
   plan asserted that after B2 "*every* label write in this repo (`labeler`'s path
   labels, `ai-review`'s own `ai:review-*` writes, the `skip-ai-review`
   label-cycle) starts an `audit-trail` run whose `verify` job is skipped." **It
@@ -90,10 +122,20 @@ graduation.
   Two consequences. First, the earlier empirical support offered for
   skipped⇒success — "`call / ai-review` job-skips on every `ai:review-*` label
   event and PRs still merge" — **is not evidence at all**: no run is created, so
-  nothing job-skips. Do not cite it. Second, the plan's verification #8 (the
-  post-merge scratch-PR smoke test) is now the *only* way to settle the
-  assumption, and it must apply the label **by hand** — a bot-applied label will
-  reproduce nothing.
+  nothing job-skips. Do not cite it. Second, that left verification #8 as the
+  *only* way to settle the assumption — which is why it was reclassified from
+  optional to required and run on scratch PR #376 before this plan was marked
+  Completed. **It must apply the label by hand**; a bot-applied label reproduces
+  nothing, and a smoke test that used one would have "passed" while measuring
+  precisely zero.
+
+- **The general fact worth keeping, independent of this migration: a
+  `GITHUB_TOKEN`-triggered event creates no workflow run.** Documented exceptions
+  are `workflow_dispatch` and `repository_dispatch`. This is why a workflow can
+  subscribe to `labeled` and still appear never to fire — the labels it sees in
+  practice are written by other workflows under `GITHUB_TOKEN`. Reason about
+  label-driven CI here with that in hand, or conclude the trigger is broken when
+  it is working exactly as specified.
 
 - **A byte-exact copy is worth keeping even when the copied comment is wrong —
   file the defect upstream instead.** Canon's `pre-commit.yml` allowlist comment

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -1,19 +1,31 @@
 # Session Handoff
 
-> **🔄 SESSION 2026-07-29 — CI-CANON-V2.16-001 in flight. PR 0 merged (#374);
-> PR 1 open; PR 2 (`CLAUDE.md` + plan → `Completed`) still to come.**
+> **✅ SESSION 2026-07-29 — CI-CANON-V2.16-001 COMPLETE. All eleven canon call
+> sites are at `@ci/v2.16.0`; the tracker holds one open issue (#373).**
 >
-> `plans/CI-CANON-V2.16-MIGRATION-PLAN.md`, Status **In Progress**. PR 1 takes
-> all eleven `aidoc-flow-ci` call sites to `@ci/v2.16.0` and applies the four
-> body changes a re-pin structurally cannot deliver (B1–B4), plus the comments
-> the bump falsifies. Records `plans/DECISIONS.md` **D-0070**.
+> `plans/CI-CANON-V2.16-MIGRATION-PLAN.md`, Status **Completed**. Three PRs, all
+> merged: **#374** (plan), **#375** (the migration — eleven pins plus the four
+> caller-body changes B1–B4 a re-pin structurally cannot deliver, plus the
+> comments the bump falsified), **this one** (`CLAUDE.md` propagation + final
+> Status). Scratch PR **#376** ran verification #8 and was closed unmerged.
+> Records `plans/DECISIONS.md` **D-0070**, which supersedes D-0066 **in scope
+> only** — its `@ci/v2.14.0` pin position, not its shared-trust-config rule.
+> D-0066's gitleaks bullet also has one *observation* spent (canon's header no
+> longer "still says `dir`"); its rule — a header comment is not the contract —
+> stands.
 >
-> **PR 1 carries four doc surfaces against governance Rule 1's ≤3 cap** —
-> `DECISIONS.md` + `HANDOFF.md` + `CHANGELOG.md` + the plan file (whose `Status`
-> must move in the same change as the state change). Founder OK granted
-> 2026-07-29 and **re-confirmed at execution time**; the commit message carries
-> the audit-trail line naming the fourth surface. It is founder-merged regardless
-> — it touches `ai-review.yml`.
+> **Both PRs took a founder-granted 4th doc surface** against governance Rule 1's
+> ≤3 cap — granted 2026-07-29 and **re-confirmed at execution time for each**,
+> each with the audit-trail line in the commit message: PR 1 because the
+> plan's own `Status` had to move with the state change, PR 2 because
+> verification #8 falsified `DECISIONS.md` *and* this file. Both were
+> founder-merged anyway (`ai-review.yml`, then `CLAUDE.md`).
+>
+> **What is genuinely new for the repo, beyond the pins:** PRs here reached
+> `CLEAN` and merged **without `--admin`**, twice — the first time in weeks. The
+> `ai-review` self-cancel (CI-0025 / ci#322) is fixed at this tag: on #375 the
+> `pull_request_target` run concluded `success` rather than being cancelled by
+> the `pull_request_review` run its own review submission fired.
 >
 > **Four things a next session must not re-derive:**
 >
@@ -62,12 +74,29 @@
 > `repository_dispatch`, irrelevant to a label). **No `audit-trail` run on that
 > branch was label-triggered** — all came from `pull_request`. Say provenance,
 > not a count; the count moves with the next push. Only a **human** (or App-token)
-> label write reaches the new trigger. Two follow-ons: the skipped⇒success
-> assumption B2 rests on is **still unexercised** — the plan's verification #8
-> smoke test is the only way to settle it, and the label must be applied **by
-> hand**; and the support previously offered for it (`call / ai-review`
-> job-skipping on `ai:review-*` writes) is **not evidence**, because no run is
-> ever created. The retracted sentences are annotated in place in the plan's §B2.
+> label write reaches the new trigger. The support previously offered for
+> skipped⇒success (`call / ai-review` job-skipping on `ai:review-*` writes) is
+> **not evidence**, because no run is ever created. The retracted sentences are
+> annotated in place in the plan's §B2.
+>
+> **Verification #8 then measured it, on scratch PR #376 — labels applied BY
+> HAND, because a bot label proves nothing.** Three results, tabulated in the
+> plan's §Step 6: (a) the hatch fires — a hand-applied `skip-audit-trail` started
+> an `audit-trail` run whose `verify` job **ran** and passed the two-signal
+> override, where before B2 it fired nothing; (b) a `skipped` run does **not
+> degrade** a required context that already succeeded at that SHA — `skipped`
+> `call / verify` + `call / ai-review` beside their successes left the PR
+> `CLEAN`; (c) check-runs are **retained alongside** with the rollup keeping the
+> worst — a `failure` and a later `success` for `call / verify` at one SHA read
+> `BLOCKED`. **B2 is safe as shipped.**
+>
+> Three things not to overstate when citing that table. `call / trust` is **not**
+> a required context (a draft counted it as one). Result (b) does **not** prove
+> the general "skipped ⇒ success" — every skip observed landed beside an existing
+> success, so a required context whose *only* run job-skips is **untested**; B2
+> does not need that case. And (c) **corroborates** rather than settles:
+> `ci#330` closed 2026-07-27 and `ci/v2.16.0` already publishes the mechanism at
+> `docs/REPO_STANDARDS.md` §23.1.
 >
 > **CI-0025 is confirmed fixed, but read the right run for it.** Under the defect
 > the `pull_request_review` run was the *canceller*, not the victim — it killed


### PR DESCRIPTION
**PR 2 of 3 — the propagation.** Completes [`plans/CI-CANON-V2.16-MIGRATION-PLAN.md`](https://github.com/vladm3105/aidoc-flow-framework/blob/main/plans/CI-CANON-V2.16-MIGRATION-PLAN.md). Plan PR #374, migration PR #375, verification #8 on scratch PR #376 (closed unmerged).

**No `VERSION` stream moves.** Documents only.

## What changes

`CLAUDE.md`'s per-repo state claimed all eleven `aidoc-flow-ci` call sites were pinned `@ci/v2.14.0`. They are at `@ci/v2.16.0`. Beyond the pin, it gains the two rules this migration earned:

- **A canon bump is a migration, not a dependency update.** Dependabot rewrites `uses:` lines and nothing else, so it can never deliver a caller-body change and never notices a comment it falsified. Use `--repin`, never `--update`.
- **The #329 allowlist is scoped by required-context, not by ownership** — with the standing obligation that any change making one of the seven exempt workflows a required context must take the allowlist **in the same PR**. That exemption is a snapshot, not a property: `acceptance` was exempt by exactly that reasoning, complete with a comment arguing it was safe, until 2026-07-27 made it required.

It also retires the rider claiming canon's `secret-scan` header "still says `dir`" — `ci/v2.16.0` documents the CI-0016 scope change and `aidoc-flow-ci#307` is closed.

## Verification #8 was run, not waived

The plan called it "post-merge, optional." PR #375 showed why that was wrong: **no label-triggered `audit-trail` run had ever occurred here**, because `labeler` and `ai-review` write labels with `GITHUB_TOKEN`, which creates no workflow run. So the assumption B2 rests on had never been exercised — on a **required** context. It was reclassified to required and run on scratch PR #376, with labels applied **by hand**.

| Question | Answer | Evidence |
|---|---|---|
| Does the escape hatch now fire? | **Yes** | Hand-applied `skip-audit-trail` started a run whose `verify` job **ran** and passed the two-signal override. Before B2, nothing fired |
| Does a `skipped` job degrade a required context? | **No** | `skipped` `call / verify` + `call / ai-review` beside their successes → PR stayed `CLEAN` |
| Retained alongside, worst-wins? | **Yes** | `failure` + later `success` for `call / verify` at one SHA → `BLOCKED` |

**Stated deliberately narrower than "skipped ⇒ success."** Every skip observed landed beside an existing success, so a required context whose *only* run job-skips is **untested** — B2 does not need that case. And it **corroborates** rather than settles: `ci#330` closed 2026-07-27, and `ci/v2.16.0` already publishes the mechanism at `docs/REPO_STANDARDS.md` §23.1.

## Governance

**Founder merge required** (touches `CLAUDE.md`). **Four doc surfaces with founder OK granted 2026-07-29**, audit-trail line in the commit message: `CLAUDE.md`, the plan, `plans/DECISIONS.md` (verification #8 falsified D-0070's "still unexercised" wording), `plans/HANDOFF.md` (its banner asserted `In Progress`, "PR 1 open" and "still unexercised" — all falsified here). The per-PR doc-of-record rule and the plan-status rule both require those to move in this change rather than a follow-up.

**Rule 2 — two fold cycles, five reviewer dispatches.** Cycle 1 found four defects, all folded: `call / trust` counted as a required context when it is not; `ci#330` described as open when it had closed and canon already published the answer; an omitted third check-run and an unrecorded observation window in the evidence for result (c); and a claim stronger than the measurement supports. Cycle 2 found one — "everything else in D-0066 carried forward unchanged" was over-claimed and falsified by this PR's own gitleaks correction — plus two precision items. **One finding was rejected on verification**: "five of ten distinct reusables" is correct, not "nine".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
