### PR TITLE
docs: retract the pin-currency misdiagnosis and record CANON-PARITY-001 (D-0071)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,11 +390,28 @@ future company projects; it ships independently semver-tagged
 `ops/iplans/IPLAN-0017-CHARTER_aidoc-flow-ci.md`.
 
 **Per-repo state (2026-07-29):** **public repo, but NOT purely
-GitHub-hosted.** All eleven `aidoc-flow-ci` call sites are pinned
-`@ci/v2.16.0` (CI-CANON-V2.16-001; plan
-`plans/CI-CANON-V2.16-MIGRATION-PLAN.md`, PRs #374/#375; decisions
-`plans/DECISIONS.md` D-0070 — which supersedes D-0066's `@ci/v2.14.0`
-position from CI-CANON-V2-001, PRs #334/#335).
+GitHub-hosted.** All **sixteen** `aidoc-flow-ci` call sites across fifteen
+files are pinned `@ci/v2.16.0` (was eleven across ten until
+CANON-PARITY-001 adopted five more; `links.yml` holds two). Pins:
+CI-CANON-V2.16-001, plan `plans/CI-CANON-V2.16-MIGRATION-PLAN.md`,
+PRs #374/#375, `plans/DECISIONS.md` D-0070 — which supersedes D-0066's
+`@ci/v2.14.0` position from CI-CANON-V2-001, PRs #334/#335.
+
+**Re-pinning and adopting are different dimensions, and only the first was
+ever automated.** A `--repin` rewrites `uses:` strings; it cannot adopt a
+canon surface this repo does not call, so an absent surface stays absent
+through any number of green bumps. CANON-PARITY-001 (PR #378, D-0071)
+closed that gap: `codeql` became a canon caller — which is what actually
+closed [#373](https://github.com/vladm3105/aidoc-flow-framework/issues/373),
+since canon's reusable already SHA-pins the actions — and `dep-scan`,
+`sast-scan`, `trivy-scan`, `markdown-lint` were adopted. Scaffold new
+surfaces with canon's `install/deploy-ci-wizard.sh scaffold <repo> <dir>
+[wf…]`: it writes byte-exact callers at the pin into a scratch dir and
+never commits, so it cannot clobber a customized caller the way `--update`
+would. **The manifest's presence check is case-sensitive** — it lists
+`.github/pull_request_template.md`, and this repo's equally-valid
+`.github/PULL_REQUEST_TEMPLATE.md` reads as absent; do not conclude a
+surface is missing from that alone.
 
 **A canon bump is a migration, not a dependency update — do not leave it to
 Dependabot.** It rewrites `uses:` lines and nothing else, so it can never
@@ -421,6 +438,15 @@ reasoning, defended by a comment arguing it was safe, until it became required
 on 2026-07-27. **Any change that makes one of the seven required must take the
 allowlist in the same PR.**
 
+The surfaces adopted by CANON-PARITY-001 add two more shapes, so "does it
+cancel?" is now a three-way question, not two: `markdown-lint` already ships
+canon's `#329` allowlist (it is a required context *for other consumers*, and the
+template is uniform), while `dep-scan`, `sast-scan` and `trivy-scan` carry **no
+`concurrency:` block at all** — they never cancel, which is the safest state and
+needs no allowlist. `codeql` keeps plain `cancel-in-progress: true`, which is why
+it stays in the seven above. **Count the exemption by shape, not by filename:**
+absent block ≠ allowlist ≠ bare `true`.
+
 Runner split — deliberate, do not "normalize":
 
 - **`ai-review` runs entirely on the self-hosted single-use pool**
@@ -431,8 +457,23 @@ Runner split — deliberate, do not "normalize":
   are never trusted, so a fork PR reaches only the no-PR-code trust job.
   The caller also sets `litellm_allow_insecure_http: true` — the bridge URL
   is `http://`, and canon's client refuses non-HTTPS without it.
+- **`dep-scan` and `trivy-scan` also run self-hosted** — canon's PLAN-014
+  uniform-protected model, adopted byte-exact. Safe on a public repo because
+  the reusable's own fork guard (`if: …head.repo.fork != true`) skips fork PRs,
+  so untrusted code never reaches the host; the label is canon's trust design,
+  not a tooling requirement (both `curl` a pinned static binary). This means the
+  pool now serves up to five jobs per PR against **two** slots — it
+  self-replenishes (`ci-runner@.service` is `Restart=always`/`RestartSec=5`), so
+  they serialize rather than starve the required `ai-review`.
+- **`sast-scan` is the exception and must stay on `ubuntu-latest`.** semgrep
+  installs into a `python3 -m venv` and the `aidoc-flow-runner` image ships no
+  Python, so on the self-hosted pool it dies at *"ensurepip is not available"*
+  before any findings logic — and `fail-on-findings: false` gates the verdict,
+  not the install, so report-only does not keep it green. Filed as
+  [aidoc-flow-ci#349](https://github.com/vladm3105/aidoc-flow-ci/issues/349);
+  revert the override only once that lands.
 - **Everything else stays on `ubuntu-latest`**, including the
-  fork-code-executing lint callers (`links`, `pre-commit`).
+  fork-code-executing lint callers (`links`, `pre-commit`) and `codeql`.
 
 Four operational facts that cost a session when unrecorded:
 

--- a/plans/DECISIONS.md
+++ b/plans/DECISIONS.md
@@ -10,6 +10,96 @@ graduation.
 
 ---
 
+## D-0071 — Adoption is a separate dimension from pinning; and an asserted absence is the cheapest defect to file and the hardest to verify
+
+**2026-07-29.** Decisions from CANON-PARITY-001 (PR `#378`), which adopted the
+four `aidoc-flow-ci` surfaces this repo had never called and converted `codeql`
+from a hand-rolled workflow into a canon caller. **Extends D-0070; supersedes
+nothing.** D-0070's rule — *a canon bump is a migration, not a dependency
+update* — is about caller **bodies**; this one is about caller **existence**.
+
+**1. A green pin audit says nothing about adoption.** `check-pin-currency.sh`
+and `check-drift.sh` both iterate over callers **that exist**. An absent surface
+is invisible to both, so this repo could report "all pins current ✅" while
+calling ten of canon's surfaces and ignoring four. The census that finds them is
+canon's `install/templates/manifest.json`, walked against the working tree.
+**Corollary:** run that walk when the canon minor moves, not just the re-pin.
+
+**2. `#373` was a symptom, and fixing it directly would have been the wrong
+repair.** The issue asked to SHA-pin `github/codeql-action` off the floating
+`@v4`. Editing the local workflow's `uses:` lines would have closed it and left
+the actual defect — a hand-rolled workflow where canon ships a reusable —
+in place, to drift again at the next action release. Adopting the caller fixed
+it upstream-of-the-symptom: canon already pins `e4fba868` (v4.37.3). **Before
+fixing a defect in a hand-rolled surface, check whether canon owns that surface.**
+
+**3. Byte-exactness is the default; each divergence pays for itself in a
+comment.** Three of five adoptions landed byte-exact (`dep-scan`,
+`sast-scan` modulo one label, `trivy-scan`), adding zero drift. Two diverge and
+say why in-file, per `check-drift.sh`'s own "intentional divergence" resolution:
+`codeql` (the `languages` input — which is *why* canon marks it
+`safe_to_replace: false`) and `markdown-lint` (globs + a permanent
+`fail-on-findings: false`).
+
+**4. `fail-on-findings: false` on `markdown-lint` is a design position, not a
+debt rollout.** The blocking markdown gate here is the `markdownlint-cli`
+pre-commit hook, running in CI under the required `Lint / format / security
+hooks` context. Canon's caller runs `markdownlint-cli2` — a different engine at
+a different rev — over the same files. Two engines may disagree on rule
+defaults; the advisory one must never be able to block a merge. So it stays
+`false` permanently, and the graduation path canon's header recommends does not
+apply.
+
+**5. Scope a lint adopted into an existing corpus by measurement, and check
+whether a "fix" is even permitted.** Canon's bare `**/*.md` reports **260 issues
+in 78 files** here — all under `legacy/`, `framework/`,
+`platforms/claude-code-plugin/framework/`, Hermes vendored content, and `.aidoc`
+cascade output. Those are not merely unwanted: `framework/` is GATE-SPEC-governed
+so a style edit **trips the gate**, and the vendored plugin copy is a generated
+byte-identical mirror (D-0022) whose drift guard a fix **breaks**. Scoped to the
+exclusion set `.pre-commit-config.yaml` had already justified: **447 files, 0
+issues**. An advisory check that points at 260 unfixable findings trains readers
+to ignore it.
+
+**6. `report-only` protects the verdict, not the toolchain — and shipping it is
+how you learn that.** `sast-scan` went red on first run with
+`fail-on-findings: false` set: semgrep installs into a `python3 -m venv` and the
+`aidoc-flow-runner` image ships no Python, so it died at *"ensurepip is not
+available"* before any findings logic. The check name (`sast-scan FAILURE`) named
+the wrong cause — it reads as "semgrep found something". Overridden to
+`ubuntu-latest` locally, filed upstream as
+[aidoc-flow-ci#349](https://github.com/vladm3105/aidoc-flow-ci/issues/349).
+`dep-scan` and `trivy-scan` share the pool and pass, because they `curl` static
+binaries. **A report-only flag is not evidence a new caller cannot fail.**
+
+**7. An asserted absence needs a log, not an inference — this one cost a wrong
+entry in two documents.** `NO-PIN-CURRENCY-CHECK` claimed "this repo runs
+`check-pin-currency.sh` nowhere," reasoned from the symptom that a mixed-pin
+state survived two days. It was false: canon's `check-standards-drift.sh` tail
+(`:499-515`) invokes it on every weekly `standards-drift` run, and it fired on
+2026-07-27 naming all ten stale pins **and** the `--repin` remedy. One
+`gh run view --log | grep pin-currency` falsified it. The real defect is that a
+warning-only annotation on a weekly scheduled job has **no reader** — a
+different fix, since adding the proposed periodic job would have duplicated a
+check that was already running and already correct. Restated in
+`plans/FRAMEWORK-TODO.md` as `PIN-CURRENCY-NO-READER`. **Verify an absence
+against a run log or a grep before writing it down; a wrong cause, once
+recorded, is re-read as fact by every later session** — the same failure mode
+D-0066 recorded for the nine-day `ai-review` outage.
+
+**8. A manifest presence check is case-sensitive, and `--jq` on a 404 lies.**
+Two false readings inside one session. The manifest lists
+`.github/pull_request_template.md`; this repo carries the equally-valid
+`.github/PULL_REQUEST_TEMPLATE.md`, which reads as absent on a case-sensitive
+filesystem — caught only because `pre-commit`'s case-conflict hook rejected the
+duplicate. And `gh api …/contents/<missing> --jq '.name'` emits the string
+`null`, which a `[ -n "$n" ]` test reads as **present**: that turned "no sibling
+repo adopts `sast-scan`" into "all seven do" until re-checked by listing the
+directory. **Test for a path's existence on disk, and never truth-test a jq
+scalar that can be `null`.**
+
+---
+
 ## D-0070 — A re-pin is not a migration; and an exemption from a required-context rule is a snapshot, not a property
 
 **2026-07-29.** Decisions from executing CI-CANON-V2.16-001

--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -57,36 +57,57 @@
   fix shape). Fails (c): `codeql.yml` feeds no required context, so it degrades
   the Security tab rather than blocking merges.
 
-### `[ci]` `NO-PIN-CURRENCY-CHECK` — nothing in this repo's CI or hooks runs `check-pin-currency.sh`, which is why a mixed-pin state accumulated unnoticed
+### `[ci]` ~~`NO-PIN-CURRENCY-CHECK`~~ → `PIN-CURRENCY-NO-READER` — the check runs and warned correctly; nothing reads warning-only annotations on a weekly scheduled job
 
-- *Context:* surfaced by `CI-CANON-V2.16-MIGRATION-PLAN.md` (2026-07-29). The
-  eleven canon call sites had drifted into **two** tags — six at `ci/v2.15.0`,
-  five at `ci/v2.14.0` — and stayed that way from 2026-07-27 until a human
-  looked. `check-drift.sh` structurally cannot catch it: it frames each caller
-  against the template *at the tag that caller declares*, so a stale pin is
-  self-consistent and silent (`aidoc-flow-ci/sync/check-pin-currency.sh:4`).
-  `check-pin-currency.sh` is the check that would have caught it, and this repo
-  runs it nowhere.
-- *Fix shape:* a periodic warning-only job (or a pre-commit hook) invoking
-  `aidoc-flow-ci/sync/check-pin-currency.sh --canon <tag>`. Warning-only is not a
-  softening — the script exits 0 by design (`:10`, `WARNING-ONLY, NEVER BLOCKS`),
-  so its output must be read, which is an argument for a scheduled job that
-  reports rather than a hook that scrolls past. Open question the fix must answer:
-  where the canon tag comes from, since hardcoding it recreates the same staleness
-  one level up.
-- *Tracker:* **TODO-only** — but on the rule's *speculative* carve-out, **not**
-  on the three-test bar, because test (a) is honestly met: the fix shape is
-  mechanical, names its own invocation, and has two copyable precedents in this
-  repo (`standards-drift.yml` as a scheduled canon caller,
-  `scripts/check-docs-updated.sh` as the blessed warning-only-hook pattern), so
-  any contributor could land it. Tests (b) and (c) do fail — the defect is an
-  *absence*, with no `file:line` in this repo where it lives, and no consumer is
-  affected. What keeps it off the tracker is that it proposes tooling that does
-  not exist and leaves a real design question open (where the canon tag comes
-  from). Promote when someone picks the work up, or as soon as that question has
-  an answer — **not** on "if it recurs": the detection gap is already established
-  as structural, and the migration plan resolves the mixed-pin *symptom* without
-  adding the check.
+**RETRACTED AND RESTATED 2026-07-29 (CANON-PARITY-001).** The original entry
+claimed this repo "runs `check-pin-currency.sh` nowhere." **That was false, and it
+was measured false, not argued false.** It runs on every weekly
+`standards-drift.yml` run: canon's reusable fetches
+`sync/check-standards-drift.sh`, whose tail (`:499-515` at `ci/v2.16.0`)
+invokes `check-pin-currency.sh` in-repo. It fired during the exact window the
+entry described — run
+[30257877863](https://github.com/vladm3105/aidoc-flow-framework/actions/runs/30257877863),
+2026-07-27T10:23:42Z:
+
+```
+pin-currency: auditing ./.github/workflows against canon ci/v2.15.0
+##[warning]pin-currency: ai-review.yml pinned @ci/v2.14.0 (canon ci/v2.15.0) — re-pin
+… ten such lines …
+pin-currency: 10 stale pin(s) — run 'install/install.sh <this-repo> --repin' (warning-only)
+```
+
+It named every stale caller *and* the remedy command, two days before a human
+noticed. So the detection was never absent and the proposed fix — "add a periodic
+job invoking `check-pin-currency.sh`" — would have added a **second** copy of a
+check that was already running and already right.
+
+- *Context (restated):* the real defect is that the signal has **no reader**.
+  `standards-drift.yml` is `schedule:`-only (weekly, Mon 09:00 UTC) plus
+  `workflow_dispatch`; the script is warning-only by design
+  (`check-pin-currency.sh:10`, `WARNING-ONLY, NEVER BLOCKS`) and its output is a
+  `::warning::` annotation inside a scheduled run that notifies nobody and blocks
+  nothing. The same run also reported `8 drift, 4 fetch/scope error(s)` unread.
+- *Fix shape:* give the existing output a destination rather than adding a
+  detector. Cheapest credible option: a small local workflow that runs the
+  script and **opens or updates a single tracking issue** when pins are stale, so
+  the state is visible where work is queued. Rejected alternatives, with reasons
+  — `strict: true` on the weekly run turns the job red permanently (8 drift +
+  4 uncheckable controls are expected here, so it would signal nothing); a
+  pre-commit hook needs a network fetch of canon's `VERSION` at commit time and
+  scrolls past anyway.
+- *Upstream angle:* canon has no adopter-facing template for this, so the
+  broadly-useful version is a feature request on `aidoc-flow-ci` (a reader for
+  warning-only drift/pin output), and the local workflow is the
+  "add a custom workflow" override mode until then.
+- *Tracker:* **TODO-only.** Test (a) is met — the fix shape is mechanical with a
+  copyable precedent (`standards-drift.yml` as a scheduled canon caller). Tests
+  (b) and (c) still fail: no `file:line` in this repo holds the defect, and no
+  consumer is affected. Promote when someone picks it up.
+- *Lesson worth more than the fix:* the original entry was written from the
+  symptom (a mixed-pin state survived two days) and inferred the cause (no check
+  exists) without reading a run log. One `gh run view --log | grep pin-currency`
+  falsified it. **An absence is the easiest defect to assert and the hardest to
+  verify — check the log before filing one.**
 
 ### `[harness]` `ACCEPTANCE-FIXTURE-WARNING-DEBT` — 13 distinct advisory findings pinned across the acceptance fixtures (30 manifest warnings / 27 entries)
 

--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -24,7 +24,26 @@
 
 ## Open
 
-### `[ci]` `CODEQL-FLOATING-ACTION-PIN` — `codeql.yml` resolves `github/codeql-action` through the floating `@v4` major → [#373](https://github.com/vladm3105/aidoc-flow-framework/issues/373)
+### `[ci]` `CODEQL-FLOATING-ACTION-PIN` — ✅ CLOSED (2026-07-29, CANON-PARITY-001 / PR #378) — `codeql.yml` resolved `github/codeql-action` through the floating `@v4` major → [#373](https://github.com/vladm3105/aidoc-flow-framework/issues/373)
+
+**Closed by adoption, not by the fix shape below.** `codeql.yml` became a canon
+caller (`@ci/v2.16.0`), and canon's reusable already SHA-pins both steps to one
+peeled commit (`github/codeql-action@e4fba868…` / v4.37.3) plus
+`actions/checkout@3d3c42e5…` / v7.0.1. So the floating references are gone
+*because this repo stopped owning the workflow*, and the "pin both steps to
+canon's SHA" plan below was never executed — it would have fixed the symptom and
+left a hand-rolled workflow to drift again at the next action release.
+
+**The caveat below still stands and was NOT widened:** `actions/checkout@v7` /
+`setup-python@v7` still float in the six remaining locally-owned workflows
+(`conformance`, `acceptance`, `chg-gate`, `doc-review`, `hermes`, `plugin`).
+Whether that convention should change is still the different, unasked question.
+`codeql` simply left that set.
+
+**Generalisable, recorded as D-0071 §2:** before fixing a defect in a
+hand-rolled surface, check whether canon owns that surface. The entry below
+correctly observed that neither canon check could see the defect — true, and the
+reason was that the surface was not a canon caller at all.
 
 - *Context:* surfaced while scoping `CI-CANON-V2.16-MIGRATION-PLAN.md`
   (2026-07-29) and named there as explicitly out of scope. `codeql.yml:30,36`


### PR DESCRIPTION
## Summary

Corrections and the decision record for CANON-PARITY-001 (#378, merged). One of these
is a **retraction of a wrong cause I wrote**, which is the part worth reading.

## Files touched (OPS-0061 Rule 1 self-check)

| Surface | Change |
| --- | --- |
| `plans/FRAMEWORK-TODO.md` | `NO-PIN-CURRENCY-CHECK` retracted → restated as `PIN-CURRENCY-NO-READER` |
| `CLAUDE.md` | three claims #378 falsified |
| `plans/DECISIONS.md` | D-0071 |

**Governance tier:** 🟡 governance — touches `CLAUDE.md` + `plans/`. **At Rule 1's ≤3
cap, not over it.** The `plans/HANDOFF.md` refresh and the `PULL_REQUEST_TEMPLATE.md`
reconciliation are held for a follow-up PR rather than taken as a 4th surface with a
carve-out. Per the auto-merge exceptions this PR is **not** auto-merged — it's yours.

## The retraction

`NO-PIN-CURRENCY-CHECK` asserted that this repo "runs `check-pin-currency.sh`
**nowhere**", and named that absence as the reason a mixed-pin state survived two days.
**It was false.** Canon's `check-standards-drift.sh` tail (`:499-515` at `ci/v2.16.0`)
invokes the script on every weekly `standards-drift` run. It fired inside the exact
window the entry described —
[run 30257877863](https://github.com/vladm3105/aidoc-flow-framework/actions/runs/30257877863),
2026-07-27T10:23:42Z:

```
pin-currency: auditing ./.github/workflows against canon ci/v2.15.0
##[warning]pin-currency: ai-review.yml pinned @ci/v2.14.0 (canon ci/v2.15.0) — re-pin
… ten such lines …
pin-currency: 10 stale pin(s) — run 'install/install.sh <this-repo> --repin' (warning-only)
```

It named every stale caller **and** the remedy, two days before a human noticed. So the
entry's proposed fix — "add a periodic job invoking `check-pin-currency.sh`" — would
have added a **second copy of a check that was already running and already right**.

The real defect is that the signal has **no reader**: `standards-drift.yml` is
`schedule:`-only, the script is warning-only by design, and a `::warning::` in a
scheduled run notifies nobody and blocks nothing. That same run also reported
`8 drift, 4 fetch/scope error(s)` unread. Restated with that framing, plus the
alternatives considered and why they lose (`strict: true` would go permanently red on
the 8 expected drift + 4 uncheckable controls; a pre-commit hook needs a network fetch
at commit time and scrolls past anyway).

**How it happened, recorded so it doesn't repeat:** the entry was written from the
symptom and inferred the cause without reading a run log. One
`gh run view --log | grep pin-currency` falsified it. An absence is the easiest defect
to assert and the hardest to verify.

## CLAUDE.md claims #378 falsified

- **"All eleven call sites"** → **sixteen across fifteen files** (`links.yml` holds two).
- **"Everything else stays on `ubuntu-latest`"** → false. `dep-scan` and `trivy-scan`
  run self-hosted per canon's fork-guarded PLAN-014 model; `sast-scan` is overridden
  *to* `ubuntu-latest` because the runner image has no Python
  ([aidoc-flow-ci#349](https://github.com/vladm3105/aidoc-flow-ci/issues/349)). The
  paragraph now also records that the pool serves up to five jobs against two
  self-replenishing slots.
- **The concurrency exemption was a filename list**; it's now a question of **shape** —
  absent block (the three scan callers) ≠ `#329` allowlist (`markdown-lint`) ≠ bare
  `true` (`codeql`, still in the seven).

Also added: re-pinning and adopting are different dimensions, and `deploy-ci-wizard.sh
scaffold` is the tool for the second — with the warning that the manifest's presence
check is case-sensitive.

## D-0071 — eight decisions

Extends D-0070 (bodies); this is about caller **existence**. Supersedes nothing. The
two that generalise furthest:

- **`report-only` protects the verdict, not the toolchain.** `sast-scan` went red on
  first run *with* `fail-on-findings: false` set, because semgrep's venv install failed
  before any findings logic. A report-only flag is not evidence a new caller cannot fail.
- **Two false readings caught in-session**, both now recorded: the case-sensitive
  manifest path (`PULL_REQUEST_TEMPLATE.md` read as absent — caught only because
  `pre-commit`'s case-conflict hook rejected the duplicate I added), and
  `gh api …/contents/<missing> --jq '.name'` emitting the string `null`, which a
  `[ -n "$n" ]` test reads as *present* — that inverted "no sibling repo adopts
  sast-scan" into "all seven do" until re-checked by listing the directory.

## Test plan

- [x] `pre-commit run --all-files` green, and green again on a second run (idempotent)
- [x] every quoted path/line re-grepped against source: `check-standards-drift.sh:499-515`,
      the runner `Dockerfile` apt layer, `check-pin-currency.sh:10`
- [x] run-log quote copied from the live log, not paraphrased
- [x] markdownlint `#NNN`-at-line-start trap hit and fixed — it had rewritten `#329`
      into an H1, the corruption CLAUDE.md already documents
- [x] supersession scope stated explicitly (extends D-0070, supersedes nothing)

## Cross-references

- Follows #378 (CANON-PARITY-001), which closed #373
- `aidoc-flow-ci#349` — the `sast-scan` runner-image defect
- D-0070 (extended), D-0066 (same failure mode: a wrong cause recorded locally and
  re-read as fact by later sessions)
