### PR TITLE
docs: the PR template's copy of the governance list names a glob that matches no plan

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,9 +22,15 @@ Closes #
 
 <!--
 Rule 1 caps a GOVERNANCE PR at ≤3 doc surfaces. This repo's governance-PR list
-(CLAUDE.md § "Governance PR discipline"): CLAUDE.md, plans/PLAN-*.md,
-plans/DECISIONS.md, .github/ai-review/, .github/workflows/ai-review.yml, or a
-change that supersedes a locked decision.
+(CLAUDE.md § "Governance PR discipline" is the definition; this is a copy, so
+check it there if the two ever disagree): CLAUDE.md, plans/*-PLAN.md and their
+plans/*-DESIGN.md companions, plans/DECISIONS.md,
+framework/governance/DECISIONS.md, .github/ai-review/,
+.github/workflows/ai-review.yml, or a change that supersedes a locked decision.
+
+The plan glob is a SUFFIX — every plan here is <NAME>-PLAN.md. The prefix form
+plans/PLAN-*.md, which this template and CLAUDE.md both carried until
+2026-07-30, matches only PLAN-TEMPLATE.md, i.e. no real plan.
 
 Over 3 surfaces on a governance PR: SPLIT into sequential PRs, or record a
 founder OK here AND as an audit-trail line in the commit message. Splitting is


### PR DESCRIPTION
`.github/PULL_REQUEST_TEMPLATE.md:25` tells every author that the governance-PR
list includes `plans/PLAN-*.md`.

```console
$ ls plans/PLAN-*.md
plans/PLAN-TEMPLATE.md
```

A prefix glob, against a repo where every plan is `<NAME>-PLAN.md` — so it
matches the template and no real plan. The copy also omitted
`framework/governance/DECISIONS.md`.

The template now points at `CLAUDE.md` § "Governance PR discipline" as the
definition it copies, so the next divergence between the two resolves in one
place.

Split from [#387](https://github.com/vladm3105/aidoc-flow-framework/pull/387),
which fixes the same defect in the definition itself and in the auto-merge
exception list. That PR is governance-tier and Rule 1 caps it at 3 doc
surfaces; this file is not on the governance list, so it is not.

## Files touched

| Surface | Change |
| --- | --- |
| `.github/PULL_REQUEST_TEMPLATE.md` | the copied governance list: suffix glob, `framework/governance/DECISIONS.md` added, definition named |

**Governance tier:** 🟢 non-governance.
