### PR TITLE
docs: the governance-PR plan glob matched no real plan — fix it and the stale state around it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — the governance-PR plan glob matched no real plan (2026-07-30)
+
+**No version moves** — `CLAUDE.md` only.
+
+- The governance-PR definition wrote the plan glob as a **prefix**,
+  `plans/PLAN-*.md`, against a repo where every plan is `<NAME>-PLAN.md`. It matched
+  exactly one file, `PLAN-TEMPLATE.md`. Since the auto-merge exception list is defined
+  by reference to that definition, the rule meant to keep plan PRs out of auto-merge
+  covered no plan. Now `plans/*-PLAN.md` plus the `plans/*-DESIGN.md` companions, with
+  both `DECISIONS.md` files named, as a bullet list rather than one prose sentence.
+- The auto-merge exception bullet kept its **own copy** of that list — same broken glob,
+  and no `DECISIONS.md` at all. The copy is deleted rather than corrected: a second
+  enumeration is how the two drifted. (The third copy, in
+  `.github/PULL_REQUEST_TEMPLATE.md`, is fixed in #390.)
+- Current-state line: Hermes `0.11.1` → `0.12.0` (the sync gap behind it is #389), and
+  [#342](https://github.com/vladm3105/aidoc-flow-framework/issues/342) /
+  [#351](https://github.com/vladm3105/aidoc-flow-framework/issues/351) were described as
+  open when both closed 2026-07-26/27. The replacement claim is scoped to what the
+  `#342` guard actually verifies, because it does not verify as much as its name
+  implies — [#385](https://github.com/vladm3105/aidoc-flow-framework/issues/385).
+
 ### Fixed — `CLAUDE.md`'s platform version tokens now self-heal (2026-07-30)
 
 **No version moves** — `scripts/sync-version-refs.sh` only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ The platforms share the `framework/` spec and nothing else. Both pass the same
 shared conformance suite (`tests/conformance/`). The `framework/` spec defines
 the 8-layer SDD flow (BRD → PRD → EARS → BDD → ADR → SPEC → TDD → IPLAN → Code).
 
-**Current state (as of 2026-07-26):** framework spec `0.40.0`, Claude Code plugin `0.24.0` (pre-1.0 preview, 52 skills = 50 active + 2 deprecated stubs), Hermes `0.11.1`. **YAML-BDD arc complete** (BDD authored as structured `scenarios:` YAML, not Gherkin-in-markdown) and the **CONSUMER-FEEDBACK P1 wave shipped**: element-level COV01/COV02 coverage (D-0039 — `REALIZING_LAYERS` map; catches orphaned requirement elements), manual-mode provisional IDs + normative SHA-256 algorithm (D-0040 — `id_state`/`PROV01`; element IDs are LLM-generated stable strings, NOT verified content-hashes), and first-class reuse / satisfied-by-reference (D-0041 — `reuse:` frontmatter; `REUSE01`/`REUSE02`). **PROVISIONAL-IDS-002 Phase 1 shipped** (D-0061/D-0062, spec `0.35.0`): the element-ID hash-input contract (normalization transform + BRD §7 extraction boundary) is formalized in `ID_NAMING_STANDARDS.md`, and `python -m sdd_doc_lint.rehash --check` verifies a canonical BRD's §7 FR IDs against it on demand (`IDDRIFT01` — advisory, opt-in, NOT in the default lint). Scoped "verifiable on demand," not "verified"; `rehash --fix` + all-layer extraction + corpus reconciliation are founder-decided Phase 2+. **ELEMENT-ID-LAYER-CONTRACT-001 shipped** (GD-09/D-0067, spec `0.39.0`): that transform had reached only `BRD-TEMPLATE.yaml`, so the re-specified algorithm is now **deleted** from the other four layer templates + three layer READMEs in favour of a cross-reference to `ID_NAMING_STANDARDS.md`; TDD gains the element-ID contract it never had; the inert `placeholder: "0000"` key is removed; `tests/conformance/test_element_id_layer_contract.py` locks all of it over `framework/layers/**` — **spec only**, so the 19 plugin/Hermes authoring surfaces ([#342](https://github.com/vladm3105/aidoc-flow-framework/issues/342)) and the acceptance harness's second hash implementation ([#351](https://github.com/vladm3105/aidoc-flow-framework/issues/351)) remain open. Plugin also ships full 8-layer playbook injection + preemptive saga driver across all 8 autopilots (SAGA-PARITY-001) + per-layer model-recommendation precheck (MODEL-PRECHECK-ROLLOUT) + review-quality calibration + necessary-upstream contract (NECESSARY-UPSTREAM-001) + threshold-resolution gate (TH-RES-001) + per-PR doc-of-record discipline (DOC_GOVERNANCE_CORE.md Principle 8). 8-layer development sequence complete. **Hermes has since advanced substantially** (`0.7.3 → 0.11.1`): the `audit_threshold` raise-only gate (HERMES-ADAPT-ENFORCE-001), `.aidoc/profile.yaml` runtime consumption, and the opt-in bounded review→remediate→re-review **quality loop** (HERMES-REVIEW-LOOP-001 Phase 1, D-0063). **Residual arc: Hermes parity** — remaining plugin-vs-Hermes deltas + quality-loop Phase 2 (cross-invocation resume / G-R1, parallel-review lock fix), tracked in [`plans/HERMES-BACKLOG.md`](plans/HERMES-BACKLOG.md). The example corpus is regenerated wholesale after framework changes (so corpus-remediation findings are deferred to that regen). IPLAN ↔ iplanic integration deferred — see `plans/IPLAN-IPLANIC-DEFERRED.md`.
+**Current state (as of 2026-07-26):** framework spec `0.40.0`, Claude Code plugin `0.24.0` (pre-1.0 preview, 52 skills = 50 active + 2 deprecated stubs), Hermes `0.12.0`. **YAML-BDD arc complete** (BDD authored as structured `scenarios:` YAML, not Gherkin-in-markdown) and the **CONSUMER-FEEDBACK P1 wave shipped**: element-level COV01/COV02 coverage (D-0039 — `REALIZING_LAYERS` map; catches orphaned requirement elements), manual-mode provisional IDs + normative SHA-256 algorithm (D-0040 — `id_state`/`PROV01`; element IDs are LLM-generated stable strings, NOT verified content-hashes), and first-class reuse / satisfied-by-reference (D-0041 — `reuse:` frontmatter; `REUSE01`/`REUSE02`). **PROVISIONAL-IDS-002 Phase 1 shipped** (D-0061/D-0062, spec `0.35.0`): the element-ID hash-input contract (normalization transform + BRD §7 extraction boundary) is formalized in `ID_NAMING_STANDARDS.md`, and `python -m sdd_doc_lint.rehash --check` verifies a canonical BRD's §7 FR IDs against it on demand (`IDDRIFT01` — advisory, opt-in, NOT in the default lint). Scoped "verifiable on demand," not "verified"; `rehash --fix` + all-layer extraction + corpus reconciliation are founder-decided Phase 2+. **ELEMENT-ID-LAYER-CONTRACT-001 shipped** (GD-09/D-0067, spec `0.39.0`): that transform had reached only `BRD-TEMPLATE.yaml`, so the re-specified algorithm is now **deleted** from the other four layer templates + three layer READMEs in favour of a cross-reference to `ID_NAMING_STANDARDS.md`; TDD gains the element-ID contract it never had; the inert `placeholder: "0000"` key is removed; `tests/conformance/test_element_id_layer_contract.py` locks all of it over `framework/layers/**` — **spec only** at the time, leaving the 19 plugin/Hermes authoring surfaces ([#342](https://github.com/vladm3105/aidoc-flow-framework/issues/342)) and the acceptance harness's second hash implementation ([#351](https://github.com/vladm3105/aidoc-flow-framework/issues/351)) open. **Both have since closed** (2026-07-26/27): the element-ID generator shipped as `python -m sdd_doc_lint.rehash --compute` (PR #363, D-0068), and the acceptance harness now delegates to that one implementation (PR #366). The guard that locks the negative property (`tests/conformance/platforms/test_no_inprompt_hashing.py`) scans less than its name implies and one unscanned surface still hashes — [#385](https://github.com/vladm3105/aidoc-flow-framework/issues/385) — so a green run of it is not evidence that no surface hashes. Plugin also ships full 8-layer playbook injection + preemptive saga driver across all 8 autopilots (SAGA-PARITY-001) + per-layer model-recommendation precheck (MODEL-PRECHECK-ROLLOUT) + review-quality calibration + necessary-upstream contract (NECESSARY-UPSTREAM-001) + threshold-resolution gate (TH-RES-001) + per-PR doc-of-record discipline (DOC_GOVERNANCE_CORE.md Principle 8). 8-layer development sequence complete. **Hermes has since advanced substantially** (from `0.7.3`): the `audit_threshold` raise-only gate (HERMES-ADAPT-ENFORCE-001), `.aidoc/profile.yaml` runtime consumption, and the opt-in bounded review→remediate→re-review **quality loop** (HERMES-REVIEW-LOOP-001 Phase 1, D-0063). **Residual arc: Hermes parity** — remaining plugin-vs-Hermes deltas + quality-loop Phase 2 (cross-invocation resume / G-R1, parallel-review lock fix), tracked in [`plans/HERMES-BACKLOG.md`](plans/HERMES-BACKLOG.md). The example corpus is regenerated wholesale after framework changes (so corpus-remediation findings are deferred to that regen). IPLAN ↔ iplanic integration deferred — see `plans/IPLAN-IPLANIC-DEFERRED.md`.
 
 ## Durable conventions
 
@@ -542,12 +542,21 @@ this repo's `.github/workflows/` and accept the drift warning.
 
 ## Governance PR discipline (mandatory)
 
-A **governance PR** is any PR that touches `DECISIONS.md`, plan files
-(`plans/PLAN-*.md` or `ops/iplans/IPLAN-*.md` per this repo's convention),
-`CLAUDE.md`, `.github/ai-review/` or `.github/workflows/ai-review.yml`,
-or supersedes a locked decision. Two rules apply to every governance
-PR — no exceptions without explicit founder OK and an audit-trail
-note in the commit message.
+A **governance PR** is any PR that touches one of these surfaces, or that
+supersedes a locked decision:
+
+- `CLAUDE.md`
+- `plans/DECISIONS.md` and `framework/governance/DECISIONS.md`
+- **`plans/*-PLAN.md`**, plus the `plans/*-DESIGN.md` companions some
+  initiatives carry (e.g. `LAYER-PLAYBOOKS-001-DESIGN.md` beside its
+  `-PLAN.md`). The plan glob is a **suffix**: every plan here is
+  `<NAME>-PLAN.md` per §"Per-repo governance" above, so the prefix form
+  `plans/PLAN-*.md` matches only `PLAN-TEMPLATE.md` — no real plan at all.
+  Sibling repos such as `aidoc-flow-operations` use `ops/iplans/IPLAN-*.md`.
+- `.github/ai-review/` and `.github/workflows/ai-review.yml`
+
+Two rules apply to every governance PR — no exceptions without explicit
+founder OK and an audit-trail note in the commit message.
 
 ### Rule 1 — Small scope (≤3 doc surfaces per PR)
 
@@ -626,9 +635,13 @@ resuming the work picks up the counter (per-PR cumulative).
   bypass).
 - **Cross-repo coordinated changes** — synchronized merges across
   repositories where ordering matters.
-- **PRs that touch this repo's CLAUDE.md / plans/PLAN-*.md /
-  `.github/ai-review/` / `.github/workflows/ai-review.yml`** (this repo's
-  governance PR list per the "Governance PR discipline" section above).
+- **PRs that touch any governance surface named in the "Governance PR
+  discipline" section above.** That list is the definition — **do not
+  restate it here.** A second copy is how the two drift apart: this bullet
+  used to carry its own enumeration, which wrote the plan glob as
+  `plans/PLAN-*.md` (matching no real plan) and omitted `DECISIONS.md`
+  entirely, so the exception silently under-covered what it was defined to
+  cover.
 
 **Human-opened PRs are unaffected** — the human controls merge timing for
 their own PRs.

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -35,7 +35,10 @@ semantics, the runner split incl. why `sast-scan` is the `ubuntu-latest` excepti
 ## Where we are — 2026-07-30
 
 Framework spec `0.40.0`, Claude Code plugin `0.24.0`, Hermes `0.12.0`. `main` clean.
-**Open issues: 0. Open PRs: 0.**
+**Open issues: 2** — [#385](https://github.com/vladm3105/aidoc-flow-framework/issues/385)
+(next-task 4 below) and [#386](https://github.com/vladm3105/aidoc-flow-framework/issues/386)
+(the `sync-version-refs.sh` framework-token gate, under *Local hooks and tooling*), both
+filed 2026-07-30. **Open PRs: 0** once the PR carrying this file lands.
 
 **Last merge: PR [#383](https://github.com/vladm3105/aidoc-flow-framework/pull/383)
 (`845ea13f`) — the PIN-CURRENCY-NO-READER *plan*, and nothing else.** No
@@ -120,23 +123,18 @@ The full queue is `plans/FRAMEWORK-TODO.md` (`## Open`) and
    awk '/^## Closed/{c=1} c&&/^### /{e++} c&&/✅ CLOSED/{m++} END{print e, m}' plans/FRAMEWORK-TODO.md
    ```
 
-4. **Two `CLAUDE.md` defects found while wrapping PR #383 — both independent of that
-   work, and one changes who may merge what.**
-   - **The governance-PR list's literal glob matches no real plan.** `CLAUDE.md:546` and
-     `:629` both write it as `plans/PLAN-*.md`, but every plan here is `<NAME>-PLAN.md` —
-     the convention `CLAUDE.md:229` itself documents. `ls plans/PLAN-*.md` returns exactly
-     one file, `PLAN-TEMPLATE.md`. Since the auto-merge exception list is defined *by
-     reference* to that list, a fresh session could defensibly read the
-     PIN-CURRENCY PR 2 as **non**-governance and auto-merge it on green — the opposite of
-     what the merged plan intends. Fix the glob to `plans/*-PLAN.md`; until then, treat
-     the *convention* as authoritative, not the pattern.
-   - **`CLAUDE.md:23` says Hermes `0.11.1`; `platforms/hermes/VERSION` is `0.12.0`.**
-     CLAUDE.md is auto-loaded, so a fresh session reads the stale number first and this
-     file's correct one second.
-
-   Both belong in a `CLAUDE.md` PR, which is governance + founder-merge. PR 4 of the
-   PIN-CURRENCY sequence already touches `CLAUDE.md` at 2 of Rule 1's 3 surfaces, so it
-   can carry them — or they ship as their own small PR, which is cleaner.
+4. **[#385](https://github.com/vladm3105/aidoc-flow-framework/issues/385) — the `#342`
+   regression guard scans less than it claims.**
+   `tests/conformance/platforms/test_no_inprompt_hashing.py:99`/`:103` use
+   `glob("doc-*/SKILL.md")` and a non-recursive `glob("*.md")`, so **41 of 52** plugin
+   SKILLs and **36 of 39** Hermes references are scanned. The 3 unscanned Hermes files
+   are all of `references/batch-brd-processing/`, and
+   `batch-remediation-script.md:24` still computes element IDs with its own
+   `hashlib.sha256` routine that diverges from the normative transform on four points.
+   The 11 unscanned plugin SKILLs are clean today — that half is latent. The guard's own
+   docstring (`:92`) forbids narrowing coverage by glob, which is what happened. Fix is
+   `rglob` both + point the script at `rehash --compute`; the issue carries the census
+   command. **A green run of this guard is not evidence that no surface hashes.**
 5. **Hermes parity — the residual arc.** `plans/HERMES-BACKLOG.md`: remaining
    plugin-vs-Hermes deltas plus quality-loop Phase 2 (cross-invocation resume / G-R1,
    the parallel-review global lock).
@@ -164,6 +162,7 @@ not. Each was verified on 2026-07-29.
 | `NO-PIN-CURRENCY-CHECK` — "this repo runs `check-pin-currency.sh` nowhere" | **Retracted, it was false.** See below |
 | `PIN-CURRENCY-NO-READER` — "the fix is a workflow that **runs the script** and opens an issue" (the restated TODO entry's own fix shape) | **Superseded by the merged plan.** Running the script would be the second detector the same entry forbids. The reader consumes the completed run's **log** — the only one of four input surfaces that carries the signal |
 | "canon has no adopter-facing pin reader at all" | **Overstated.** `standards-drift-self.yml:85` runs a `--fleet` pin audit against *this repo* every Monday and discards it with `\|\| true`. The gap is that **no** audit has a reader, on either side |
+| `plans/PLAN-*.md` as the governance-PR plan glob (`CHANGELOG.md:1892`, `CI-CANON-V2.16-MIGRATION-PLAN.md:468`/`:784`) | **Fixed in `CLAUDE.md`.** The glob is a **suffix** — `plans/*-PLAN.md`. The prefix form matched only `PLAN-TEMPLATE.md`, so the governance list read as covering *no* real plan, and the auto-merge exception list inherits that list by reference. Merged plans and the CHANGELOG keep the old string as history; `CLAUDE.md` is the live rule |
 
 **The retraction, because the lesson generalises.** That entry named an absence as the
 cause of a mixed-pin state surviving two days. The check *does* run — canon's
@@ -282,6 +281,26 @@ defect to assert and the hardest to verify — read the log before writing one d
   linter's own sync script is `tools/sdd_doc_lint/sync-vendored.sh`, **not**
   `tools/sync-plugin-framework.sh` (which vendors `framework/` subtrees plus three
   named tools files and does not touch `sdd_doc_lint`).
+- **Both `CLAUDE.md` current-state platform tokens now self-heal** (PR #389). `sync-version-refs.sh`
+  detects the previous plugin and Hermes values **from `CLAUDE.md` itself**, not from
+  `plugin.json` / `README.md`, so a stale token is fixed even when every other surface is
+  already current — the state that let `CLAUDE.md` sit at Hermes `0.11.1` against a
+  `0.12.0` VERSION for four days. The plugin token had carried the same latent bug since
+  SYNC-CLAUDE-PLUGIN-VERSION-GAP (its write was nested inside the `plugin.json`-derived
+  guard); it is now independent too. **The framework-spec token still is not**, and it
+  carries the higher-fanout version of the same bug: `fw_prev` is detected from
+  `CLAUDE.md` *and* gates propagation to `README.md`, `docs/PARITY.md`, both platform
+  READMEs and the conformance-test literal — five files stranded, silently, exit 0, if
+  `CLAUDE.md` is corrected first. Measured, not inferred, and filed as
+  [#386](https://github.com/vladm3105/aidoc-flow-framework/issues/386). **The hand-edit
+  hazard below now applies to that token alone.** The 52 SKILL frontmatters, the
+  playbooks and `platforms/*/FRAMEWORK_SPEC_VERSION` are **not** in that blast radius —
+  each has its own detector.
+- **Run a sync-script reproduction in a throwaway clone, never in the working tree.**
+  Proving #386 meant bumping `framework/VERSION`, which fired the three independent
+  detectors and rewrote **100+** SKILL / playbook / `FRAMEWORK_SPEC_VERSION` files — and
+  the script's closing `git add -u` **staged all of them**. Restoring the two files the
+  test targeted is not enough; the collateral is elsewhere and already in the index.
 - **Propagation order for a framework version bump is load-bearing:**
   `framework/VERSION` → `scripts/sync-version-refs.sh` → **then**
   `tools/sync-plugin-framework.sh`. Reversing it lands 51 drifted bundled playbooks and


### PR DESCRIPTION
## What and why

`CLAUDE.md`'s governance-PR definition wrote the plan glob as a **prefix** —
`plans/PLAN-*.md` — while every plan in this repo is `<NAME>-PLAN.md`, the
convention the same file documents at §"Per-repo governance".

```console
$ ls plans/PLAN-*.md
plans/PLAN-TEMPLATE.md
```

One file, and it is the template. The auto-merge exception list is defined *by
reference* to that definition, so the rule that is supposed to keep plan PRs
out of auto-merge covered no plan. Concretely: PR 2 of the merged PIN-CURRENCY
sequence could have been read as non-governance and auto-merged on green, which
is the opposite of what that plan states.

Both copies inside `CLAUDE.md` carried it:

| Copy | Was | Now |
| --- | --- | --- |
| §"Governance PR discipline" — the definition | one prose sentence, prefix glob | bullet list; `plans/*-PLAN.md` + `plans/*-DESIGN.md` companions; both `DECISIONS.md` files named |
| auto-merge exceptions | **its own copy** — broken glob, no `DECISIONS.md` | copy deleted; defers to the definition, and says why a second copy is the bug |

The third copy lives in `.github/PULL_REQUEST_TEMPLATE.md` and is
[#390](https://github.com/vladm3105/aidoc-flow-framework/pull/390).

## Stale state in the auto-loaded line

`CLAUDE.md:23` is read before anything else every session. It said Hermes
`0.11.1` against a `0.12.0` `VERSION` (four days), and described #342 / #351 as
open when both closed 2026-07-26/27. The sync gap behind the version half is
fixed in [#389](https://github.com/vladm3105/aidoc-flow-framework/pull/389)
(merged).

## Two defects found while verifying — filed, not narrated

- **[#385](https://github.com/vladm3105/aidoc-flow-framework/issues/385)** —
  `tests/conformance/platforms/test_no_inprompt_hashing.py` scans **41 of 52**
  plugin SKILLs (`doc-*` prefix) and **36 of 39** Hermes references
  (non-recursive glob); one unscanned file still computes element IDs with a
  `hashlib.sha256` routine that diverges from the normative transform. This
  falsified a sentence drafted for this PR, which is why `CLAUDE.md` now says a
  green run of that guard proves less than its name implies.
- **[#386](https://github.com/vladm3105/aidoc-flow-framework/issues/386)** —
  the framework-spec token keeps the *higher-fanout* form of the sync bug:
  `fw_prev` is read from `CLAUDE.md` **and** gates propagation to five other
  files, so correcting `CLAUDE.md` first strands them silently at exit 0.

Queue entries for both are in
[#388](https://github.com/vladm3105/aidoc-flow-framework/pull/388) (merged).

## Files touched (OPS-0061 Rule 1 self-check)

**3 doc surfaces.**

| Surface | Change |
| --- | --- |
| `CLAUDE.md` | governance-PR definition; auto-merge exception; current-state line |
| `plans/HANDOFF.md` | completed item dropped, #385 added as next-task 4, two tooling traps |
| `CHANGELOG.md` | `[Unreleased]` entry |

Two things that started in this PR were **split out to hold that line** rather
than take a founder-OK carve-out for a fourth surface: the
`scripts/sync-version-refs.sh` fix (#389, merged) and the PR template (#390).
Rule 1 names splitting as the default and a carve-out as the exception.

**Governance tier:** 🟡 governance — touches `CLAUDE.md`. **Not auto-merged;
founder merges.**

## Review

Two local cycles, five `code-reviewer` agents, then the CI reviewer.

- Cycle 1 (governance-docs consistency / claim fact-check / shell correctness):
  6 findings, all folded. The most valuable was that a claim drafted here was
  false — that became #385.
- Cycle 2 (fold verification / adversarial): caught the fold reproducing this
  PR's own defect class — the restated exception list omitted the `*-DESIGN.md`
  companions the definition had just gained. That restatement is now deleted
  rather than corrected.
- CI reviewer: found the missing `CHANGELOG.md` entry, which is what forced the
  Rule 1 rebalance above.
