### PR TITLE
fix(scripts): make CLAUDE.md's platform version tokens self-healing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — `CLAUDE.md`'s platform version tokens now self-heal (2026-07-30)
+
+**No version moves** — `scripts/sync-version-refs.sh` only.
+
+- `CLAUDE.md` sat at Hermes `0.11.1` against a `0.12.0` `VERSION` for four days, because
+  the hermes fanout never wrote `CLAUDE.md` at all. Both platform tokens now detect their
+  previous value **from `CLAUDE.md` itself** rather than from `plugin.json` / `README.md`,
+  so a stale token is corrected even when every other surface is already current — the
+  state that hid this one, and which the plugin token shared latently since
+  SYNC-CLAUDE-PLUGIN-VERSION-GAP (its write was nested inside the `plugin.json`-derived
+  guard). Verified by injecting each token stale with all other surfaces current: both
+  corrected in one run, idempotent on the second.
+- The framework-spec token is deliberately **not** changed: `fw_prev` is read from
+  `CLAUDE.md` *and* gates propagation to five other files, so it is a load-bearing path
+  rather than a doc edit. Filed as
+  [#386](https://github.com/vladm3105/aidoc-flow-framework/issues/386).
+
 ### Added — `doc-maintainer` adopted in dry-run; canon manifest parity is complete (2026-07-29)
 
 **No version moves** — `.github/` only. The last of the 28 canon manifest surfaces.

--- a/scripts/sync-version-refs.sh
+++ b/scripts/sync-version-refs.sh
@@ -43,7 +43,15 @@
 #   - README.md "framework spec `<X.Y.Z>`" Status block
 #   - docs/PARITY.md "framework spec `<X.Y.Z>`" current-state row
 #
-# Hermes VERSION (platforms/hermes/VERSION): same pattern for hermes/v<X.Y.Z>.
+# Hermes VERSION (platforms/hermes/VERSION): same pattern for hermes/v<X.Y.Z>,
+# plus:
+#   - CLAUDE.md "Hermes `<X.Y.Z>`" current-state line
+#
+# The two CLAUDE.md current-state tokens (plugin, hermes) are detected from
+# CLAUDE.md itself, so they self-heal even when every other surface is already
+# current. The framework-spec token is deliberately NOT: fw_prev detected from
+# CLAUDE.md is what gates propagation to README / PARITY / both platform READMEs,
+# so hand-editing CLAUDE.md before a framework bump still silently skips them.
 #
 # What it does NOT do (semantic / human-authored content):
 #   - CHANGELOG entries (text)
@@ -124,6 +132,26 @@ plugin_ver="$(read_version platforms/claude-code-plugin/VERSION)"
 log "plugin VERSION: ${plugin_ver:-(missing)}"
 
 if [[ -n "$plugin_ver" ]]; then
+  # CLAUDE.md current-state line: "Claude Code plugin `<X.Y.Z>`"
+  # (SYNC-CLAUDE-PLUGIN-VERSION-GAP). Detected from CLAUDE.md itself, NOT from
+  # the plugin.json-derived prev below, so it self-heals when plugin.json is
+  # already current and the block below is skipped — the state that let the
+  # Hermes token sit at 0.11.1 against a 0.12.0 VERSION for four days.
+  #
+  # HAZARD (same class as FRWK-REVIEW-002 F1 below): replace_in_file does a
+  # GLOBAL sed of the literal, so a historical/provenance mention written in this
+  # exact form would be swept to the new version on the next bump. Write those as
+  # "the `0.23.4` plugin cycle" or "(from `0.7.3`)", never as
+  # "Claude Code plugin `0.23.4`" / "Hermes `0.11.1`".
+  claude_plugin_prev="$(detect_version_in CLAUDE.md \
+    'Claude Code plugin `[0-9]+\.[0-9]+\.[0-9]+`')"
+  if [[ -n "$claude_plugin_prev" && "$claude_plugin_prev" != "$plugin_ver" ]]; then
+    log "plugin CLAUDE.md sync $claude_plugin_prev -> $plugin_ver"
+    replace_in_file CLAUDE.md \
+      "Claude Code plugin \`$claude_plugin_prev\`" \
+      "Claude Code plugin \`$plugin_ver\`"
+  fi
+
   plugin_prev="$(detect_version_in \
     platforms/claude-code-plugin/.claude-plugin/plugin.json \
     '"version": "[0-9]+\.[0-9]+\.[0-9]+"')"
@@ -140,11 +168,6 @@ if [[ -n "$plugin_ver" ]]; then
       replace_in_file "$skill" \
         "version: \"$plugin_prev\"" "version: \"$plugin_ver\""
     done
-    # CLAUDE.md current-state line: "Claude Code plugin `<X.Y.Z>`"
-    # (SYNC-CLAUDE-PLUGIN-VERSION-GAP — the framework-spec token was already
-    # synced below; the plugin token was not, so every plugin bump left it stale).
-    replace_in_file CLAUDE.md \
-      "Claude Code plugin \`$plugin_prev\`" "Claude Code plugin \`$plugin_ver\`"
     replace_in_file README.md \
       "claude-code-plugin/v$plugin_prev" "claude-code-plugin/v$plugin_ver"
     replace_in_file platforms/claude-code-plugin/README.md \
@@ -305,6 +328,22 @@ hermes_ver="$(read_version platforms/hermes/VERSION)"
 log "hermes VERSION: ${hermes_ver:-(missing)}"
 
 if [[ -n "$hermes_ver" ]]; then
+  # CLAUDE.md current-state line: "Hermes `<X.Y.Z>`". Detected from CLAUDE.md
+  # itself, NOT from the README-derived prev below, so it self-heals even when
+  # README.md is already current and the block below is skipped — exactly the
+  # state that let CLAUDE.md sit at 0.11.1 while every other surface said 0.12.0
+  # for four days. CLAUDE.md is auto-loaded, so a stale token there is read
+  # before any correct one. Same shape, and same global-sed hazard, as the plugin
+  # token block above — see the HAZARD note there before adding a historical
+  # "Hermes `X.Y.Z`" mention to CLAUDE.md.
+  claude_hermes_prev="$(detect_version_in CLAUDE.md \
+    'Hermes `[0-9]+\.[0-9]+\.[0-9]+`')"
+  if [[ -n "$claude_hermes_prev" && "$claude_hermes_prev" != "$hermes_ver" ]]; then
+    log "hermes CLAUDE.md sync $claude_hermes_prev -> $hermes_ver"
+    replace_in_file CLAUDE.md \
+      "Hermes \`$claude_hermes_prev\`" "Hermes \`$hermes_ver\`"
+  fi
+
   hermes_prev="$(detect_version_in README.md 'hermes/v[0-9]+\.[0-9]+\.[0-9]+')"
   if [[ -n "$hermes_prev" && "$hermes_prev" != "$hermes_ver" ]]; then
     log "hermes sync $hermes_prev -> $hermes_ver"


### PR DESCRIPTION
Split out of [#387](https://github.com/vladm3105/aidoc-flow-framework/pull/387)
on the CI reviewer's finding: that PR is governance-tier and already at Rule 1's
3-doc-surface cap, so the CHANGELOG entry this code change requires did not fit
there. Splitting is Rule 1's stated default; the alternative was a founder-OK
carve-out for a fourth surface.

## The defect

`CLAUDE.md` read Hermes `0.11.1` against a `0.12.0` `VERSION` for four days.
`CLAUDE.md` is auto-loaded every session, so the stale number is the *first*
thing read.

The hermes fanout never wrote `CLAUDE.md` at all. The plugin block that did
write it was nested inside the guard derived from `plugin.json` — so once the
other surfaces were current, neither token could ever be corrected. Both had the
same shape: **detection from a file that isn't the one being fixed.**

## The fix

Each token now detects its previous value from `CLAUDE.md` itself and writes
only `CLAUDE.md`, so nothing else is gated on it.

| Injected state | Before | After |
| --- | --- | --- |
| Hermes token stale, README current | no-op | `hermes CLAUDE.md sync 0.11.1 -> 0.12.0` |
| Plugin token stale, `plugin.json` current | unreachable | `plugin CLAUDE.md sync 0.23.4 -> 0.24.0` |
| Either token current | no-op | no-op |

Idempotent on a second run; working tree restored byte-identical after each
injection test. `shellcheck -S warning` clean on the new hunks (the one SC2164
at `:73` is pre-existing and untouched).

## Deliberately not fixed here

The **framework-spec** token keeps the higher-fanout form of the same bug:
`fw_prev` is read from `CLAUDE.md` *and* gates propagation to `README.md`,
`docs/PARITY.md`, both platform READMEs and a conformance-test literal — so
correcting `CLAUDE.md` first strands five files, silently, at exit 0. That is a
load-bearing propagation path rather than a doc edit, and it is filed as
[#386](https://github.com/vladm3105/aidoc-flow-framework/issues/386) with the
blast radius **measured**: the 52 SKILL frontmatters, the playbooks and
`platforms/*/FRAMEWORK_SPEC_VERSION` are *not* in it, since each has its own
detector.

## Files touched

| Surface | Change |
| --- | --- |
| `scripts/sync-version-refs.sh` | two self-detecting blocks; header block documents them; FRWK-REVIEW-002 F1 hazard comment added |
| `CHANGELOG.md` | `[Unreleased]` entry |

**Governance tier:** 🟢 non-governance — no `CLAUDE.md`, plan, `DECISIONS.md`
or `.github/ai-review/` change.
