### PR TITLE
feat(ci): give the pin-currency verdict a reader (PIN-CURRENCY-NO-READER PR 2/4)

### DIFF
--- a/.github/workflows/pin-currency-reader.yml
+++ b/.github/workflows/pin-currency-reader.yml
@@ -1,0 +1,153 @@
+# pin-currency-reader — give the EXISTING pin-currency output a reader.
+#
+# The weekly `standards-drift` run already detects stale `@ci/v*` pins correctly
+# and names the `--repin` remedy. Nothing read it: canon's check is warning-only
+# by contract, its reusable exposes no `outputs:`, it writes no step summary,
+# and the check-run annotations API caps at 10 warnings per level — which on the
+# measured run dropped all ten pin-currency lines, because they are emitted at
+# the script's tail. This workflow reads the completed run's LOG, the only
+# surface that carries the signal, and reconciles one tracking issue from it.
+#
+# It adds NO second detector. See plans/PIN-CURRENCY-READER-PLAN.md.
+#
+# LOCAL OVERRIDE, not a canon caller. Canon has no adopter-facing pin reader —
+# in fact its own weekly fleet audit (standards-drift-self.yml) discards its
+# verdict with `|| true`, so no audit anywhere has a reader. The generalizable
+# half is filed upstream; delete this file once canon's own reader lands.
+name: pin-currency-reader
+
+on:
+  workflow_run:
+    # Scoped by name so the reader can never trigger on itself.
+    workflows: ["standards-drift"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: standards-drift run ID whose log should be read
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  actions: read       # required to download another workflow run's log
+  issues: write
+
+# SERIALIZATION, not cancellation. `cancel-in-progress: false` under a fixed
+# group name stops a `workflow_run` fire and a concurrent `workflow_dispatch`
+# from both finding no open issue and each creating one.
+#
+# Do NOT rewrite this rationale as "nothing to cancel, so nothing to fix" —
+# that is verbatim this repo's justification for shipping NO `concurrency:`
+# block at all (see audit-trail.yml), so a future sweep reading it here would
+# delete the block and reintroduce the duplicate-issue race. Recorded at the
+# level a `concurrency:` sweep actually greps, per D-0070.
+#
+# This workflow feeds no required context, so the #329 allowlist does not apply.
+# Counting by SHAPE rather than by filename, as `CLAUDE.md` requires, this is a
+# FOURTH shape alongside "absent block", the #329 allowlist, and bare `true`.
+#
+# Caveat worth knowing before relying on it: `cancel-in-progress: false` does not
+# make a run uncancellable. GitHub queues at most one PENDING run per group, so a
+# third arrival while one is running and one is queued displaces the queued one.
+# Benign here — the surviving run reads a newer log — but it is not a guarantee
+# that every upstream verdict is read.
+concurrency:
+  group: pin-currency-reader
+  cancel-in-progress: false
+
+jobs:
+  read:
+    name: Read pin-currency verdict
+    # The precedent's FULL form (auto-merge-ai-prs.yml). A conclusion-only
+    # filter green-SKIPS every dispatch, because
+    # `github.event.workflow_run.conclusion` is empty on a `workflow_dispatch`
+    # run — and a skipped job is green, so a manual verification run would
+    # report "no issue created" against a passing workflow.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    # The reconcile's arg parser is arity-checked, but an unattended job with no
+    # ceiling would burn the 6h default if anything ever did hang.
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Resolve the source run
+        id: src
+        # `run_id` is an attacker-controllable `workflow_dispatch` string, so it
+        # reaches the shell ONLY through `env:` — never interpolated into the
+        # script body. A `${{ }}` expansion is textual substitution performed
+        # before bash parses the line, so a quoted `$(…)` payload in the input
+        # would execute here with GH_TOKEN in scope and `issues: write` on the
+        # job token. `actionlint` does not flag this, so the pattern is the
+        # only guard. Same reason the digits check is a hard fail, not a warn.
+        env:
+          INPUT_RUN_ID: ${{ github.event.inputs.run_id }}
+          EVENT_RUN_ID: ${{ github.event.workflow_run.id }}
+          SERVER_URL: ${{ github.server_url }}
+        run: |
+          run_id="${INPUT_RUN_ID:-$EVENT_RUN_ID}"
+          [ -n "$run_id" ] || { echo "::error::pin-currency-reader: no run id to read"; exit 1; }
+          case "$run_id" in
+            ''|*[!0-9]*) echo "::error::pin-currency-reader: run id is not numeric: '${run_id}'"; exit 1;;
+          esac
+          echo "run_id=${run_id}" >> "$GITHUB_OUTPUT"
+          echo "run_url=${SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${run_id}" >> "$GITHUB_OUTPUT"
+
+      - name: Download the standards-drift run log
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ steps.src.outputs.run_id }}
+        run: |
+          # Bounded retry: `gh run view --log` 404s while a just-completed run's
+          # log archive is still being assembled — which is exactly when
+          # `workflow_run: completed` fires. Without this the dominant failure
+          # mode is a red workflow on an unwatched surface: the same
+          # invisibility this reader exists to remove, inverted.
+          for attempt in 1 2 3 4 5; do
+            if gh run view "$RUN_ID" --repo "$GITHUB_REPOSITORY" --log > drift.log 2>run-view.err; then
+              [ -s drift.log ] && { echo "log downloaded on attempt ${attempt}"; exit 0; }
+            fi
+            echo "::notice::pin-currency-reader: log not ready (attempt ${attempt}/5), backing off"
+            sleep $((attempt * 15))
+          done
+          echo "::error::pin-currency-reader: could not download the log for run ${RUN_ID}"
+          cat run-view.err >&2 || true
+          exit 1
+
+      - name: Parse the pin-currency verdict
+        id: parse
+        run: bash scripts/read-pin-currency-log.sh drift.log >> "$GITHUB_OUTPUT"
+
+      - name: Reconcile the tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ steps.src.outputs.run_url }}
+          ASSIGNEE: ${{ github.repository_owner }}
+        run: |
+          bash scripts/read-pin-currency-log.sh drift.log \
+            | bash scripts/reconcile-pin-currency-issue.sh \
+                --repo "$GITHUB_REPOSITORY" \
+                --run-url "$RUN_URL" \
+                --assignee "$ASSIGNEE"
+
+      - name: Summary
+        if: always()
+        # Same `env:`-only rule as the resolve step — `run_url` carries the
+        # dispatch input transitively, so it must not be interpolated either.
+        env:
+          VERDICT: ${{ steps.parse.outputs.verdict }}
+          STALE_COUNT: ${{ steps.parse.outputs.stale_count }}
+          CANON: ${{ steps.parse.outputs.canon }}
+          RUN_URL: ${{ steps.src.outputs.run_url }}
+        run: |
+          {
+            echo "### pin-currency"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| verdict | \`${VERDICT}\` |"
+            echo "| stale files | ${STALE_COUNT} |"
+            echo "| canon | \`${CANON}\` |"
+            echo "| source run | ${RUN_URL} |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,45 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added — the pin-currency verdict finally has a reader (2026-07-30)
+
+**No version moves** — local CI surface only. PR 2 of the four-PR sequence in
+[`plans/PIN-CURRENCY-READER-PLAN.md`](plans/PIN-CURRENCY-READER-PLAN.md).
+
+- `.github/workflows/pin-currency-reader.yml` reads a completed `standards-drift`
+  run and reconciles **one** auto-maintained tracking issue from its verdict —
+  created on `stale`, edited in place, **reopened** rather than duplicated, closed
+  when clean. No second detector is added: the weekly run already detects stale
+  `@ci/v*` pins correctly and names the `--repin` remedy; nothing read it.
+- **The run log is the only surface carrying the signal**, which is why this parses
+  a log rather than calling an API. Canon's reusable declares `inputs:` and no
+  `outputs:`; the drift script writes nothing to `$GITHUB_STEP_SUMMARY`; and the
+  check-run annotations API truncates — on the measured run it returned 10 of the
+  job's 22 warnings and **none** of the ten pin-currency lines, which are emitted at
+  the script's tail.
+- `scripts/read-pin-currency-log.sh` — log in, `verdict` / `stale_count` / `canon` /
+  `stale_files` / `drift_summary` out. Four verdicts (`stale`, `clean`, `unresolved`,
+  `skipped`); a truncated log or a **malformed canon token** exits non-zero. That
+  token check is load-bearing: if canon's `VERSION` fetch returns an error page
+  rather than failing, its `ver_cmp` falls through to equal and prints
+  `all pins current ✅`, and honouring that false clean would **close** the tracking
+  issue on a transient.
+- `scripts/reconcile-pin-currency-issue.sh` — takes canon's own `GH="${GH:-gh}"`
+  injection point, so `--dry-run` is driven by a stub rather than a live
+  authenticated read. Creating the issue is its own notification; beyond that it
+  comments on exactly three transitions (closed → stale on reopen, a changed stale
+  set while open, stale → clean on close), and an unchanged re-run edits silently.
+  `unresolved` / `skipped` touch no open/closed state and stamp a `last verified`
+  line into an existing issue, preserving the machine-readable block verbatim; with
+  no issue open there is nothing to stamp and the run is a no-op.
+- Both halves are extracted from the workflow **because** `workflow_run` and
+  `workflow_dispatch` each require the file on the default branch, so nothing
+  end-to-end can run on the PR that introduces it. 17 unit tests over five
+  checked-in fixtures cover what ships; end-to-end verification follows the merge.
+- `tests/conformance/test_repo_scripts.py` registers those tests into the
+  conformance suite. `tests/unit/` is run by no hook and no workflow, so without
+  this the new tests would guard nothing after merge (253 → 271 tests).
+
 ### Fixed — the governance-PR plan glob matched no real plan (2026-07-30)
 
 **No version moves** — `CLAUDE.md` only.

--- a/plans/PIN-CURRENCY-READER-PLAN.md
+++ b/plans/PIN-CURRENCY-READER-PLAN.md
@@ -4,7 +4,7 @@
 | -------------- | ---------------------------------------------------------------------- |
 | Task           | `PIN-CURRENCY-NO-READER` (`plans/FRAMEWORK-TODO.md`, `[ci]`)            |
 | Type           | feature                                                                |
-| Status         | READY — 2026-07-30 (Pass 5, 4 independent passes, zero load-bearing findings outstanding) |
+| Status         | IN PROGRESS — 2026-07-30. PR 1 merged (plan); **PR 2 open** (scripts, workflow, fixtures, tests, registration shim). PR 3 gated on V10–V14; PR 4 last. Reviewed over 5 passes, zero load-bearing findings outstanding |
 | Depends on     | D-0070 (`@ci/v2.16.0` pins), D-0071 (CANON-PARITY-001)                 |
 | Feeds          | an upstream feature request on `aidoc-flow-ci`                          |
 | Version impact | none — no version stream moves (local CI surface only)                  |
@@ -171,10 +171,15 @@ inline, which was the wrong half to trust.
 - **"Comment only on verdict change" is defined by the verdict and the stale set, not by
   the body.** The body embeds a run URL that changes weekly, so body-diffing would
   comment every run. Comment on exactly three transitions: `clean`/absent → `stale`
-  (opened or reopened), a change in `stale_count` or the stale file set while open, and
-  `stale` → `clean` (closing). A re-run with an identical verdict and identical stale
-  set edits the body silently. Without the middle transition, a count going 10 → 15
-  would be a silent edit with no notification, which defeats R8.
+  **where that reopens an existing issue**, a change in `stale_count` or the stale file
+  set while open, and `stale` → `clean` (closing). A re-run with an identical verdict and
+  identical stale set edits the body silently. Without the middle transition, a count
+  going 10 → 15 would be a silent edit with no notification, which defeats R8.
+  - **Creating the issue is itself the notification, so a create emits no comment.**
+    An issue opened and assigned already notifies; a comment restating the body it was
+    created with is noise. A reopen is the case that needs one, because reopening alone
+    is quiet. *(Clarified during PR 2 — the original "(opened or reopened)" read as
+    requiring both, which V10 never asked for and V12 asked for only on reopen.)*
 - **Assignee is set *after* creation, via `gh issue edit --add-assignee`** (R8) — a
   `github-actions[bot]` issue notifies only repo watchers, and `GITHUB_TOKEN` authorship
   fires no `issues`-triggered automation, so an assignee is needed. But
@@ -290,7 +295,7 @@ and `.github/labeler.yml` that no such label existed. Those are not the live lab
 
 | Path | Purpose |
 | ---- | ------- |
-| `scripts/read-pin-currency-log.sh` | parse a `standards-drift` log → `stale` / `clean` / `skipped` verdict |
+| `scripts/read-pin-currency-log.sh` | parse a `standards-drift` log → `stale` / `clean` / `unresolved` / `skipped` verdict |
 | `scripts/reconcile-pin-currency-issue.sh` | reconcile the single tracking issue; `--dry-run` capable |
 | `.github/workflows/pin-currency-reader.yml` | run both per completed `standards-drift` run |
 | `tests/unit/fixtures/standards_drift_stale.log` | run `30257877863`, in **`v2.16.0` shape** (coverage tail appended) — 10 stale pins |
@@ -440,7 +445,7 @@ Split by what can run before the merge and what structurally cannot (R1).
 
 | #  | Check (command or observable) | Expected result | Maps to |
 | -- | ----------------------------- | --------------- | ------- |
-| V1 | `python3 -m unittest tests.unit.test_pin_currency_reader -v` | 6 parse cases + 7 reconcile cases (six scenarios plus the label fallback) pass | Task 1, Task 2 |
+| V1 | `python3 -m unittest tests.unit.test_pin_currency_reader -v` | 17 pass: 8 parse cases (4 verdicts + 4 must-fail shapes) and 9 reconcile cases (six scenarios, the label fallback, and two asserting generated body content). Grew from 6 + 7 during PR 2's self-review — see §Review log Pass 6 | Task 1, Task 2 |
 | V2 | `python3 -m unittest discover -s tests/conformance` before vs. after the registration shim | the test count **increases** by the new cases, proving the shim reaches `tests/unit/` | R6 |
 | V3 | `bash scripts/read-pin-currency-log.sh tests/unit/fixtures/standards_drift_stale.log` | `verdict=stale`, `stale_count=10`, `canon=ci/v2.15.0` | Task 1 |
 | V4 | `GH=<stub> bash scripts/reconcile-pin-currency-issue.sh --dry-run` across the six scenarios in Task 2 | the expected create / edit / edit+comment / reopen / close / stamp-only sequence; **zero** live API writes, and no `gh` or network needed | Task 2 |
@@ -469,7 +474,7 @@ which is what forces the reopen contract rather than create-on-stale (R5).
 
 Per §PR sequencing, not in one PR.
 
-- [ ] `CHANGELOG.md` — entry *(PR 2)*
+- [x] `CHANGELOG.md` — entry *(PR 2)*
 - [ ] `plans/DECISIONS.md` — `D-00NN`: why the log, why not annotations, why the reader
       fails loudly *(PR 3)*
 - [ ] `plans/FRAMEWORK-TODO.md` — entry → `## Closed` with the merge ref *(PR 3)*
@@ -821,3 +826,59 @@ already accepted (the registration shim's reducibility; `unresolved`/`skipped` s
 behavior) remain open by decision, not oversight.
 
 **Result:** ready — no load-bearing findings outstanding.
+
+### Pass 6 — 2026-07-30 — PR 2 implementation self-review (Rule 2, 3 agents)
+
+Not a plan review: the mandatory adversarial review of the **implementation** diff,
+dispatched per governance Rule 2 / OPS-0067 across three agents (shell correctness,
+workflow + test fidelity, governance + dead refs). Fourteen load-bearing findings, all
+fixed before push. The four that would have shipped real defects:
+
+- **The completion gate proved the wrong thing.** Pass 5 authorized grepping the common
+  prefix `check-standards-drift:` as positive evidence that the drift script ran. It is
+  not a terminal marker: the script emits an opening `repo=… tier=…` header and a
+  `cannot check <family>` warning per unreadable family under that same prefix — the
+  first of them **24 lines ahead** of pin-currency in the measured log. So a log
+  truncated anywhere in that window satisfied the gate, parsed as `skipped`, and exited
+  0 with ten stale pins in the real run. Reachable, not theoretical: `workflow_run:
+  completed` fires while the log archive is still assembling and a partial archive is
+  non-empty. Now gated on the summary line **or** the `coverage —` line, both of which
+  only appear at termination. The plan's own C39/C40 wording was right and the
+  "one substring for free" optimisation was what broke it.
+- **The `--repin` remedy was swallowed into the markdown table.** `$(render_table)`
+  inside a heredoc — command substitution strips trailing newlines, so the blank line
+  meant to terminate the GFM table could not survive, and the remedy paragraph rendered
+  as two junk table rows. On **every issue the tool would ever open**.
+- **A `workflow_dispatch` `run_id` reached three `run:` blocks by interpolation**, with
+  `GH_TOKEN` in scope and `issues: write` on the job token. Now `env:`-only, plus a
+  digits check. `actionlint` does not flag this, so V6 could never have caught it.
+- **A failed `jq` read routed to CREATE.** `gh --jq` uses gh's built-in jq, so the
+  `|| die` on the list call passes even when the external `jq` the extractions use is
+  broken — leaving `issue_number` empty, which is indistinguishable from "no issue
+  exists". A read failure could open a duplicate. Now `|| die` per extraction.
+
+Also fixed: the stamp silently no-opped (and reported success) on a body whose
+`last verified` line had been hand-edited away; `clean` closed the issue with a body
+headed "Stale @ci/v\* pins" reporting 0 stale files; a CRLF body from a web-UI edit
+blanked every previous-verdict field and would have commented weekly; a value-less
+trailing option hung the arg parser forever with no `timeout-minutes` above it; and
+`sort` was locale-dependent on a string compared **across** runs.
+
+**The fixtures were vindicated, the filter was not.** A reviewer flagged the fixtures as
+unfaithful because they carry `^[` rather than raw `0x1b`. Measured against the live
+download: `gh run view --log` emits **zero** raw ESC and 68 literal `^[`, so the fixtures
+are byte-faithful and the *filter* was wrong — `grep -v $'\x1b'` matched nothing, making
+a guard the script documented as load-bearing into dead code.
+
+**Four test guards were vacuous and are now mutation-verified.** The `gh` stub ignored
+`--state all` / `--limit 200`, so removing either kept the suite green while production
+opened duplicates; the `--add-assignee` assertion tested a dry-run `printf` literal, not
+the shipping branch; and no test read a single generated body, leaving both the
+state-block round trip and Pass 5's "stamp preserves the block verbatim" fold unlocked.
+Every guard added here was mutation-tested — the defect reintroduced, the guard confirmed
+to fail, the defect reverted.
+
+**Verified and NOT changed:** Rule 1 compliance (2 doc surfaces); the diff matching PR 2's
+declared contents exactly, with no PR 3 or PR 4 leak; `permissions:`, the dual-trigger
+`if:`, and the retry loop's control flow under the runner's `bash -e`; and every
+cross-file claim in the new comments, checked against canon at the pinned tag.

--- a/scripts/read-pin-currency-log.sh
+++ b/scripts/read-pin-currency-log.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# read-pin-currency-log.sh — parse a completed `standards-drift` run log and
+# emit the pin-currency verdict as GITHUB_OUTPUT-style key=value lines.
+#
+# WHY A LOG PARSER AND NOT AN API READ. The pin-currency signal exists on
+# exactly one surface. Canon's reusable declares `inputs:` only and no
+# `outputs:`, so a caller job receives nothing; the drift script writes nothing
+# to $GITHUB_STEP_SUMMARY; and the check-run annotations API caps at 10 warnings
+# per level, which on the measured run dropped all ten pin-currency lines
+# (they are emitted at the script's tail). The run log is the only complete
+# surface. See plans/PIN-CURRENCY-READER-PLAN.md §"What the measurements
+# changed" for the four-surface table and its measurements.
+#
+# This script is deliberately pure: a file path in, key=value out. No network,
+# no `gh`, no GitHub context — so it is unit-testable against checked-in
+# fixtures before the workflow that calls it can ever run (both `workflow_run`
+# and `workflow_dispatch` require the file on the default branch).
+#
+# Usage: bash scripts/read-pin-currency-log.sh <path-to-run-log>
+#
+# Emits: verdict, stale_count, canon, stale_files, drift_summary
+#
+# Verdicts (exit 0):
+#   stale       N stale pin(s), N > 0, with a well-formed canon token
+#   clean       all pins current, with a well-formed canon token
+#   unresolved  canon's `curl` of main's VERSION failed; the pin script exits 0
+#               before it ever audits, so there is no verdict to honour
+#   skipped     no verdict line at all — canon's documented `::notice::` skip,
+#               or `stop_uncheckable` exiting before the pin-currency tail
+#
+# Exits NON-ZERO on: a missing/unreadable log, a log with no evidence the drift
+# script ran at all (truncated, empty, or from the wrong run), a verdict line
+# whose canon token is malformed, or two contradictory verdict lines.
+#
+# The malformed-token check is load-bearing, not defensive tidiness. If canon's
+# VERSION fetch returns an error page rather than failing, `ver_cmp` compares
+# non-numeric fields under `2>/dev/null`, every comparison falls through to
+# equal, and the script prints `all pins current ✅` — a false clean. Honouring
+# it would CLOSE the tracking issue on a transient. Filed upstream; guarded here.
+set -uo pipefail
+
+die() { echo "::error::read-pin-currency-log: $*" >&2; exit 1; }
+
+[ $# -eq 1 ] || die "usage: $0 <path-to-run-log>"
+LOG="$1"
+[ -f "$LOG" ] || die "log not found: $LOG"
+[ -s "$LOG" ] || die "log is empty: $LOG"
+
+# `gh run view --log` prefixes every line with "job<TAB>step<TAB>timestamp ".
+# Strip it, then drop the runner's command echoes — those replay the workflow's
+# own `run:` block, comments included, and its comments mention pin-currency.
+#
+# Echoes are identifiable by their colour sequence, which `gh` renders as the
+# two literal characters `^` `[` — NOT as a raw ESC byte. A real download
+# contains zero 0x1b; matching on `$'\x1b'` here would silently filter nothing.
+# Measured against run 30257877863: 0 raw ESC, 68 literal `^[`.
+#
+# Anchoring every match to the start of the stripped message is the second half
+# of the guard: real output begins with `pin-currency:` or a `##[...]` marker.
+MSGS="$(cut -f3- -- "$LOG" | sed -e 's/^[0-9][0-9-]*T[0-9:.]*Z //' | grep -v '\^\[' || true)"
+
+# --- positive evidence that the drift script RAN TO COMPLETION ---------------
+# Without this, a truncated or wrong-run log has no verdict line and would parse
+# as a benign `skipped` — exit 0, no signal — which is precisely the silent
+# failure this whole workflow exists to remove.
+#
+# It must be a TERMINAL marker. The bare `check-standards-drift:` prefix is NOT
+# one: the script emits an opening `repo=… tier=…` header under the same prefix
+# before auditing anything, plus a `cannot check <family>` warning per unreadable
+# control family. In the measured run the first of those lands 24 lines ahead of
+# the pin-currency section, so a log truncated anywhere in between would satisfy
+# a prefix test and report `skipped` while ten stale pins sat in the real run.
+# That window is reachable: `workflow_run: completed` fires while the log
+# archive is still assembling, and a partial archive is non-empty.
+#
+# Both markers below are emitted only at the end: the summary line closes every
+# completed run, and `coverage —` is emitted by `emit_coverage`, which runs both
+# at normal termination and from every `stop_uncheckable` early exit.
+grep -qE '^(##\[[a-z]*\])?check-standards-drift: ([0-9]+ drift,|coverage —)' <<<"$MSGS" \
+  || die "no terminal 'check-standards-drift:' line in $LOG (no summary and no coverage) — truncated, empty, or the wrong run"
+
+drift_summary="$(sed -n 's/^check-standards-drift: \(.*drift,.*\)$/\1/p' <<<"$MSGS" | tail -1)"
+
+# The canon token comes from the audit header, which the pin script prints only
+# once it has resolved a token. An `unresolved` run exits before that line.
+canon="$(sed -n 's/^pin-currency: auditing .* against canon \(.*\)$/\1/p' <<<"$MSGS" | tail -1)"
+
+emit() {
+  printf 'verdict=%s\n'       "$1"
+  printf 'stale_count=%s\n'   "$2"
+  printf 'canon=%s\n'         "$3"
+  printf 'stale_files=%s\n'   "$4"
+  printf 'drift_summary=%s\n' "$drift_summary"
+  exit 0
+}
+
+# --- unresolved, tested BEFORE the no-verdict-line fallback ------------------
+# An `unresolved` log satisfies `skipped`'s definition (it has no verdict line),
+# so checking `skipped` first would swallow it. Order is load-bearing.
+if grep -q '^##\[warning\]pin-currency: could not resolve canon VERSION' <<<"$MSGS"; then
+  emit unresolved 0 "" ""
+fi
+
+stale_line="$(grep -m1 '^pin-currency: [0-9][0-9]* stale pin(s)' <<<"$MSGS" || true)"
+clean_line="$(grep -m1 '^pin-currency: all pins current' <<<"$MSGS" || true)"
+
+[ -n "$stale_line" ] && [ -n "$clean_line" ] \
+  && die "contradictory verdicts in $LOG — both a stale count and 'all pins current'"
+
+# --- no verdict line: canon's documented skip paths --------------------------
+if [ -z "$stale_line" ] && [ -z "$clean_line" ]; then
+  emit skipped 0 "" ""
+fi
+
+# A verdict is only honoured behind a well-formed canon token — see the header.
+[[ "$canon" =~ ^ci/v[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+  || die "verdict line present but canon token is malformed: '${canon}' (expected ci/vX.Y.Z)"
+
+if [ -n "$clean_line" ]; then
+  emit clean 0 "$canon" ""
+fi
+
+stale_count="$(sed -n 's/^pin-currency: \([0-9][0-9]*\) stale pin(s).*/\1/p' <<<"$stale_line")"
+[ "${stale_count:-0}" -gt 0 ] 2>/dev/null \
+  || die "stale verdict line reports ${stale_count:-<unparseable>} stale pins — expected > 0"
+
+# One entry per stale caller, as `<file>@<pinned-tag>`, sorted. Sorted because
+# the reconcile compares this set against the one stored in the issue body to
+# decide whether to comment; an unstable order would comment every run — and
+# `LC_ALL=C` because that comparison spans runs, so a locale difference between
+# two runners would reorder the set and look like a change.
+stale_files="$(
+  sed -n 's/^##\[warning\]pin-currency: \([^ ]*\) pinned @\([^ ]*\) .*/\1@\2/p' <<<"$MSGS" \
+    | LC_ALL=C sort -u | paste -sd, -
+)"
+
+emit stale "$stale_count" "$canon" "$stale_files"

--- a/scripts/reconcile-pin-currency-issue.sh
+++ b/scripts/reconcile-pin-currency-issue.sh
@@ -1,0 +1,367 @@
+#!/usr/bin/env bash
+# reconcile-pin-currency-issue.sh — reconcile exactly ONE tracking issue against
+# a pin-currency verdict produced by scripts/read-pin-currency-log.sh.
+#
+# WHY THIS IS A SCRIPT AND NOT INLINE YAML. `workflow_run` and
+# `workflow_dispatch` both require the workflow file on the DEFAULT BRANCH, so
+# nothing end-to-end runs on the PR branch that introduces it. Extracting the
+# branchy create/edit/reopen/close logic is what makes it testable before merge.
+# This repo has no prior `gh issue create/list/edit/close` usage in any workflow
+# or script, so none of this logic is load-bearing-by-precedent either.
+#
+# Usage:
+#   bash scripts/read-pin-currency-log.sh run.log \
+#     | bash scripts/reconcile-pin-currency-issue.sh --repo O/R --run-url URL
+#
+# Options:
+#   --repo O/R        target repository (default: $GITHUB_REPOSITORY)
+#   --run-url URL     the standards-drift run the verdict came from
+#   --input FILE      read the verdict from FILE instead of stdin
+#   --assignee USER   who to notify (default: $PIN_CURRENCY_ASSIGNEE, else none)
+#   --dry-run         execute reads, PRINT writes instead of running them
+#
+# GH="${GH:-gh}" adopts canon's own injectable-binary pattern
+# (aidoc-flow-ci/sync/check-pin-currency.sh:21). It is what makes the tests real:
+# they substitute a stub that returns a canned `gh issue list` response, so
+# create-vs-edit-vs-reopen is driven by a fixture rather than by a live
+# authenticated read. Without it the test would need `gh`, auth and network —
+# and the suite it registers into runs on EVERY commit via an `always_run`
+# pre-commit hook, so that would fail an offline contributor's commit.
+set -uo pipefail
+
+GH="${GH:-gh}"
+
+# The idempotence key. Do not change it without migrating the existing issue:
+# lookup is an exact title compare, so a renamed title creates a second issue.
+TITLE='CI canon drift — stale @ci/v* pins'
+LABEL='ci'
+STATE_FENCE='pin-currency-state'
+STAMP_PREFIX='last verified '
+
+REPO="${GITHUB_REPOSITORY:-}"
+RUN_URL=""
+INPUT=""
+ASSIGNEE="${PIN_CURRENCY_ASSIGNEE:-}"
+DRY_RUN=0
+
+die() { echo "::error::reconcile-pin-currency-issue: $*" >&2; exit 1; }
+warn() { echo "::warning::reconcile-pin-currency-issue: $*"; }
+note() { echo "::notice::reconcile-pin-currency-issue: $*"; }
+
+# `shift 2` with only one argument left FAILS WITHOUT SHIFTING, and there is no
+# `set -e` here — so a value-less trailing option spins this loop forever. The
+# explicit arity check is what stops a typo from hanging an unattended job.
+need_value() { [ "$1" -ge 2 ] || die "$2 requires a value"; }
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo)     need_value $# --repo;     REPO="$2";     shift 2;;
+    --run-url)  need_value $# --run-url;  RUN_URL="$2";  shift 2;;
+    --input)    need_value $# --input;    INPUT="$2";    shift 2;;
+    --assignee) need_value $# --assignee; ASSIGNEE="$2"; shift 2;;
+    --dry-run) DRY_RUN=1; shift;;
+    *) die "unknown arg: $1";;
+  esac
+done
+[ -n "$REPO" ] || die "--repo is required (or set GITHUB_REPOSITORY)"
+
+# --- read the verdict --------------------------------------------------------
+verdict=""; stale_count=0; canon=""; stale_files=""; drift_summary=""
+while IFS='=' read -r key value; do
+  case "$key" in
+    verdict) verdict="$value";;
+    stale_count) stale_count="$value";;
+    canon) canon="$value";;
+    stale_files) stale_files="$value";;
+    drift_summary) drift_summary="$value";;
+  esac
+done < <(if [ -n "$INPUT" ]; then cat -- "$INPUT"; else cat; fi)
+
+case "$verdict" in
+  stale|clean|unresolved|skipped) ;;
+  *) die "unrecognized verdict: '${verdict}'";;
+esac
+
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# --- gh plumbing -------------------------------------------------------------
+# Reads always execute. Writes are printed under --dry-run so the whole call
+# sequence is assertable without a live API write.
+gh_read() { "$GH" "$@"; }
+gh_write() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf 'DRY-RUN gh %s\n' "$*"
+    return 0
+  fi
+  "$GH" "$@"
+}
+
+# --- find the one issue ------------------------------------------------------
+# NOT `--search`: that goes through a tokenized, eventually-consistent index, so
+# a just-created issue can be invisible and the next run duplicates it. Exact
+# `jq` compare on the title instead.
+#
+# `--state all` because a stale → clean → stale cycle recurs once per canon
+# release (the drift script resolves canon from main's VERSION, which this repo
+# does not control), so `--state open` would create one issue per release rather
+# than reopening one.
+#
+# `--limit 200` is load-bearing: the default is 30 and this repo is past #382,
+# so a long-closed tracking issue falls off the first page, the exact-title
+# compare finds nothing, and the run creates a DUPLICATE. It does age out
+# eventually; raising it is a one-token change when it does.
+#
+# `body` is in the field list because the body is the only persistent store of
+# the previous verdict — the comment trigger compares against it.
+list_err="$(mktemp)"
+found="$(gh_read issue list --repo "$REPO" --state all --limit 200 \
+  --json number,title,state,body \
+  --jq "[.[] | select(.title == \"${TITLE}\")] | first // empty" 2>"$list_err")" \
+  || die "could not list issues on ${REPO}: $(tr '\n' ' ' <"$list_err")"
+rm -f "$list_err"
+
+# Every extraction below is `|| die`, NOT best-effort. `gh --jq` uses gh's own
+# built-in jq, so the guard above passes even when the external `jq` these lines
+# call is broken — and an unchecked failure would leave `issue_number` empty,
+# which is indistinguishable from "no issue has ever existed" and routes
+# straight to CREATE. A read failure must never be able to open a duplicate.
+issue_number=""; issue_state=""; issue_body=""
+if [ -n "$found" ]; then
+  issue_number="$(jq -r '.number' <<<"$found")" \
+    || die "could not parse the issue number out of the list response"
+  issue_state="$(jq -r '.state' <<<"$found" | tr '[:upper:]' '[:lower:]')" \
+    || die "could not parse the issue state out of the list response"
+  # `tr -d '\r'`: a body hand-edited through the GitHub web UI comes back with
+  # CRLF endings (HTML textareas submit them), and the state-block reader below
+  # compares whole lines exactly. Without this, one web edit blanks every
+  # previous-verdict field and the reader comments on every run thereafter.
+  issue_body="$(jq -r '.body // ""' <<<"$found" | tr -d '\r')" \
+    || die "could not parse the issue body out of the list response"
+  case "$issue_number" in
+    ''|*[!0-9]*) die "unusable issue number from the list response: '${issue_number}'";;
+  esac
+fi
+
+# --- the machine-readable state block ---------------------------------------
+# The human-facing prose above it is free to change without affecting the
+# comparison; only these four fields decide whether to comment.
+prev_state() { # $1 = key
+  awk -v k="$1" -v f="$STATE_FENCE" '
+    $0 == "```" f {inside=1; next}
+    inside && $0 == "```" {inside=0}
+    inside && index($0, k "=") == 1 {print substr($0, length(k) + 2)}
+  ' <<<"$issue_body"
+}
+
+render_state_block() {
+  printf '```%s\n' "$STATE_FENCE"
+  printf 'verdict=%s\nstale_count=%s\ncanon=%s\nstale_files=%s\n' \
+    "$verdict" "$stale_count" "$canon" "$stale_files"
+  printf '```\n'
+}
+
+render_table() {
+  [ -n "$stale_files" ] || return 0
+  printf '| Caller | Pinned |\n| --- | --- |\n'
+  tr ',' '\n' <<<"$stale_files" | while IFS='@' read -r file tag; do
+    [ -n "$file" ] && printf '| `%s` | `%s` |\n' "$file" "$tag"
+  done
+  # NO trailing blank line here. Command substitution strips trailing newlines,
+  # so one emitted at this level cannot survive into the heredoc below — the
+  # blank line that terminates the GFM table has to be a literal line THERE.
+  # Without it the remedy paragraph is absorbed into the table as junk rows,
+  # which is every issue this tool opens.
+}
+
+render_body() {
+  cat <<EOF
+## Stale \`@ci/v*\` pins
+
+\`standards-drift\` found **${stale_count}** caller file(s) pinned below canon
+**\`${canon}\`**.
+
+$(render_table)
+
+**Remedy** — re-pin only. Never \`--update\`: that replaces whole caller bodies
+and would clobber this repo's local overrides.
+
+\`\`\`sh
+CI_TAG=${canon} bash install/install.sh ${REPO} --repin
+\`\`\`
+
+The count is per **file**, not per call site — canon's \`sort -u\` collapses two
+same-tag pins in one file to one, so a fully-stale repo reports fewer files than
+it has \`uses:\` lines.
+
+Other drift dimensions this run: \`${drift_summary}\`
+
+Source run: ${RUN_URL:-(not recorded)}
+
+${STAMP_PREFIX}${NOW}
+
+$(render_state_block)
+<sub>Opened and maintained by \`.github/workflows/pin-currency-reader.yml\`.
+Edited in place each run. Do not rename the title — it is the idempotence key.
+Closing this by hand is fine; the next stale reading reopens it.</sub>
+EOF
+}
+
+render_resolved_body() {
+  cat <<EOF
+## \`@ci/v*\` pins are current
+
+Every caller is pinned at or above canon **\`${canon}\`**. Nothing to do.
+
+This issue is reopened automatically the next time \`standards-drift\` reports a
+stale pin — which recurs once per canon release, because the drift script
+resolves canon from \`main\`'s \`VERSION\` rather than anything this repo pins.
+
+Other drift dimensions this run: \`${drift_summary}\`
+
+Source run: ${RUN_URL:-(not recorded)}
+
+${STAMP_PREFIX}${NOW}
+
+$(render_state_block)
+<sub>Opened and maintained by \`.github/workflows/pin-currency-reader.yml\`.
+Do not rename the title — it is the idempotence key.</sub>
+EOF
+}
+
+body_file="$(mktemp)"
+comment_file="$(mktemp)"
+trap 'rm -f "$body_file" "$comment_file"' EXIT
+
+# --- silent verdicts: stamp only --------------------------------------------
+# `unresolved` and `skipped` produce no verdict to act on, but they are exactly
+# the failure modes that made the original signal invisible — so they still
+# write a `last verified` line, making the READER's own staleness visible in the
+# artifact it maintains.
+#
+# The stamp must PRESERVE the state block verbatim. Regenerating the body from
+# the template here would clear the stored stale set, so the next identical
+# `stale` reading would look like clean → stale and emit a spurious comment.
+if [ "$verdict" = unresolved ] || [ "$verdict" = skipped ]; then
+  if [ -z "$issue_number" ]; then
+    # The steady state: creation happens only on `stale`, so with no issue there
+    # is nothing to stamp. Not an error.
+    note "verdict=${verdict} and no tracking issue exists — nothing to stamp"
+    exit 0
+  fi
+  # Replace the stamp in place if present; APPEND it if not. A body that has
+  # been hand-edited may have lost the line, and an awk that only substitutes
+  # would then rewrite the body byte-identically and still report success —
+  # a stamp that silently does nothing, on the one artifact whose whole job is
+  # to make silence visible.
+  awk -v p="$STAMP_PREFIX" -v now="$NOW" '
+    index($0, p) == 1 { print p now; hit = 1; next }
+    { print }
+    END { if (!hit) { print ""; print p now } }
+  ' <<<"$issue_body" >"$body_file"
+  gh_write issue edit "$issue_number" --repo "$REPO" --body-file "$body_file" \
+    || die "could not stamp issue #${issue_number}"
+  note "verdict=${verdict} — stamped issue #${issue_number}, state unchanged"
+  exit 0
+fi
+
+# --- clean -------------------------------------------------------------------
+if [ "$verdict" = clean ]; then
+  if [ -z "$issue_number" ] || [ "$issue_state" != open ]; then
+    note "all pins current — no open tracking issue to close"
+    exit 0
+  fi
+  # NOT render_body — that renders the STALE template, so closing would leave
+  # behind a body headed "Stale @ci/v* pins", reporting 0 stale files and
+  # offering a --repin command, as the artifact's final persisted state.
+  render_resolved_body >"$body_file"
+  gh_write issue edit "$issue_number" --repo "$REPO" --body-file "$body_file" \
+    || warn "could not update body of #${issue_number} before closing"
+  printf 'All \`@ci/v*\` pins are current as of \`%s\` (canon \`%s\`). Closing.\n\nSource run: %s\n' \
+    "$NOW" "$canon" "${RUN_URL:-(not recorded)}" >"$comment_file"
+  gh_write issue comment "$issue_number" --repo "$REPO" --body-file "$comment_file" \
+    || warn "could not comment on #${issue_number}"
+  gh_write issue close "$issue_number" --repo "$REPO" \
+    || die "could not close #${issue_number}"
+  note "all pins current — closed issue #${issue_number}"
+  exit 0
+fi
+
+# --- stale -------------------------------------------------------------------
+render_body >"$body_file"
+
+if [ -z "$issue_number" ]; then
+  # No issue has ever carried this title — create one.
+  #
+  # The label is applied non-fatally BY RETRY, not by `|| true`. `gh issue
+  # create --label ci … || true` would make the whole creation non-fatal,
+  # reintroducing exactly the invisibility this workflow exists to close.
+  # The retry drops ONLY the label. The assignee is not on the create call at
+  # all — see below.
+  if ! create_out="$(gh_write issue create --repo "$REPO" --title "$TITLE" \
+        --label "$LABEL" --body-file "$body_file" 2>&1)"; then
+    warn "create with --label ${LABEL} failed; retrying unlabelled"
+    create_out="$(gh_write issue create --repo "$REPO" --title "$TITLE" \
+      --body-file "$body_file" 2>&1)" \
+      || die "could not create the tracking issue on ${REPO}: ${create_out}"
+  fi
+  printf '%s\n' "$create_out"
+
+  # Assignee is set AFTER creation, never as `--assignee` on the create call:
+  # that flag ERRORS on a non-assignable user, which would fail both the create
+  # AND its unlabelled retry, producing no issue at all. Setting it here makes
+  # the failure non-fatal by construction — the issue exists either way.
+  #
+  # It matters because a `github-actions[bot]` issue notifies only repo
+  # watchers, and a GITHUB_TOKEN-authored event fires no `issues`-triggered
+  # automation, so without an assignee the artifact has no reader — which is
+  # the failure this whole workflow exists to remove, one level up.
+  if [ -n "$ASSIGNEE" ]; then
+    new_ref="$(grep -oE 'https://[^[:space:]]*/issues/[0-9]+' <<<"$create_out" | tail -1)"
+    if [ "$DRY_RUN" -eq 1 ]; then
+      printf 'DRY-RUN gh issue edit <new-issue> --repo %s --add-assignee %s\n' \
+        "$REPO" "$ASSIGNEE"
+    elif [ -n "$new_ref" ]; then
+      gh_write issue edit "$new_ref" --repo "$REPO" --add-assignee "$ASSIGNEE" \
+        || warn "could not assign ${ASSIGNEE}; the issue was created and stands"
+    else
+      warn "could not determine the new issue URL; ${ASSIGNEE} not assigned"
+    fi
+  fi
+  note "opened the tracking issue (${stale_count} stale pin file(s), canon ${canon})"
+  exit 0
+fi
+
+prev_verdict="$(prev_state verdict)"
+prev_count="$(prev_state stale_count)"
+prev_files="$(prev_state stale_files)"
+
+gh_write issue edit "$issue_number" --repo "$REPO" --body-file "$body_file" \
+  || die "could not update issue #${issue_number}"
+
+if [ "$issue_state" != open ]; then
+  # Reopen, never recreate — see the --state all rationale above.
+  gh_write issue reopen "$issue_number" --repo "$REPO" \
+    || die "could not reopen #${issue_number}"
+  printf 'Stale pins are back: **%s** caller file(s) below canon `%s`. Reopening.\n\nSource run: %s\n' \
+    "$stale_count" "$canon" "${RUN_URL:-(not recorded)}" >"$comment_file"
+  gh_write issue comment "$issue_number" --repo "$REPO" --body-file "$comment_file" \
+    || warn "could not comment on #${issue_number}"
+  note "reopened issue #${issue_number}"
+  exit 0
+fi
+
+# Already open. Comment ONLY when the verdict or the stale set actually moved.
+#
+# The trigger is the state block, NOT the body: the body embeds a run URL that
+# changes every week, so body-diffing would comment on every single run. And
+# without the count/set comparison a count going 10 → 15 would be a silent edit
+# with no notification at all, which defeats the point of having an assignee.
+if [ "$prev_count" != "$stale_count" ] || [ "$prev_files" != "$stale_files" ] \
+   || [ "$prev_verdict" != stale ]; then
+  printf 'Stale pin set changed: **%s** → **%s** caller file(s) (canon `%s`).\n\nSource run: %s\n' \
+    "${prev_count:-unknown}" "$stale_count" "$canon" "${RUN_URL:-(not recorded)}" >"$comment_file"
+  gh_write issue comment "$issue_number" --repo "$REPO" --body-file "$comment_file" \
+    || warn "could not comment on #${issue_number}"
+  note "issue #${issue_number} updated and commented (${prev_count:-unknown} → ${stale_count})"
+else
+  note "issue #${issue_number} updated silently (unchanged at ${stale_count} stale file(s))"
+fi

--- a/tests/conformance/test_repo_scripts.py
+++ b/tests/conformance/test_repo_scripts.py
@@ -1,0 +1,53 @@
+"""Registration shim: pull repo-script unit tests into the conformance suite.
+
+WHY THIS FILE EXISTS. `tests/unit/` is executed by no hook and no workflow —
+`.pre-commit-config.yaml` discovers `tests/conformance` only, and the workflows
+run `tests/conformance`, `tests/acceptance/deterministic`,
+`tools/sdd_doc_lint/tests` and Hermes' own suite. `pre_push_check.sh` invokes no
+`unittest` at all. So a test placed under `tests/unit/` proves something once,
+locally, and never again after merge.
+
+`unittest discover -s tests/conformance` walks that directory only, so it cannot
+reach `tests/unit/` by pattern. This module loads the modules it names
+explicitly, via the `load_tests` protocol, so they run wherever the conformance
+suite runs — which includes the `always_run` pre-commit hook and the
+`Framework + platform conformance` required context.
+
+SCOPE, stated honestly: this registers the modules NAMED BELOW, not the
+directory. The other ~30 modules under `tests/unit/` remain unguarded after
+merge. Fixing the class rather than the instance — wiring `tests/unit` into
+`.pre-commit-config.yaml`, or dropping the `|| true` from the two uncalled
+`unittest discover tests/unit` invocations in `tests/scripts/test-plugin.sh` —
+is tracked separately and is the better long-term fix.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Modules under tests/unit/ that must run wherever conformance runs.
+REGISTERED = ("tests.unit.test_pin_currency_reader",)
+
+
+def load_tests(loader, tests, pattern):  # noqa: ARG001 — unittest protocol
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+    for name in REGISTERED:
+        tests.addTests(loader.loadTestsFromName(name))
+    return tests
+
+
+class RegistrationShimTests(unittest.TestCase):
+    def test_every_registered_module_exists(self):
+        """A typo in REGISTERED would otherwise register nothing, silently —
+        `loadTestsFromName` turns an ImportError into a _FailedTest that reports
+        as a failure, but only once the module is actually reached."""
+        for name in REGISTERED:
+            with self.subTest(module=name):
+                relative = Path(*name.split(".")).with_suffix(".py")
+                self.assertTrue(
+                    (REPO_ROOT / relative).is_file(),
+                    f"{name} is registered but {relative} does not exist",
+                )

--- a/tests/unit/fixtures/gh_stub_issue_open.json
+++ b/tests/unit/fixtures/gh_stub_issue_open.json
@@ -1,0 +1,20 @@
+[
+  {
+    "number": 411,
+    "title": "Some unrelated open issue",
+    "state": "OPEN",
+    "body": "Not the tracking issue. Present so the exact-title compare has something to reject."
+  },
+  {
+    "number": 412,
+    "title": "CI canon drift — stale @ci/v* pins",
+    "state": "OPEN",
+    "body": "## Stale `@ci/v*` pins\n\n`standards-drift` found **10** caller file(s) pinned below canon\n**`ci/v2.15.0`**.\n\n| Caller | Pinned |\n| --- | --- |\n| `ai-review.yml` | `ci/v2.14.0` |\n\n**Remedy** — re-pin only.\n\nSource run: https://github.com/vladm3105/aidoc-flow-framework/actions/runs/30257877863\n\nlast verified 2026-07-27T10:30:00Z\n\n```pin-currency-state\nverdict=stale\nstale_count=10\ncanon=ci/v2.15.0\nstale_files=ai-review.yml@ci/v2.14.0,audit-trail.yml@ci/v2.14.0,auto-merge-ai-prs.yml@ci/v2.14.0,composition.yml@ci/v2.14.0,docs-sync.yml@ci/v2.14.0,labeler.yml@ci/v2.14.0,links.yml@ci/v2.14.0,pre-commit.yml@ci/v2.14.0,secret-scan.yml@ci/v2.14.0,standards-drift.yml@ci/v2.14.0\n```\n"
+  },
+  {
+    "number": 380,
+    "title": "CI canon drift — stale @ci/v* pins (old, hand-filed)",
+    "state": "CLOSED",
+    "body": "A near-miss title. The lookup is an EXACT compare, so this must not match."
+  }
+]

--- a/tests/unit/fixtures/standards_drift_clean.log
+++ b/tests/unit/fixtures/standards_drift_clean.log
@@ -1,0 +1,249 @@
+drift / check-standards-drift	UNKNOWN STEP	﻿2026-07-27T10:23:37.5851074Z Current runner version: '2.335.1'
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5886338Z ##[group]Runner Image Provisioner
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5887548Z Hosted Compute Agent
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5888772Z Version: 20260707.563
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5889745Z Commit: 02667638d2b423fbc733a8e32a88b44996a3ba6e
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5890894Z Build Date: 2026-07-07T19:33:50Z
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5892047Z Worker ID: {80b6579b-448e-46a7-b35c-7b87bd7801d7}
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5893153Z Azure Region: eastus2
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5894130Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5896172Z ##[group]Operating System
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5897183Z Ubuntu
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5898295Z 24.04.4
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5899100Z LTS
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5899884Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5900859Z ##[group]Runner Image
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5901824Z Image: ubuntu-24.04
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5902734Z Version: 20260720.247.2
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5904707Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260720.247/images/ubuntu/Ubuntu2404-Readme.md
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5907321Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260720.247
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5909263Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5910983Z ##[group]GITHUB_TOKEN Permissions
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5913749Z Contents: read
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5914616Z Metadata: read
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5915619Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5918725Z Secret source: Actions
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5920187Z Prepare workflow directory
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.6373153Z Prepare all required actions
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.6427058Z Getting action download info
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.8326118Z Download action repository 'actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0' (SHA:9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0)
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.0517227Z Uses: vladm3105/aidoc-flow-ci/.github/workflows/standards-drift.yml@refs/tags/ci/v2.14.0 (8cf9e62e6b62a5d90a3b12dd204ba7b657d69055)
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.0522128Z ##[group] Inputs
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.0522903Z   tier: governance
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.0523945Z   strict: false
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.0524641Z   runner_labels: "ubuntu-latest"
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.0525373Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.0525985Z Complete job name: drift / check-standards-drift
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1366562Z ##[group]Run actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1367573Z with:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1368290Z   repository: vladm3105/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1372535Z   token: ***
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1372991Z   ssh-strict: true
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1373441Z   ssh-user: git
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1373897Z   persist-credentials: true
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1374395Z   clean: true
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1374853Z   sparse-checkout-cone-mode: true
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1375385Z   fetch-depth: 1
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1375827Z   fetch-tags: false
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1376273Z   show-progress: true
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1376728Z   lfs: false
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1377145Z   submodules: false
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1377600Z   set-safe-directory: true
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1378224Z   allow-unsafe-pr-checkout: false
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1379101Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2406935Z Syncing repository: vladm3105/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2409544Z ##[group]Getting Git version info
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2410510Z Working directory is '/home/runner/work/aidoc-flow-framework/aidoc-flow-framework'
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2411824Z [command]/usr/bin/git version
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2432694Z git version 2.54.0
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2453575Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2466074Z Temporarily overriding HOME='/home/runner/work/_temp/28a74eec-37d4-4cd0-99e0-13d3f396c277' before making global git config changes
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2468477Z Adding repository directory to the temporary git global config as a safe directory
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2473066Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/aidoc-flow-framework/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2523410Z Deleting the contents of '/home/runner/work/aidoc-flow-framework/aidoc-flow-framework'
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2527331Z ##[group]Determining repository object format
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2529476Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2530622Z ##[group]Initializing the repository
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2535176Z [command]/usr/bin/git init /home/runner/work/aidoc-flow-framework/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2631114Z hint: Using 'master' as the name for the initial branch. This default branch name
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2632904Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2634669Z hint: to use in all of your new repositories, which will suppress this warning,
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2636135Z hint: call:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2636948Z hint:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2638162Z hint: 	git config --global init.defaultBranch <name>
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2639342Z hint:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2640401Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2641996Z hint: 'development'. The just-created branch can be renamed via this command:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2643443Z hint:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2644350Z hint: 	git branch -m <name>
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2645362Z hint:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2646536Z hint: Disable this message with "git config set advice.defaultBranchName false"
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2648978Z Initialized empty Git repository in /home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git/
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2652407Z [command]/usr/bin/git remote add origin https://github.com/vladm3105/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2691781Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2692608Z ##[group]Disabling automatic garbage collection
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2695517Z [command]/usr/bin/git config --local gc.auto 0
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2728260Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2729196Z ##[group]Setting up auth
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2729755Z Removing SSH command configuration
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2734580Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2770987Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3084667Z Removing HTTP extra header
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3091046Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3122648Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3351149Z Removing includeIf entries pointing to credentials config files
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3356261Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3388977Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3630536Z [command]/usr/bin/git config --file /home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config http.https://github.com/.extraheader AUTHORIZATION: basic ***
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3669359Z [command]/usr/bin/git config --local includeIf.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git.path /home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3700327Z [command]/usr/bin/git config --local includeIf.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git/worktrees/*.path /home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3734154Z [command]/usr/bin/git config --local includeIf.gitdir:/github/workspace/.git.path /github/runner_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3766125Z [command]/usr/bin/git config --local includeIf.gitdir:/github/workspace/.git/worktrees/*.path /github/runner_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3793606Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3800207Z ##[group]Fetching the repository
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3801596Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +2f6479b1a002b7146e7b2ed1729a5753b80cbc26:refs/remotes/origin/main
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1100982Z From https://github.com/vladm3105/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1103286Z  * [new ref]         2f6479b1a002b7146e7b2ed1729a5753b80cbc26 -> origin/main
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1140306Z [command]/usr/bin/git branch --list --remote origin/main
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1169077Z   origin/main
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1178844Z [command]/usr/bin/git rev-parse refs/remotes/origin/main
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1204047Z 2f6479b1a002b7146e7b2ed1729a5753b80cbc26
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1209085Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1210290Z ##[group]Determining the checkout info
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1211780Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1213250Z [command]/usr/bin/git sparse-checkout disable
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1259476Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1289841Z ##[group]Checking out the ref
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1292142Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2466237Z Switched to a new branch 'main'
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2468488Z branch 'main' set up to track 'origin/main'.
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2479281Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2533325Z [command]/usr/bin/git log -1 --format=%H
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2559721Z 2f6479b1a002b7146e7b2ed1729a5753b80cbc26
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2824971Z ##[group]Run set -euo pipefail
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2826448Z ^[[36;1mset -euo pipefail^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2828376Z ^[[36;1m# Resolve the adopted canon tag from the consumer's OWN checked-out^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2830683Z ^[[36;1m# standards-drift caller pin (actions/checkout above put it on disk).^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2833046Z ^[[36;1m# Deterministic and pin-accurate; see the header for why not workflow_ref.^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2835432Z ^[[36;1m# FT-22: brought to the full docs/REPO_STANDARDS.md §4.2a property list —^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2837845Z ^[[36;1m# this workflow pioneered the approach but predated five of its rules.^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2839788Z ^[[36;1m[ -d .github/workflows ] \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2842508Z ^[[36;1m  || { echo "::error::standards-drift: .github/workflows/ not found after checkout — INFRASTRUCTURE error, not a drift verdict."; exit 1; }^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2845237Z ^[[36;1m^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2846652Z ^[[36;1m# Read only real `uses:` lines in files GitHub actually executes: a^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2848899Z ^[[36;1m# *.yml.bak/*.disabled leftover or a commented-out example must never^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2850985Z ^[[36;1m# supply the tag (it would WIN the version sort — verified).^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2852582Z ^[[36;1mset +e^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2854370Z ^[[36;1mUSES_LINES="$(grep -rhE --include='*.yml' --include='*.yaml' '^[[:space:]]*uses:' .github/workflows/)"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2856497Z ^[[36;1mgrc=$?^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2857471Z ^[[36;1mset -e^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2858965Z ^[[36;1m# grep rc: 0=match, 1=no match, >=2=real error (unreadable dir). Without^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2861052Z ^[[36;1m# this split, an I/O error is misreported as "caller not installed".^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2862755Z ^[[36;1m[ "$grc" -le 1 ] \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2865330Z ^[[36;1m  || { echo "::error::standards-drift: could not read .github/workflows/ (grep exit $grc) — INFRASTRUCTURE error, not a drift verdict."; exit 1; }^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2868261Z ^[[36;1m^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2869303Z ^[[36;1mPINS="$(printf '%s\n' "$USES_LINES" \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2871990Z ^[[36;1m  | grep -ohE 'vladm3105/aidoc-flow-ci/\.github/workflows/standards-drift\.yml@([0-9a-f]{40} +# +)?ci/v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?' \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2874615Z ^[[36;1m  | sort -u || true)"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2876022Z ^[[36;1mPIN_COUNT="$(printf '%s' "$PINS" | grep -c . || true)"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2877951Z ^[[36;1m[ "$PIN_COUNT" -ge 1 ] \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2881680Z ^[[36;1m  || { echo "::error::standards-drift: could not find a standards-drift '@ci/vX.Y.Z' pin on a 'uses:' line in .github/workflows/ — is this caller installed from the canon template? INFRASTRUCTURE error, not a drift verdict."; exit 1; }^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2885946Z ^[[36;1m# Fail CLOSED on ambiguity: only one reusable actually runs, so the^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2888132Z ^[[36;1m# correct tag is unknowable from the tree. Picking the highest would^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2890205Z ^[[36;1m# silently compare against a version the repo never adopted.^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2891830Z ^[[36;1m[ "$PIN_COUNT" -eq 1 ] \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2895378Z ^[[36;1m  || { echo "::error::standards-drift: found $PIN_COUNT differing standards-drift pins in .github/workflows/ — resolve to one. INFRASTRUCTURE error, not a drift verdict."; printf '%s\n' "$PINS" | sed 's/^/  /'; exit 1; }^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2899180Z ^[[36;1m^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2900706Z ^[[36;1mCANON_TAG="$(printf '%s' "$PINS" | grep -oE 'ci/v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?')"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2903063Z ^[[36;1mCANON_SHA="$(printf '%s' "$PINS" | grep -oE '@[0-9a-f]{40}' | tr -d '@' || true)"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2904831Z ^[[36;1mcase "$CANON_TAG" in^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2907830Z ^[[36;1m  *-*) echo "::error::standards-drift: pre-release canon pin '${CANON_TAG}' is not supported — pin a released ci/vX.Y.Z tag. INFRASTRUCTURE error, not a drift verdict."; exit 1 ;;^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2911196Z ^[[36;1mesac^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2912589Z ^[[36;1m# SHA-pinned caller → GitHub executes THAT SHA, so fetch from it; the^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2914528Z ^[[36;1m# trailing `# ci/vX.Y.Z` is documentation and can lag.^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2916061Z ^[[36;1mFETCH_REF="${CANON_SHA:-$CANON_TAG}"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2918510Z ^[[36;1mecho "::notice::standards-drift: adopted canon pin vladm3105/aidoc-flow-ci@${CANON_TAG} (fetching at ${FETCH_REF})"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2920831Z ^[[36;1m^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2922127Z ^[[36;1m# The consumer does not ship sync/. Fetch the script from the adopted^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2924171Z ^[[36;1m# canon tag; owner/repo hardcoded to canonical canon (matching the^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2926280Z ^[[36;1m# script's own template + pin-currency fetches, check-standards-drift.sh).^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2928635Z ^[[36;1m# ALWAYS fetch to a fresh temp path — never run a caller-vendored copy^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2930712Z ^[[36;1m# that could shadow the pinned version. The script self-fetches its^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2932808Z ^[[36;1m# check-pin-currency.sh dependency from the same tag (see its tail).^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2934480Z ^[[36;1mSCRIPT="$(mktemp)"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2935621Z ^[[36;1mcurl -fsSL --retry 3 --retry-delay 2 \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2936909Z ^[[36;1m  -o "$SCRIPT" \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2939129Z ^[[36;1m  "https://raw.githubusercontent.com/vladm3105/aidoc-flow-ci/${FETCH_REF}/sync/check-standards-drift.sh" \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2943447Z ^[[36;1m  || { echo "::error::standards-drift: could not fetch check-standards-drift.sh from vladm3105/aidoc-flow-ci@${FETCH_REF} — INFRASTRUCTURE error, not a drift verdict. Re-run."; exit 1; }^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2946646Z ^[[36;1m[ -s "$SCRIPT" ] \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2948607Z ^[[36;1m  || { echo "::error::standards-drift: fetched check-standards-drift.sh is empty"; exit 1; }^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2950516Z ^[[36;1m^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2951836Z ^[[36;1m# --ci-tag pins the comparison base (tier templates + pin-currency) to^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2953955Z ^[[36;1m# the SAME adopted tag — deterministic; the consumer compares against^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2955674Z ^[[36;1m# exactly the version it adopted.^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2957338Z ^[[36;1m# FETCH_REF, not CANON_TAG: the script uses this purely as a^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2959694Z ^[[36;1m# raw.githubusercontent ref for TEMPLATE_BASE + its check-pin-currency^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2962086Z ^[[36;1m# self-fetch, so a 40-hex SHA works identically — and a SHA-pinned^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2964397Z ^[[36;1m# caller must compare against the templates it actually executed, not a^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2966527Z ^[[36;1m# tag whose trailing comment may lag. Identical for plain-tag pins.^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2968975Z ^[[36;1margs=(--tier "$TIER" --repo "$GH_REPO" --ci-tag "$FETCH_REF")^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2971376Z ^[[36;1m[ "$STRICT" = "true" ] && args+=(--strict)^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2973334Z ^[[36;1mbash "$SCRIPT" "${args[@]}"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3028809Z shell: /usr/bin/bash -e {0}
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3029906Z env:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3039995Z   GH_TOKEN: ***
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3040991Z   GH_REPO: vladm3105/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3042181Z   TIER: governance
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3043119Z   STRICT: false
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3044011Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3281173Z ##[notice]standards-drift: adopted canon pin vladm3105/aidoc-flow-ci@ci/v2.14.0 (fetching at ci/v2.14.0)
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.0178638Z check-standards-drift: repo=vladm3105/aidoc-flow-framework tier=governance canon=ci/v2.14.0 branch=main (warning-only)
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.2740952Z ##[warning]check-standards-drift: cannot check branch-protection (needs 'administration: read' on the token (FT-5) — grant it to the drift job (or run with a PAT) to verify branch protection; skipping)
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7063861Z ##[warning]repo-settings.allow_merge_commit: canon=false actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7121461Z ##[warning]repo-settings.allow_squash_merge: canon=true actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7182333Z ##[warning]repo-settings.allow_rebase_merge: canon=false actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7241729Z ##[warning]repo-settings.delete_branch_on_merge: canon=true actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7300247Z ##[warning]repo-settings.allow_auto_merge: canon=true actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7358322Z ##[warning]repo-settings.allow_update_branch: canon=true actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7416594Z ##[warning]repo-settings.squash_merge_commit_title: canon=PR_TITLE actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7473984Z ##[warning]repo-settings.squash_merge_commit_message: canon=PR_BODY actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.9818875Z ##[warning]check-standards-drift: cannot check actions.general (gh api failed (token scope?))
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:41.1524008Z ##[warning]check-standards-drift: cannot check actions.workflow (gh api failed (token scope?))
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:41.3495951Z ##[warning]check-standards-drift: cannot check actions.selected (gh api failed (or allowed_actions != selected))
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.1692883Z pin-currency: auditing ./.github/workflows against canon ci/v2.15.0
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.2467007Z pin-currency: all pins current ✅
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.2481217Z check-standards-drift: 8 drift, 4 fetch/scope error(s), 0 pin error(s) (warning-only)
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.2500000Z ##[warning]check-standards-drift: coverage — verified 2/4 control families (actions, labels); NOT verified: branch-protection, repo-settings. Could not be read (cause is named per-family in the warnings above — commonly insufficient token scope, in which case re-run with an admin PAT or grant 'administration: read'): branch-protection, repo-settings. A green result does NOT mean the unverified families match canon.
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.2686215Z Post job cleanup.
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3528642Z [command]/usr/bin/git version
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3566163Z git version 2.54.0
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3601196Z Temporarily overriding HOME='/home/runner/work/_temp/492cbc0d-7353-4149-8b6c-9ae2dec8756c' before making global git config changes
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3602958Z Adding repository directory to the temporary git global config as a safe directory
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3607231Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/aidoc-flow-framework/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3641264Z Removing SSH command configuration
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3646670Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3681549Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3918047Z Removing HTTP extra header
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3923412Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3959360Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4191878Z Removing includeIf entries pointing to credentials config files
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4198276Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4225800Z includeif.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4226975Z includeif.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git/worktrees/*.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4228137Z includeif.gitdir:/github/workspace/.git.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4228868Z includeif.gitdir:/github/workspace/.git/worktrees/*.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4235750Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4259290Z /home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4269130Z [command]/usr/bin/git config --local --unset includeif.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git.path /home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4304290Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git/worktrees/*.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4327185Z /home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4335931Z [command]/usr/bin/git config --local --unset includeif.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git/worktrees/*.path /home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4367646Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/github/workspace/.git.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4390606Z /github/runner_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4397187Z [command]/usr/bin/git config --local --unset includeif.gitdir:/github/workspace/.git.path /github/runner_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4429335Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/github/workspace/.git/worktrees/*.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4451435Z /github/runner_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4459641Z [command]/usr/bin/git config --local --unset includeif.gitdir:/github/workspace/.git/worktrees/*.path /github/runner_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4492740Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4724501Z Removing credentials config '/home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config'
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4870190Z Cleaning up orphan processes

--- a/tests/unit/fixtures/standards_drift_skipped.log
+++ b/tests/unit/fixtures/standards_drift_skipped.log
@@ -1,0 +1,248 @@
+drift / check-standards-drift	UNKNOWN STEP	﻿2026-07-27T10:23:37.5851074Z Current runner version: '2.335.1'
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5886338Z ##[group]Runner Image Provisioner
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5887548Z Hosted Compute Agent
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5888772Z Version: 20260707.563
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5889745Z Commit: 02667638d2b423fbc733a8e32a88b44996a3ba6e
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5890894Z Build Date: 2026-07-07T19:33:50Z
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5892047Z Worker ID: {80b6579b-448e-46a7-b35c-7b87bd7801d7}
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5893153Z Azure Region: eastus2
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5894130Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5896172Z ##[group]Operating System
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5897183Z Ubuntu
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5898295Z 24.04.4
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5899100Z LTS
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5899884Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5900859Z ##[group]Runner Image
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5901824Z Image: ubuntu-24.04
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5902734Z Version: 20260720.247.2
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5904707Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260720.247/images/ubuntu/Ubuntu2404-Readme.md
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5907321Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260720.247
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5909263Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5910983Z ##[group]GITHUB_TOKEN Permissions
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5913749Z Contents: read
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5914616Z Metadata: read
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5915619Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5918725Z Secret source: Actions
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5920187Z Prepare workflow directory
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.6373153Z Prepare all required actions
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.6427058Z Getting action download info
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.8326118Z Download action repository 'actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0' (SHA:9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0)
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.0517227Z Uses: vladm3105/aidoc-flow-ci/.github/workflows/standards-drift.yml@refs/tags/ci/v2.14.0 (8cf9e62e6b62a5d90a3b12dd204ba7b657d69055)
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.0522128Z ##[group] Inputs
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.0522903Z   tier: governance
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.0523945Z   strict: false
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.0524641Z   runner_labels: "ubuntu-latest"
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.0525373Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.0525985Z Complete job name: drift / check-standards-drift
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1366562Z ##[group]Run actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1367573Z with:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1368290Z   repository: vladm3105/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1372535Z   token: ***
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1372991Z   ssh-strict: true
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1373441Z   ssh-user: git
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1373897Z   persist-credentials: true
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1374395Z   clean: true
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1374853Z   sparse-checkout-cone-mode: true
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1375385Z   fetch-depth: 1
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1375827Z   fetch-tags: false
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1376273Z   show-progress: true
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1376728Z   lfs: false
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1377145Z   submodules: false
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1377600Z   set-safe-directory: true
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1378224Z   allow-unsafe-pr-checkout: false
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1379101Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2406935Z Syncing repository: vladm3105/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2409544Z ##[group]Getting Git version info
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2410510Z Working directory is '/home/runner/work/aidoc-flow-framework/aidoc-flow-framework'
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2411824Z [command]/usr/bin/git version
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2432694Z git version 2.54.0
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2453575Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2466074Z Temporarily overriding HOME='/home/runner/work/_temp/28a74eec-37d4-4cd0-99e0-13d3f396c277' before making global git config changes
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2468477Z Adding repository directory to the temporary git global config as a safe directory
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2473066Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/aidoc-flow-framework/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2523410Z Deleting the contents of '/home/runner/work/aidoc-flow-framework/aidoc-flow-framework'
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2527331Z ##[group]Determining repository object format
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2529476Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2530622Z ##[group]Initializing the repository
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2535176Z [command]/usr/bin/git init /home/runner/work/aidoc-flow-framework/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2631114Z hint: Using 'master' as the name for the initial branch. This default branch name
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2632904Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2634669Z hint: to use in all of your new repositories, which will suppress this warning,
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2636135Z hint: call:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2636948Z hint:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2638162Z hint: 	git config --global init.defaultBranch <name>
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2639342Z hint:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2640401Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2641996Z hint: 'development'. The just-created branch can be renamed via this command:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2643443Z hint:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2644350Z hint: 	git branch -m <name>
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2645362Z hint:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2646536Z hint: Disable this message with "git config set advice.defaultBranchName false"
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2648978Z Initialized empty Git repository in /home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git/
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2652407Z [command]/usr/bin/git remote add origin https://github.com/vladm3105/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2691781Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2692608Z ##[group]Disabling automatic garbage collection
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2695517Z [command]/usr/bin/git config --local gc.auto 0
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2728260Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2729196Z ##[group]Setting up auth
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2729755Z Removing SSH command configuration
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2734580Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2770987Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3084667Z Removing HTTP extra header
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3091046Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3122648Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3351149Z Removing includeIf entries pointing to credentials config files
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3356261Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3388977Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3630536Z [command]/usr/bin/git config --file /home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config http.https://github.com/.extraheader AUTHORIZATION: basic ***
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3669359Z [command]/usr/bin/git config --local includeIf.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git.path /home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3700327Z [command]/usr/bin/git config --local includeIf.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git/worktrees/*.path /home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3734154Z [command]/usr/bin/git config --local includeIf.gitdir:/github/workspace/.git.path /github/runner_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3766125Z [command]/usr/bin/git config --local includeIf.gitdir:/github/workspace/.git/worktrees/*.path /github/runner_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3793606Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3800207Z ##[group]Fetching the repository
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3801596Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +2f6479b1a002b7146e7b2ed1729a5753b80cbc26:refs/remotes/origin/main
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1100982Z From https://github.com/vladm3105/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1103286Z  * [new ref]         2f6479b1a002b7146e7b2ed1729a5753b80cbc26 -> origin/main
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1140306Z [command]/usr/bin/git branch --list --remote origin/main
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1169077Z   origin/main
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1178844Z [command]/usr/bin/git rev-parse refs/remotes/origin/main
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1204047Z 2f6479b1a002b7146e7b2ed1729a5753b80cbc26
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1209085Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1210290Z ##[group]Determining the checkout info
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1211780Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1213250Z [command]/usr/bin/git sparse-checkout disable
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1259476Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1289841Z ##[group]Checking out the ref
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1292142Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2466237Z Switched to a new branch 'main'
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2468488Z branch 'main' set up to track 'origin/main'.
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2479281Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2533325Z [command]/usr/bin/git log -1 --format=%H
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2559721Z 2f6479b1a002b7146e7b2ed1729a5753b80cbc26
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2824971Z ##[group]Run set -euo pipefail
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2826448Z ^[[36;1mset -euo pipefail^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2828376Z ^[[36;1m# Resolve the adopted canon tag from the consumer's OWN checked-out^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2830683Z ^[[36;1m# standards-drift caller pin (actions/checkout above put it on disk).^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2833046Z ^[[36;1m# Deterministic and pin-accurate; see the header for why not workflow_ref.^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2835432Z ^[[36;1m# FT-22: brought to the full docs/REPO_STANDARDS.md §4.2a property list —^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2837845Z ^[[36;1m# this workflow pioneered the approach but predated five of its rules.^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2839788Z ^[[36;1m[ -d .github/workflows ] \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2842508Z ^[[36;1m  || { echo "::error::standards-drift: .github/workflows/ not found after checkout — INFRASTRUCTURE error, not a drift verdict."; exit 1; }^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2845237Z ^[[36;1m^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2846652Z ^[[36;1m# Read only real `uses:` lines in files GitHub actually executes: a^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2848899Z ^[[36;1m# *.yml.bak/*.disabled leftover or a commented-out example must never^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2850985Z ^[[36;1m# supply the tag (it would WIN the version sort — verified).^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2852582Z ^[[36;1mset +e^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2854370Z ^[[36;1mUSES_LINES="$(grep -rhE --include='*.yml' --include='*.yaml' '^[[:space:]]*uses:' .github/workflows/)"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2856497Z ^[[36;1mgrc=$?^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2857471Z ^[[36;1mset -e^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2858965Z ^[[36;1m# grep rc: 0=match, 1=no match, >=2=real error (unreadable dir). Without^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2861052Z ^[[36;1m# this split, an I/O error is misreported as "caller not installed".^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2862755Z ^[[36;1m[ "$grc" -le 1 ] \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2865330Z ^[[36;1m  || { echo "::error::standards-drift: could not read .github/workflows/ (grep exit $grc) — INFRASTRUCTURE error, not a drift verdict."; exit 1; }^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2868261Z ^[[36;1m^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2869303Z ^[[36;1mPINS="$(printf '%s\n' "$USES_LINES" \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2871990Z ^[[36;1m  | grep -ohE 'vladm3105/aidoc-flow-ci/\.github/workflows/standards-drift\.yml@([0-9a-f]{40} +# +)?ci/v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?' \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2874615Z ^[[36;1m  | sort -u || true)"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2876022Z ^[[36;1mPIN_COUNT="$(printf '%s' "$PINS" | grep -c . || true)"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2877951Z ^[[36;1m[ "$PIN_COUNT" -ge 1 ] \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2881680Z ^[[36;1m  || { echo "::error::standards-drift: could not find a standards-drift '@ci/vX.Y.Z' pin on a 'uses:' line in .github/workflows/ — is this caller installed from the canon template? INFRASTRUCTURE error, not a drift verdict."; exit 1; }^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2885946Z ^[[36;1m# Fail CLOSED on ambiguity: only one reusable actually runs, so the^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2888132Z ^[[36;1m# correct tag is unknowable from the tree. Picking the highest would^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2890205Z ^[[36;1m# silently compare against a version the repo never adopted.^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2891830Z ^[[36;1m[ "$PIN_COUNT" -eq 1 ] \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2895378Z ^[[36;1m  || { echo "::error::standards-drift: found $PIN_COUNT differing standards-drift pins in .github/workflows/ — resolve to one. INFRASTRUCTURE error, not a drift verdict."; printf '%s\n' "$PINS" | sed 's/^/  /'; exit 1; }^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2899180Z ^[[36;1m^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2900706Z ^[[36;1mCANON_TAG="$(printf '%s' "$PINS" | grep -oE 'ci/v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?')"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2903063Z ^[[36;1mCANON_SHA="$(printf '%s' "$PINS" | grep -oE '@[0-9a-f]{40}' | tr -d '@' || true)"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2904831Z ^[[36;1mcase "$CANON_TAG" in^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2907830Z ^[[36;1m  *-*) echo "::error::standards-drift: pre-release canon pin '${CANON_TAG}' is not supported — pin a released ci/vX.Y.Z tag. INFRASTRUCTURE error, not a drift verdict."; exit 1 ;;^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2911196Z ^[[36;1mesac^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2912589Z ^[[36;1m# SHA-pinned caller → GitHub executes THAT SHA, so fetch from it; the^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2914528Z ^[[36;1m# trailing `# ci/vX.Y.Z` is documentation and can lag.^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2916061Z ^[[36;1mFETCH_REF="${CANON_SHA:-$CANON_TAG}"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2918510Z ^[[36;1mecho "::notice::standards-drift: adopted canon pin vladm3105/aidoc-flow-ci@${CANON_TAG} (fetching at ${FETCH_REF})"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2920831Z ^[[36;1m^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2922127Z ^[[36;1m# The consumer does not ship sync/. Fetch the script from the adopted^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2924171Z ^[[36;1m# canon tag; owner/repo hardcoded to canonical canon (matching the^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2926280Z ^[[36;1m# script's own template + pin-currency fetches, check-standards-drift.sh).^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2928635Z ^[[36;1m# ALWAYS fetch to a fresh temp path — never run a caller-vendored copy^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2930712Z ^[[36;1m# that could shadow the pinned version. The script self-fetches its^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2932808Z ^[[36;1m# check-pin-currency.sh dependency from the same tag (see its tail).^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2934480Z ^[[36;1mSCRIPT="$(mktemp)"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2935621Z ^[[36;1mcurl -fsSL --retry 3 --retry-delay 2 \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2936909Z ^[[36;1m  -o "$SCRIPT" \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2939129Z ^[[36;1m  "https://raw.githubusercontent.com/vladm3105/aidoc-flow-ci/${FETCH_REF}/sync/check-standards-drift.sh" \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2943447Z ^[[36;1m  || { echo "::error::standards-drift: could not fetch check-standards-drift.sh from vladm3105/aidoc-flow-ci@${FETCH_REF} — INFRASTRUCTURE error, not a drift verdict. Re-run."; exit 1; }^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2946646Z ^[[36;1m[ -s "$SCRIPT" ] \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2948607Z ^[[36;1m  || { echo "::error::standards-drift: fetched check-standards-drift.sh is empty"; exit 1; }^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2950516Z ^[[36;1m^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2951836Z ^[[36;1m# --ci-tag pins the comparison base (tier templates + pin-currency) to^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2953955Z ^[[36;1m# the SAME adopted tag — deterministic; the consumer compares against^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2955674Z ^[[36;1m# exactly the version it adopted.^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2957338Z ^[[36;1m# FETCH_REF, not CANON_TAG: the script uses this purely as a^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2959694Z ^[[36;1m# raw.githubusercontent ref for TEMPLATE_BASE + its check-pin-currency^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2962086Z ^[[36;1m# self-fetch, so a 40-hex SHA works identically — and a SHA-pinned^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2964397Z ^[[36;1m# caller must compare against the templates it actually executed, not a^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2966527Z ^[[36;1m# tag whose trailing comment may lag. Identical for plain-tag pins.^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2968975Z ^[[36;1margs=(--tier "$TIER" --repo "$GH_REPO" --ci-tag "$FETCH_REF")^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2971376Z ^[[36;1m[ "$STRICT" = "true" ] && args+=(--strict)^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2973334Z ^[[36;1mbash "$SCRIPT" "${args[@]}"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3028809Z shell: /usr/bin/bash -e {0}
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3029906Z env:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3039995Z   GH_TOKEN: ***
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3040991Z   GH_REPO: vladm3105/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3042181Z   TIER: governance
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3043119Z   STRICT: false
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3044011Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3281173Z ##[notice]standards-drift: adopted canon pin vladm3105/aidoc-flow-ci@ci/v2.14.0 (fetching at ci/v2.14.0)
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.0178638Z check-standards-drift: repo=vladm3105/aidoc-flow-framework tier=governance canon=ci/v2.14.0 branch=main (warning-only)
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.2740952Z ##[warning]check-standards-drift: cannot check branch-protection (needs 'administration: read' on the token (FT-5) — grant it to the drift job (or run with a PAT) to verify branch protection; skipping)
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7063861Z ##[warning]repo-settings.allow_merge_commit: canon=false actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7121461Z ##[warning]repo-settings.allow_squash_merge: canon=true actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7182333Z ##[warning]repo-settings.allow_rebase_merge: canon=false actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7241729Z ##[warning]repo-settings.delete_branch_on_merge: canon=true actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7300247Z ##[warning]repo-settings.allow_auto_merge: canon=true actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7358322Z ##[warning]repo-settings.allow_update_branch: canon=true actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7416594Z ##[warning]repo-settings.squash_merge_commit_title: canon=PR_TITLE actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7473984Z ##[warning]repo-settings.squash_merge_commit_message: canon=PR_BODY actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.9818875Z ##[warning]check-standards-drift: cannot check actions.general (gh api failed (token scope?))
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:41.1524008Z ##[warning]check-standards-drift: cannot check actions.workflow (gh api failed (token scope?))
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:41.3495951Z ##[warning]check-standards-drift: cannot check actions.selected (gh api failed (or allowed_actions != selected))
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.1692883Z ##[notice]check-standards-drift: check-pin-currency.sh not available at ci/v2.16.0 — skipping pin-currency (re-pin standards-drift to a release that includes it)
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.2481217Z check-standards-drift: 8 drift, 4 fetch/scope error(s), 0 pin error(s) (warning-only)
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.2500000Z ##[warning]check-standards-drift: coverage — verified 2/4 control families (actions, labels); NOT verified: branch-protection, repo-settings. Could not be read (cause is named per-family in the warnings above — commonly insufficient token scope, in which case re-run with an admin PAT or grant 'administration: read'): branch-protection, repo-settings. A green result does NOT mean the unverified families match canon.
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.2686215Z Post job cleanup.
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3528642Z [command]/usr/bin/git version
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3566163Z git version 2.54.0
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3601196Z Temporarily overriding HOME='/home/runner/work/_temp/492cbc0d-7353-4149-8b6c-9ae2dec8756c' before making global git config changes
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3602958Z Adding repository directory to the temporary git global config as a safe directory
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3607231Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/aidoc-flow-framework/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3641264Z Removing SSH command configuration
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3646670Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3681549Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3918047Z Removing HTTP extra header
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3923412Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3959360Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4191878Z Removing includeIf entries pointing to credentials config files
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4198276Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4225800Z includeif.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4226975Z includeif.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git/worktrees/*.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4228137Z includeif.gitdir:/github/workspace/.git.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4228868Z includeif.gitdir:/github/workspace/.git/worktrees/*.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4235750Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4259290Z /home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4269130Z [command]/usr/bin/git config --local --unset includeif.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git.path /home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4304290Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git/worktrees/*.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4327185Z /home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4335931Z [command]/usr/bin/git config --local --unset includeif.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git/worktrees/*.path /home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4367646Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/github/workspace/.git.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4390606Z /github/runner_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4397187Z [command]/usr/bin/git config --local --unset includeif.gitdir:/github/workspace/.git.path /github/runner_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4429335Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/github/workspace/.git/worktrees/*.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4451435Z /github/runner_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4459641Z [command]/usr/bin/git config --local --unset includeif.gitdir:/github/workspace/.git/worktrees/*.path /github/runner_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4492740Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4724501Z Removing credentials config '/home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config'
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4870190Z Cleaning up orphan processes

--- a/tests/unit/fixtures/standards_drift_stale.log
+++ b/tests/unit/fixtures/standards_drift_stale.log
@@ -1,0 +1,259 @@
+drift / check-standards-drift	UNKNOWN STEP	﻿2026-07-27T10:23:37.5851074Z Current runner version: '2.335.1'
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5886338Z ##[group]Runner Image Provisioner
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5887548Z Hosted Compute Agent
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5888772Z Version: 20260707.563
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5889745Z Commit: 02667638d2b423fbc733a8e32a88b44996a3ba6e
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5890894Z Build Date: 2026-07-07T19:33:50Z
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5892047Z Worker ID: {80b6579b-448e-46a7-b35c-7b87bd7801d7}
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5893153Z Azure Region: eastus2
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5894130Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5896172Z ##[group]Operating System
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5897183Z Ubuntu
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5898295Z 24.04.4
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5899100Z LTS
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5899884Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5900859Z ##[group]Runner Image
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5901824Z Image: ubuntu-24.04
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5902734Z Version: 20260720.247.2
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5904707Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260720.247/images/ubuntu/Ubuntu2404-Readme.md
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5907321Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260720.247
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5909263Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5910983Z ##[group]GITHUB_TOKEN Permissions
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5913749Z Contents: read
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5914616Z Metadata: read
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5915619Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5918725Z Secret source: Actions
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5920187Z Prepare workflow directory
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.6373153Z Prepare all required actions
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.6427058Z Getting action download info
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.8326118Z Download action repository 'actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0' (SHA:9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0)
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.0517227Z Uses: vladm3105/aidoc-flow-ci/.github/workflows/standards-drift.yml@refs/tags/ci/v2.14.0 (8cf9e62e6b62a5d90a3b12dd204ba7b657d69055)
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.0522128Z ##[group] Inputs
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.0522903Z   tier: governance
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.0523945Z   strict: false
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.0524641Z   runner_labels: "ubuntu-latest"
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.0525373Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.0525985Z Complete job name: drift / check-standards-drift
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1366562Z ##[group]Run actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1367573Z with:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1368290Z   repository: vladm3105/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1372535Z   token: ***
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1372991Z   ssh-strict: true
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1373441Z   ssh-user: git
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1373897Z   persist-credentials: true
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1374395Z   clean: true
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1374853Z   sparse-checkout-cone-mode: true
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1375385Z   fetch-depth: 1
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1375827Z   fetch-tags: false
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1376273Z   show-progress: true
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1376728Z   lfs: false
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1377145Z   submodules: false
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1377600Z   set-safe-directory: true
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1378224Z   allow-unsafe-pr-checkout: false
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1379101Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2406935Z Syncing repository: vladm3105/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2409544Z ##[group]Getting Git version info
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2410510Z Working directory is '/home/runner/work/aidoc-flow-framework/aidoc-flow-framework'
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2411824Z [command]/usr/bin/git version
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2432694Z git version 2.54.0
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2453575Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2466074Z Temporarily overriding HOME='/home/runner/work/_temp/28a74eec-37d4-4cd0-99e0-13d3f396c277' before making global git config changes
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2468477Z Adding repository directory to the temporary git global config as a safe directory
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2473066Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/aidoc-flow-framework/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2523410Z Deleting the contents of '/home/runner/work/aidoc-flow-framework/aidoc-flow-framework'
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2527331Z ##[group]Determining repository object format
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2529476Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2530622Z ##[group]Initializing the repository
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2535176Z [command]/usr/bin/git init /home/runner/work/aidoc-flow-framework/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2631114Z hint: Using 'master' as the name for the initial branch. This default branch name
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2632904Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2634669Z hint: to use in all of your new repositories, which will suppress this warning,
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2636135Z hint: call:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2636948Z hint:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2638162Z hint: 	git config --global init.defaultBranch <name>
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2639342Z hint:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2640401Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2641996Z hint: 'development'. The just-created branch can be renamed via this command:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2643443Z hint:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2644350Z hint: 	git branch -m <name>
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2645362Z hint:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2646536Z hint: Disable this message with "git config set advice.defaultBranchName false"
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2648978Z Initialized empty Git repository in /home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git/
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2652407Z [command]/usr/bin/git remote add origin https://github.com/vladm3105/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2691781Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2692608Z ##[group]Disabling automatic garbage collection
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2695517Z [command]/usr/bin/git config --local gc.auto 0
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2728260Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2729196Z ##[group]Setting up auth
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2729755Z Removing SSH command configuration
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2734580Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2770987Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3084667Z Removing HTTP extra header
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3091046Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3122648Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3351149Z Removing includeIf entries pointing to credentials config files
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3356261Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3388977Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3630536Z [command]/usr/bin/git config --file /home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config http.https://github.com/.extraheader AUTHORIZATION: basic ***
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3669359Z [command]/usr/bin/git config --local includeIf.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git.path /home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3700327Z [command]/usr/bin/git config --local includeIf.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git/worktrees/*.path /home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3734154Z [command]/usr/bin/git config --local includeIf.gitdir:/github/workspace/.git.path /github/runner_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3766125Z [command]/usr/bin/git config --local includeIf.gitdir:/github/workspace/.git/worktrees/*.path /github/runner_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3793606Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3800207Z ##[group]Fetching the repository
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3801596Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +2f6479b1a002b7146e7b2ed1729a5753b80cbc26:refs/remotes/origin/main
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1100982Z From https://github.com/vladm3105/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1103286Z  * [new ref]         2f6479b1a002b7146e7b2ed1729a5753b80cbc26 -> origin/main
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1140306Z [command]/usr/bin/git branch --list --remote origin/main
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1169077Z   origin/main
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1178844Z [command]/usr/bin/git rev-parse refs/remotes/origin/main
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1204047Z 2f6479b1a002b7146e7b2ed1729a5753b80cbc26
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1209085Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1210290Z ##[group]Determining the checkout info
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1211780Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1213250Z [command]/usr/bin/git sparse-checkout disable
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1259476Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1289841Z ##[group]Checking out the ref
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1292142Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2466237Z Switched to a new branch 'main'
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2468488Z branch 'main' set up to track 'origin/main'.
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2479281Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2533325Z [command]/usr/bin/git log -1 --format=%H
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2559721Z 2f6479b1a002b7146e7b2ed1729a5753b80cbc26
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2824971Z ##[group]Run set -euo pipefail
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2826448Z ^[[36;1mset -euo pipefail^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2828376Z ^[[36;1m# Resolve the adopted canon tag from the consumer's OWN checked-out^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2830683Z ^[[36;1m# standards-drift caller pin (actions/checkout above put it on disk).^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2833046Z ^[[36;1m# Deterministic and pin-accurate; see the header for why not workflow_ref.^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2835432Z ^[[36;1m# FT-22: brought to the full docs/REPO_STANDARDS.md §4.2a property list —^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2837845Z ^[[36;1m# this workflow pioneered the approach but predated five of its rules.^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2839788Z ^[[36;1m[ -d .github/workflows ] \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2842508Z ^[[36;1m  || { echo "::error::standards-drift: .github/workflows/ not found after checkout — INFRASTRUCTURE error, not a drift verdict."; exit 1; }^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2845237Z ^[[36;1m^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2846652Z ^[[36;1m# Read only real `uses:` lines in files GitHub actually executes: a^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2848899Z ^[[36;1m# *.yml.bak/*.disabled leftover or a commented-out example must never^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2850985Z ^[[36;1m# supply the tag (it would WIN the version sort — verified).^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2852582Z ^[[36;1mset +e^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2854370Z ^[[36;1mUSES_LINES="$(grep -rhE --include='*.yml' --include='*.yaml' '^[[:space:]]*uses:' .github/workflows/)"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2856497Z ^[[36;1mgrc=$?^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2857471Z ^[[36;1mset -e^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2858965Z ^[[36;1m# grep rc: 0=match, 1=no match, >=2=real error (unreadable dir). Without^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2861052Z ^[[36;1m# this split, an I/O error is misreported as "caller not installed".^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2862755Z ^[[36;1m[ "$grc" -le 1 ] \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2865330Z ^[[36;1m  || { echo "::error::standards-drift: could not read .github/workflows/ (grep exit $grc) — INFRASTRUCTURE error, not a drift verdict."; exit 1; }^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2868261Z ^[[36;1m^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2869303Z ^[[36;1mPINS="$(printf '%s\n' "$USES_LINES" \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2871990Z ^[[36;1m  | grep -ohE 'vladm3105/aidoc-flow-ci/\.github/workflows/standards-drift\.yml@([0-9a-f]{40} +# +)?ci/v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?' \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2874615Z ^[[36;1m  | sort -u || true)"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2876022Z ^[[36;1mPIN_COUNT="$(printf '%s' "$PINS" | grep -c . || true)"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2877951Z ^[[36;1m[ "$PIN_COUNT" -ge 1 ] \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2881680Z ^[[36;1m  || { echo "::error::standards-drift: could not find a standards-drift '@ci/vX.Y.Z' pin on a 'uses:' line in .github/workflows/ — is this caller installed from the canon template? INFRASTRUCTURE error, not a drift verdict."; exit 1; }^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2885946Z ^[[36;1m# Fail CLOSED on ambiguity: only one reusable actually runs, so the^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2888132Z ^[[36;1m# correct tag is unknowable from the tree. Picking the highest would^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2890205Z ^[[36;1m# silently compare against a version the repo never adopted.^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2891830Z ^[[36;1m[ "$PIN_COUNT" -eq 1 ] \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2895378Z ^[[36;1m  || { echo "::error::standards-drift: found $PIN_COUNT differing standards-drift pins in .github/workflows/ — resolve to one. INFRASTRUCTURE error, not a drift verdict."; printf '%s\n' "$PINS" | sed 's/^/  /'; exit 1; }^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2899180Z ^[[36;1m^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2900706Z ^[[36;1mCANON_TAG="$(printf '%s' "$PINS" | grep -oE 'ci/v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?')"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2903063Z ^[[36;1mCANON_SHA="$(printf '%s' "$PINS" | grep -oE '@[0-9a-f]{40}' | tr -d '@' || true)"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2904831Z ^[[36;1mcase "$CANON_TAG" in^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2907830Z ^[[36;1m  *-*) echo "::error::standards-drift: pre-release canon pin '${CANON_TAG}' is not supported — pin a released ci/vX.Y.Z tag. INFRASTRUCTURE error, not a drift verdict."; exit 1 ;;^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2911196Z ^[[36;1mesac^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2912589Z ^[[36;1m# SHA-pinned caller → GitHub executes THAT SHA, so fetch from it; the^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2914528Z ^[[36;1m# trailing `# ci/vX.Y.Z` is documentation and can lag.^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2916061Z ^[[36;1mFETCH_REF="${CANON_SHA:-$CANON_TAG}"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2918510Z ^[[36;1mecho "::notice::standards-drift: adopted canon pin vladm3105/aidoc-flow-ci@${CANON_TAG} (fetching at ${FETCH_REF})"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2920831Z ^[[36;1m^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2922127Z ^[[36;1m# The consumer does not ship sync/. Fetch the script from the adopted^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2924171Z ^[[36;1m# canon tag; owner/repo hardcoded to canonical canon (matching the^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2926280Z ^[[36;1m# script's own template + pin-currency fetches, check-standards-drift.sh).^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2928635Z ^[[36;1m# ALWAYS fetch to a fresh temp path — never run a caller-vendored copy^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2930712Z ^[[36;1m# that could shadow the pinned version. The script self-fetches its^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2932808Z ^[[36;1m# check-pin-currency.sh dependency from the same tag (see its tail).^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2934480Z ^[[36;1mSCRIPT="$(mktemp)"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2935621Z ^[[36;1mcurl -fsSL --retry 3 --retry-delay 2 \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2936909Z ^[[36;1m  -o "$SCRIPT" \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2939129Z ^[[36;1m  "https://raw.githubusercontent.com/vladm3105/aidoc-flow-ci/${FETCH_REF}/sync/check-standards-drift.sh" \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2943447Z ^[[36;1m  || { echo "::error::standards-drift: could not fetch check-standards-drift.sh from vladm3105/aidoc-flow-ci@${FETCH_REF} — INFRASTRUCTURE error, not a drift verdict. Re-run."; exit 1; }^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2946646Z ^[[36;1m[ -s "$SCRIPT" ] \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2948607Z ^[[36;1m  || { echo "::error::standards-drift: fetched check-standards-drift.sh is empty"; exit 1; }^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2950516Z ^[[36;1m^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2951836Z ^[[36;1m# --ci-tag pins the comparison base (tier templates + pin-currency) to^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2953955Z ^[[36;1m# the SAME adopted tag — deterministic; the consumer compares against^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2955674Z ^[[36;1m# exactly the version it adopted.^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2957338Z ^[[36;1m# FETCH_REF, not CANON_TAG: the script uses this purely as a^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2959694Z ^[[36;1m# raw.githubusercontent ref for TEMPLATE_BASE + its check-pin-currency^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2962086Z ^[[36;1m# self-fetch, so a 40-hex SHA works identically — and a SHA-pinned^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2964397Z ^[[36;1m# caller must compare against the templates it actually executed, not a^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2966527Z ^[[36;1m# tag whose trailing comment may lag. Identical for plain-tag pins.^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2968975Z ^[[36;1margs=(--tier "$TIER" --repo "$GH_REPO" --ci-tag "$FETCH_REF")^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2971376Z ^[[36;1m[ "$STRICT" = "true" ] && args+=(--strict)^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2973334Z ^[[36;1mbash "$SCRIPT" "${args[@]}"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3028809Z shell: /usr/bin/bash -e {0}
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3029906Z env:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3039995Z   GH_TOKEN: ***
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3040991Z   GH_REPO: vladm3105/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3042181Z   TIER: governance
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3043119Z   STRICT: false
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3044011Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3281173Z ##[notice]standards-drift: adopted canon pin vladm3105/aidoc-flow-ci@ci/v2.14.0 (fetching at ci/v2.14.0)
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.0178638Z check-standards-drift: repo=vladm3105/aidoc-flow-framework tier=governance canon=ci/v2.14.0 branch=main (warning-only)
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.2740952Z ##[warning]check-standards-drift: cannot check branch-protection (needs 'administration: read' on the token (FT-5) — grant it to the drift job (or run with a PAT) to verify branch protection; skipping)
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7063861Z ##[warning]repo-settings.allow_merge_commit: canon=false actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7121461Z ##[warning]repo-settings.allow_squash_merge: canon=true actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7182333Z ##[warning]repo-settings.allow_rebase_merge: canon=false actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7241729Z ##[warning]repo-settings.delete_branch_on_merge: canon=true actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7300247Z ##[warning]repo-settings.allow_auto_merge: canon=true actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7358322Z ##[warning]repo-settings.allow_update_branch: canon=true actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7416594Z ##[warning]repo-settings.squash_merge_commit_title: canon=PR_TITLE actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7473984Z ##[warning]repo-settings.squash_merge_commit_message: canon=PR_BODY actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.9818875Z ##[warning]check-standards-drift: cannot check actions.general (gh api failed (token scope?))
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:41.1524008Z ##[warning]check-standards-drift: cannot check actions.workflow (gh api failed (token scope?))
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:41.3495951Z ##[warning]check-standards-drift: cannot check actions.selected (gh api failed (or allowed_actions != selected))
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.1692883Z pin-currency: auditing ./.github/workflows against canon ci/v2.15.0
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.1752545Z ##[warning]pin-currency: ai-review.yml pinned @ci/v2.14.0 (canon ci/v2.15.0) — re-pin
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.1809609Z ##[warning]pin-currency: audit-trail.yml pinned @ci/v2.14.0 (canon ci/v2.15.0) — re-pin
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.1866153Z ##[warning]pin-currency: auto-merge-ai-prs.yml pinned @ci/v2.14.0 (canon ci/v2.15.0) — re-pin
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.1993801Z ##[warning]pin-currency: composition.yml pinned @ci/v2.14.0 (canon ci/v2.15.0) — re-pin
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.2123727Z ##[warning]pin-currency: docs-sync.yml pinned @ci/v2.14.0 (canon ci/v2.15.0) — re-pin
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.2214414Z ##[warning]pin-currency: labeler.yml pinned @ci/v2.14.0 (canon ci/v2.15.0) — re-pin
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.2269149Z ##[warning]pin-currency: links.yml pinned @ci/v2.14.0 (canon ci/v2.15.0) — re-pin
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.2357623Z ##[warning]pin-currency: pre-commit.yml pinned @ci/v2.14.0 (canon ci/v2.15.0) — re-pin
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.2410537Z ##[warning]pin-currency: secret-scan.yml pinned @ci/v2.14.0 (canon ci/v2.15.0) — re-pin
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.2465003Z ##[warning]pin-currency: standards-drift.yml pinned @ci/v2.14.0 (canon ci/v2.15.0) — re-pin
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.2467007Z pin-currency: 10 stale pin(s) — run 'install/install.sh <this-repo> --repin' (warning-only)
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.2481217Z check-standards-drift: 8 drift, 4 fetch/scope error(s), 0 pin error(s) (warning-only)
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.2500000Z ##[warning]check-standards-drift: coverage — verified 2/4 control families (actions, labels); NOT verified: branch-protection, repo-settings. Could not be read (cause is named per-family in the warnings above — commonly insufficient token scope, in which case re-run with an admin PAT or grant 'administration: read'): branch-protection, repo-settings. A green result does NOT mean the unverified families match canon.
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.2686215Z Post job cleanup.
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3528642Z [command]/usr/bin/git version
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3566163Z git version 2.54.0
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3601196Z Temporarily overriding HOME='/home/runner/work/_temp/492cbc0d-7353-4149-8b6c-9ae2dec8756c' before making global git config changes
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3602958Z Adding repository directory to the temporary git global config as a safe directory
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3607231Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/aidoc-flow-framework/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3641264Z Removing SSH command configuration
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3646670Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3681549Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3918047Z Removing HTTP extra header
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3923412Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3959360Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4191878Z Removing includeIf entries pointing to credentials config files
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4198276Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4225800Z includeif.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4226975Z includeif.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git/worktrees/*.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4228137Z includeif.gitdir:/github/workspace/.git.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4228868Z includeif.gitdir:/github/workspace/.git/worktrees/*.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4235750Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4259290Z /home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4269130Z [command]/usr/bin/git config --local --unset includeif.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git.path /home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4304290Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git/worktrees/*.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4327185Z /home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4335931Z [command]/usr/bin/git config --local --unset includeif.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git/worktrees/*.path /home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4367646Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/github/workspace/.git.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4390606Z /github/runner_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4397187Z [command]/usr/bin/git config --local --unset includeif.gitdir:/github/workspace/.git.path /github/runner_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4429335Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/github/workspace/.git/worktrees/*.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4451435Z /github/runner_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4459641Z [command]/usr/bin/git config --local --unset includeif.gitdir:/github/workspace/.git/worktrees/*.path /github/runner_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4492740Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4724501Z Removing credentials config '/home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config'
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4870190Z Cleaning up orphan processes

--- a/tests/unit/fixtures/standards_drift_unresolved.log
+++ b/tests/unit/fixtures/standards_drift_unresolved.log
@@ -1,0 +1,248 @@
+drift / check-standards-drift	UNKNOWN STEP	﻿2026-07-27T10:23:37.5851074Z Current runner version: '2.335.1'
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5886338Z ##[group]Runner Image Provisioner
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5887548Z Hosted Compute Agent
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5888772Z Version: 20260707.563
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5889745Z Commit: 02667638d2b423fbc733a8e32a88b44996a3ba6e
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5890894Z Build Date: 2026-07-07T19:33:50Z
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5892047Z Worker ID: {80b6579b-448e-46a7-b35c-7b87bd7801d7}
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5893153Z Azure Region: eastus2
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5894130Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5896172Z ##[group]Operating System
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5897183Z Ubuntu
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5898295Z 24.04.4
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5899100Z LTS
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5899884Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5900859Z ##[group]Runner Image
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5901824Z Image: ubuntu-24.04
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5902734Z Version: 20260720.247.2
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5904707Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260720.247/images/ubuntu/Ubuntu2404-Readme.md
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5907321Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260720.247
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5909263Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5910983Z ##[group]GITHUB_TOKEN Permissions
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5913749Z Contents: read
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5914616Z Metadata: read
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5915619Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5918725Z Secret source: Actions
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.5920187Z Prepare workflow directory
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.6373153Z Prepare all required actions
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.6427058Z Getting action download info
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:37.8326118Z Download action repository 'actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0' (SHA:9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0)
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.0517227Z Uses: vladm3105/aidoc-flow-ci/.github/workflows/standards-drift.yml@refs/tags/ci/v2.14.0 (8cf9e62e6b62a5d90a3b12dd204ba7b657d69055)
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.0522128Z ##[group] Inputs
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.0522903Z   tier: governance
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.0523945Z   strict: false
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.0524641Z   runner_labels: "ubuntu-latest"
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.0525373Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.0525985Z Complete job name: drift / check-standards-drift
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1366562Z ##[group]Run actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1367573Z with:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1368290Z   repository: vladm3105/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1372535Z   token: ***
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1372991Z   ssh-strict: true
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1373441Z   ssh-user: git
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1373897Z   persist-credentials: true
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1374395Z   clean: true
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1374853Z   sparse-checkout-cone-mode: true
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1375385Z   fetch-depth: 1
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1375827Z   fetch-tags: false
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1376273Z   show-progress: true
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1376728Z   lfs: false
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1377145Z   submodules: false
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1377600Z   set-safe-directory: true
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1378224Z   allow-unsafe-pr-checkout: false
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.1379101Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2406935Z Syncing repository: vladm3105/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2409544Z ##[group]Getting Git version info
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2410510Z Working directory is '/home/runner/work/aidoc-flow-framework/aidoc-flow-framework'
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2411824Z [command]/usr/bin/git version
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2432694Z git version 2.54.0
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2453575Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2466074Z Temporarily overriding HOME='/home/runner/work/_temp/28a74eec-37d4-4cd0-99e0-13d3f396c277' before making global git config changes
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2468477Z Adding repository directory to the temporary git global config as a safe directory
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2473066Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/aidoc-flow-framework/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2523410Z Deleting the contents of '/home/runner/work/aidoc-flow-framework/aidoc-flow-framework'
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2527331Z ##[group]Determining repository object format
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2529476Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2530622Z ##[group]Initializing the repository
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2535176Z [command]/usr/bin/git init /home/runner/work/aidoc-flow-framework/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2631114Z hint: Using 'master' as the name for the initial branch. This default branch name
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2632904Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2634669Z hint: to use in all of your new repositories, which will suppress this warning,
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2636135Z hint: call:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2636948Z hint:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2638162Z hint: 	git config --global init.defaultBranch <name>
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2639342Z hint:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2640401Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2641996Z hint: 'development'. The just-created branch can be renamed via this command:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2643443Z hint:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2644350Z hint: 	git branch -m <name>
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2645362Z hint:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2646536Z hint: Disable this message with "git config set advice.defaultBranchName false"
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2648978Z Initialized empty Git repository in /home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git/
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2652407Z [command]/usr/bin/git remote add origin https://github.com/vladm3105/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2691781Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2692608Z ##[group]Disabling automatic garbage collection
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2695517Z [command]/usr/bin/git config --local gc.auto 0
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2728260Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2729196Z ##[group]Setting up auth
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2729755Z Removing SSH command configuration
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2734580Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.2770987Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3084667Z Removing HTTP extra header
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3091046Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3122648Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3351149Z Removing includeIf entries pointing to credentials config files
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3356261Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3388977Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3630536Z [command]/usr/bin/git config --file /home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config http.https://github.com/.extraheader AUTHORIZATION: basic ***
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3669359Z [command]/usr/bin/git config --local includeIf.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git.path /home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3700327Z [command]/usr/bin/git config --local includeIf.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git/worktrees/*.path /home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3734154Z [command]/usr/bin/git config --local includeIf.gitdir:/github/workspace/.git.path /github/runner_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3766125Z [command]/usr/bin/git config --local includeIf.gitdir:/github/workspace/.git/worktrees/*.path /github/runner_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3793606Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3800207Z ##[group]Fetching the repository
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:38.3801596Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +2f6479b1a002b7146e7b2ed1729a5753b80cbc26:refs/remotes/origin/main
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1100982Z From https://github.com/vladm3105/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1103286Z  * [new ref]         2f6479b1a002b7146e7b2ed1729a5753b80cbc26 -> origin/main
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1140306Z [command]/usr/bin/git branch --list --remote origin/main
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1169077Z   origin/main
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1178844Z [command]/usr/bin/git rev-parse refs/remotes/origin/main
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1204047Z 2f6479b1a002b7146e7b2ed1729a5753b80cbc26
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1209085Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1210290Z ##[group]Determining the checkout info
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1211780Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1213250Z [command]/usr/bin/git sparse-checkout disable
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1259476Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1289841Z ##[group]Checking out the ref
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.1292142Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2466237Z Switched to a new branch 'main'
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2468488Z branch 'main' set up to track 'origin/main'.
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2479281Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2533325Z [command]/usr/bin/git log -1 --format=%H
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2559721Z 2f6479b1a002b7146e7b2ed1729a5753b80cbc26
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2824971Z ##[group]Run set -euo pipefail
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2826448Z ^[[36;1mset -euo pipefail^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2828376Z ^[[36;1m# Resolve the adopted canon tag from the consumer's OWN checked-out^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2830683Z ^[[36;1m# standards-drift caller pin (actions/checkout above put it on disk).^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2833046Z ^[[36;1m# Deterministic and pin-accurate; see the header for why not workflow_ref.^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2835432Z ^[[36;1m# FT-22: brought to the full docs/REPO_STANDARDS.md §4.2a property list —^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2837845Z ^[[36;1m# this workflow pioneered the approach but predated five of its rules.^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2839788Z ^[[36;1m[ -d .github/workflows ] \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2842508Z ^[[36;1m  || { echo "::error::standards-drift: .github/workflows/ not found after checkout — INFRASTRUCTURE error, not a drift verdict."; exit 1; }^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2845237Z ^[[36;1m^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2846652Z ^[[36;1m# Read only real `uses:` lines in files GitHub actually executes: a^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2848899Z ^[[36;1m# *.yml.bak/*.disabled leftover or a commented-out example must never^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2850985Z ^[[36;1m# supply the tag (it would WIN the version sort — verified).^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2852582Z ^[[36;1mset +e^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2854370Z ^[[36;1mUSES_LINES="$(grep -rhE --include='*.yml' --include='*.yaml' '^[[:space:]]*uses:' .github/workflows/)"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2856497Z ^[[36;1mgrc=$?^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2857471Z ^[[36;1mset -e^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2858965Z ^[[36;1m# grep rc: 0=match, 1=no match, >=2=real error (unreadable dir). Without^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2861052Z ^[[36;1m# this split, an I/O error is misreported as "caller not installed".^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2862755Z ^[[36;1m[ "$grc" -le 1 ] \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2865330Z ^[[36;1m  || { echo "::error::standards-drift: could not read .github/workflows/ (grep exit $grc) — INFRASTRUCTURE error, not a drift verdict."; exit 1; }^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2868261Z ^[[36;1m^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2869303Z ^[[36;1mPINS="$(printf '%s\n' "$USES_LINES" \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2871990Z ^[[36;1m  | grep -ohE 'vladm3105/aidoc-flow-ci/\.github/workflows/standards-drift\.yml@([0-9a-f]{40} +# +)?ci/v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?' \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2874615Z ^[[36;1m  | sort -u || true)"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2876022Z ^[[36;1mPIN_COUNT="$(printf '%s' "$PINS" | grep -c . || true)"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2877951Z ^[[36;1m[ "$PIN_COUNT" -ge 1 ] \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2881680Z ^[[36;1m  || { echo "::error::standards-drift: could not find a standards-drift '@ci/vX.Y.Z' pin on a 'uses:' line in .github/workflows/ — is this caller installed from the canon template? INFRASTRUCTURE error, not a drift verdict."; exit 1; }^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2885946Z ^[[36;1m# Fail CLOSED on ambiguity: only one reusable actually runs, so the^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2888132Z ^[[36;1m# correct tag is unknowable from the tree. Picking the highest would^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2890205Z ^[[36;1m# silently compare against a version the repo never adopted.^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2891830Z ^[[36;1m[ "$PIN_COUNT" -eq 1 ] \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2895378Z ^[[36;1m  || { echo "::error::standards-drift: found $PIN_COUNT differing standards-drift pins in .github/workflows/ — resolve to one. INFRASTRUCTURE error, not a drift verdict."; printf '%s\n' "$PINS" | sed 's/^/  /'; exit 1; }^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2899180Z ^[[36;1m^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2900706Z ^[[36;1mCANON_TAG="$(printf '%s' "$PINS" | grep -oE 'ci/v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?')"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2903063Z ^[[36;1mCANON_SHA="$(printf '%s' "$PINS" | grep -oE '@[0-9a-f]{40}' | tr -d '@' || true)"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2904831Z ^[[36;1mcase "$CANON_TAG" in^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2907830Z ^[[36;1m  *-*) echo "::error::standards-drift: pre-release canon pin '${CANON_TAG}' is not supported — pin a released ci/vX.Y.Z tag. INFRASTRUCTURE error, not a drift verdict."; exit 1 ;;^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2911196Z ^[[36;1mesac^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2912589Z ^[[36;1m# SHA-pinned caller → GitHub executes THAT SHA, so fetch from it; the^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2914528Z ^[[36;1m# trailing `# ci/vX.Y.Z` is documentation and can lag.^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2916061Z ^[[36;1mFETCH_REF="${CANON_SHA:-$CANON_TAG}"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2918510Z ^[[36;1mecho "::notice::standards-drift: adopted canon pin vladm3105/aidoc-flow-ci@${CANON_TAG} (fetching at ${FETCH_REF})"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2920831Z ^[[36;1m^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2922127Z ^[[36;1m# The consumer does not ship sync/. Fetch the script from the adopted^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2924171Z ^[[36;1m# canon tag; owner/repo hardcoded to canonical canon (matching the^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2926280Z ^[[36;1m# script's own template + pin-currency fetches, check-standards-drift.sh).^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2928635Z ^[[36;1m# ALWAYS fetch to a fresh temp path — never run a caller-vendored copy^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2930712Z ^[[36;1m# that could shadow the pinned version. The script self-fetches its^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2932808Z ^[[36;1m# check-pin-currency.sh dependency from the same tag (see its tail).^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2934480Z ^[[36;1mSCRIPT="$(mktemp)"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2935621Z ^[[36;1mcurl -fsSL --retry 3 --retry-delay 2 \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2936909Z ^[[36;1m  -o "$SCRIPT" \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2939129Z ^[[36;1m  "https://raw.githubusercontent.com/vladm3105/aidoc-flow-ci/${FETCH_REF}/sync/check-standards-drift.sh" \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2943447Z ^[[36;1m  || { echo "::error::standards-drift: could not fetch check-standards-drift.sh from vladm3105/aidoc-flow-ci@${FETCH_REF} — INFRASTRUCTURE error, not a drift verdict. Re-run."; exit 1; }^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2946646Z ^[[36;1m[ -s "$SCRIPT" ] \^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2948607Z ^[[36;1m  || { echo "::error::standards-drift: fetched check-standards-drift.sh is empty"; exit 1; }^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2950516Z ^[[36;1m^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2951836Z ^[[36;1m# --ci-tag pins the comparison base (tier templates + pin-currency) to^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2953955Z ^[[36;1m# the SAME adopted tag — deterministic; the consumer compares against^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2955674Z ^[[36;1m# exactly the version it adopted.^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2957338Z ^[[36;1m# FETCH_REF, not CANON_TAG: the script uses this purely as a^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2959694Z ^[[36;1m# raw.githubusercontent ref for TEMPLATE_BASE + its check-pin-currency^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2962086Z ^[[36;1m# self-fetch, so a 40-hex SHA works identically — and a SHA-pinned^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2964397Z ^[[36;1m# caller must compare against the templates it actually executed, not a^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2966527Z ^[[36;1m# tag whose trailing comment may lag. Identical for plain-tag pins.^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2968975Z ^[[36;1margs=(--tier "$TIER" --repo "$GH_REPO" --ci-tag "$FETCH_REF")^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2971376Z ^[[36;1m[ "$STRICT" = "true" ] && args+=(--strict)^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.2973334Z ^[[36;1mbash "$SCRIPT" "${args[@]}"^[[0m
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3028809Z shell: /usr/bin/bash -e {0}
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3029906Z env:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3039995Z   GH_TOKEN: ***
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3040991Z   GH_REPO: vladm3105/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3042181Z   TIER: governance
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3043119Z   STRICT: false
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3044011Z ##[endgroup]
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:39.3281173Z ##[notice]standards-drift: adopted canon pin vladm3105/aidoc-flow-ci@ci/v2.14.0 (fetching at ci/v2.14.0)
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.0178638Z check-standards-drift: repo=vladm3105/aidoc-flow-framework tier=governance canon=ci/v2.14.0 branch=main (warning-only)
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.2740952Z ##[warning]check-standards-drift: cannot check branch-protection (needs 'administration: read' on the token (FT-5) — grant it to the drift job (or run with a PAT) to verify branch protection; skipping)
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7063861Z ##[warning]repo-settings.allow_merge_commit: canon=false actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7121461Z ##[warning]repo-settings.allow_squash_merge: canon=true actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7182333Z ##[warning]repo-settings.allow_rebase_merge: canon=false actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7241729Z ##[warning]repo-settings.delete_branch_on_merge: canon=true actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7300247Z ##[warning]repo-settings.allow_auto_merge: canon=true actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7358322Z ##[warning]repo-settings.allow_update_branch: canon=true actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7416594Z ##[warning]repo-settings.squash_merge_commit_title: canon=PR_TITLE actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.7473984Z ##[warning]repo-settings.squash_merge_commit_message: canon=PR_BODY actual=null
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:40.9818875Z ##[warning]check-standards-drift: cannot check actions.general (gh api failed (token scope?))
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:41.1524008Z ##[warning]check-standards-drift: cannot check actions.workflow (gh api failed (token scope?))
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:41.3495951Z ##[warning]check-standards-drift: cannot check actions.selected (gh api failed (or allowed_actions != selected))
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.1692883Z ##[warning]pin-currency: could not resolve canon VERSION (pass --canon ci/vX.Y.Z)
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.2481217Z check-standards-drift: 8 drift, 4 fetch/scope error(s), 0 pin error(s) (warning-only)
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.2500000Z ##[warning]check-standards-drift: coverage — verified 2/4 control families (actions, labels); NOT verified: branch-protection, repo-settings. Could not be read (cause is named per-family in the warnings above — commonly insufficient token scope, in which case re-run with an admin PAT or grant 'administration: read'): branch-protection, repo-settings. A green result does NOT mean the unverified families match canon.
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.2686215Z Post job cleanup.
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3528642Z [command]/usr/bin/git version
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3566163Z git version 2.54.0
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3601196Z Temporarily overriding HOME='/home/runner/work/_temp/492cbc0d-7353-4149-8b6c-9ae2dec8756c' before making global git config changes
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3602958Z Adding repository directory to the temporary git global config as a safe directory
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3607231Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/aidoc-flow-framework/aidoc-flow-framework
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3641264Z Removing SSH command configuration
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3646670Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3681549Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3918047Z Removing HTTP extra header
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3923412Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.3959360Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4191878Z Removing includeIf entries pointing to credentials config files
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4198276Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4225800Z includeif.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4226975Z includeif.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git/worktrees/*.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4228137Z includeif.gitdir:/github/workspace/.git.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4228868Z includeif.gitdir:/github/workspace/.git/worktrees/*.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4235750Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4259290Z /home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4269130Z [command]/usr/bin/git config --local --unset includeif.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git.path /home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4304290Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git/worktrees/*.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4327185Z /home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4335931Z [command]/usr/bin/git config --local --unset includeif.gitdir:/home/runner/work/aidoc-flow-framework/aidoc-flow-framework/.git/worktrees/*.path /home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4367646Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/github/workspace/.git.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4390606Z /github/runner_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4397187Z [command]/usr/bin/git config --local --unset includeif.gitdir:/github/workspace/.git.path /github/runner_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4429335Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/github/workspace/.git/worktrees/*.path
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4451435Z /github/runner_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4459641Z [command]/usr/bin/git config --local --unset includeif.gitdir:/github/workspace/.git/worktrees/*.path /github/runner_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4492740Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4724501Z Removing credentials config '/home/runner/work/_temp/git-credentials-8d84a334-5df2-4afd-a23a-24d0ad8199ff.config'
+drift / check-standards-drift	UNKNOWN STEP	2026-07-27T10:23:42.4870190Z Cleaning up orphan processes

--- a/tests/unit/test_pin_currency_reader.py
+++ b/tests/unit/test_pin_currency_reader.py
@@ -1,0 +1,438 @@
+"""Unit: the pin-currency reader's parse and reconcile scripts.
+
+Covers `scripts/read-pin-currency-log.sh` and
+`scripts/reconcile-pin-currency-issue.sh` (PIN-CURRENCY-NO-READER).
+
+Neither script may need network, `gh` or auth: this module is loaded into the
+conformance suite by `tests/conformance/test_repo_scripts.py`, and that suite
+runs on EVERY commit via an `always_run` pre-commit hook. A test here that
+reached the network would fail an offline contributor's commit.
+
+The reconcile's `gh` calls are served by a stub installed on PATH, per canon's
+own `GH="${GH:-gh}"` injection point. The stub applies the real `jq` to its
+canned response, so the script's exact-title compare is genuinely exercised
+rather than stubbed past.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+READ = REPO_ROOT / "scripts" / "read-pin-currency-log.sh"
+RECONCILE = REPO_ROOT / "scripts" / "reconcile-pin-currency-issue.sh"
+
+TITLE = "CI canon drift — stale @ci/v* pins"
+
+# The ten callers the measured run reported stale, in the parser's sorted form.
+STALE_SET = ",".join(
+    f"{name}@ci/v2.14.0"
+    for name in sorted(
+        [
+            "ai-review.yml",
+            "audit-trail.yml",
+            "auto-merge-ai-prs.yml",
+            "composition.yml",
+            "docs-sync.yml",
+            "labeler.yml",
+            "links.yml",
+            "pre-commit.yml",
+            "secret-scan.yml",
+            "standards-drift.yml",
+        ]
+    )
+)
+
+# A `gh` stand-in. Records every invocation, serves a canned `issue list`
+# through the real jq, and can be told to fail a labelled `issue create`.
+GH_STUB = r"""#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_CALLS"
+# Capture every --body-file payload so tests can assert on generated CONTENT,
+# not just on the call sequence. The script deletes these via its own trap.
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "--body-file" ] && [ -f "$a" ]; then
+    cat "$a" >> "$GH_BODIES"
+    printf '\n===BODY-BOUNDARY===\n' >> "$GH_BODIES"
+  fi
+  prev="$a"
+done
+if [ "${1:-}" = issue ] && [ "${2:-}" = list ]; then
+  jqexpr=""
+  while [ $# -gt 0 ]; do [ "$1" = "--jq" ] && jqexpr="${2:-}"; shift; done
+  if [ -n "$jqexpr" ]; then jq -r "$jqexpr" < "$GH_LIST_JSON"; else cat "$GH_LIST_JSON"; fi
+  exit 0
+fi
+if [ "${1:-}" = issue ] && [ "${2:-}" = create ]; then
+  if [ "${GH_FAIL_LABELLED_CREATE:-0}" = 1 ] && [[ "$*" == *--label* ]]; then
+    echo "could not add label: 'ci' not found" >&2
+    exit 1
+  fi
+  echo "https://github.com/vladm3105/aidoc-flow-framework/issues/999"
+  exit 0
+fi
+exit 0
+"""
+
+
+def run_parse(log: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(READ), str(log)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def parse_kv(stdout: str) -> dict[str, str]:
+    out = {}
+    for line in stdout.splitlines():
+        if "=" in line:
+            key, _, value = line.partition("=")
+            out[key] = value
+    return out
+
+
+class ParseLogTests(unittest.TestCase):
+    """Eight cases: four verdicts that exit 0, four shapes that must exit non-zero."""
+
+    def test_stale_log_yields_ten_files_and_the_canon_token(self):
+        result = run_parse(FIXTURES / "standards_drift_stale.log")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        kv = parse_kv(result.stdout)
+        self.assertEqual(kv["verdict"], "stale")
+        self.assertEqual(kv["stale_count"], "10")
+        self.assertEqual(kv["canon"], "ci/v2.15.0")
+        self.assertEqual(kv["stale_files"], STALE_SET)
+        self.assertIn("8 drift", kv["drift_summary"])
+
+    def test_clean_log_yields_clean_and_no_files(self):
+        result = run_parse(FIXTURES / "standards_drift_clean.log")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        kv = parse_kv(result.stdout)
+        self.assertEqual(kv["verdict"], "clean")
+        self.assertEqual(kv["stale_count"], "0")
+        self.assertEqual(kv["canon"], "ci/v2.15.0")
+        self.assertEqual(kv["stale_files"], "")
+
+    def test_skipped_log_is_not_an_error(self):
+        """Canon's documented `::notice::` skip is a real, benign log shape."""
+        result = run_parse(FIXTURES / "standards_drift_skipped.log")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(parse_kv(result.stdout)["verdict"], "skipped")
+
+    def test_unresolved_is_not_swallowed_by_skipped(self):
+        """An unresolved log has no verdict line either, so `skipped` would
+        match it. The check order is what keeps them distinct."""
+        result = run_parse(FIXTURES / "standards_drift_unresolved.log")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(parse_kv(result.stdout)["verdict"], "unresolved")
+
+    def test_truncated_log_exits_non_zero(self):
+        """A log with no evidence the drift script ran must FAIL, not parse as
+        a benign `skipped` — absence of signal is the failure mode this whole
+        workflow exists to remove."""
+        with tempfile.TemporaryDirectory() as tmp:
+            garbage = Path(tmp) / "truncated.log"
+            garbage.write_text("job\tstep\t2026-07-27T10:23:42.0000000Z Cleaning up\n")
+            result = run_parse(garbage)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("check-standards-drift", result.stderr)
+
+    def test_log_truncated_mid_run_exits_non_zero(self):
+        """The regression guard for the reader's worst failure mode. The drift
+        script emits an OPENING `check-standards-drift: repo=… tier=…` header
+        and a `cannot check <family>` warning per unreadable family, all under
+        the same prefix and all well before the pin-currency section. A gate
+        that only proved the script STARTED would report `skipped` — exit 0,
+        green run — on a truncated download of a run with ten stale pins. The
+        window is real: `workflow_run: completed` fires while the log archive
+        is still assembling, and a partial archive is non-empty."""
+        full = (FIXTURES / "standards_drift_stale.log").read_text().splitlines(True)
+        opening = next(i for i, ln in enumerate(full) if "check-standards-drift: repo=" in ln)
+        pin = next(i for i, ln in enumerate(full) if "pin-currency: auditing" in ln)
+        self.assertLess(opening, pin, "fixture no longer has the opening header")
+        for cut in (opening + 1, pin):
+            with self.subTest(truncated_at=cut):
+                with tempfile.TemporaryDirectory() as tmp:
+                    log = Path(tmp) / "partial.log"
+                    log.write_text("".join(full[:cut]))
+                    result = run_parse(log)
+                self.assertNotEqual(
+                    result.returncode, 0, f"truncation at {cut} parsed as a verdict"
+                )
+
+    def test_contradictory_verdict_lines_exit_non_zero(self):
+        """Both a stale count and `all pins current` cannot be true of one run;
+        guessing which to honour would either open or close the issue wrongly."""
+        source = (FIXTURES / "standards_drift_stale.log").read_text()
+        both = source.replace(
+            "pin-currency: 10 stale pin(s)",
+            "pin-currency: all pins current ✅\npin-currency: 10 stale pin(s)",
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "both.log"
+            log.write_text(both)
+            result = run_parse(log)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("contradictory", result.stderr)
+
+    def test_malformed_canon_token_exits_non_zero(self):
+        """A `curl` that returns an error page instead of failing makes canon's
+        ver_cmp fall through to equal and print `all pins current` — a false
+        clean. Honouring it would close the tracking issue on a transient."""
+        source = (FIXTURES / "standards_drift_clean.log").read_text()
+        poisoned = source.replace("against canon ci/v2.15.0", "against canon <!DOCTYPE html>")
+        self.assertNotEqual(source, poisoned, "fixture shape changed")
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "poisoned.log"
+            log.write_text(poisoned)
+            result = run_parse(log)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("malformed", result.stderr)
+
+
+class ReconcileIssueTests(unittest.TestCase):
+    """Nine cases: six reconciliation scenarios, the label fallback, and two that
+    assert generated body CONTENT rather than the call sequence."""
+
+    @classmethod
+    def setUpClass(cls):
+        if shutil.which("jq") is None:
+            raise unittest.SkipTest("jq not available")
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self.bin = self.tmp / "bin"
+        self.bin.mkdir()
+        stub = self.bin / "gh"
+        stub.write_text(GH_STUB)
+        stub.chmod(0o755)
+        self.calls = self.tmp / "calls.txt"
+        self.calls.touch()
+        self.bodies = self.tmp / "bodies.txt"
+        self.bodies.touch()
+        self.addCleanup(self._tmp.cleanup)
+
+    def written_bodies(self) -> list[str]:
+        raw = self.bodies.read_text()
+        return [b for b in raw.split("===BODY-BOUNDARY===") if b.strip()]
+
+    def list_json(self, issues) -> Path:
+        path = self.tmp / "list.json"
+        path.write_text(json.dumps(issues))
+        return path
+
+    def open_issue_fixture(self) -> list:
+        return json.loads((FIXTURES / "gh_stub_issue_open.json").read_text())
+
+    def reconcile(self, verdict_kv: str, issues, dry_run=True, fail_label=False):
+        env = dict(os.environ)
+        env.update(
+            {
+                "GH": str(self.bin / "gh"),
+                "GH_CALLS": str(self.calls),
+                "GH_BODIES": str(self.bodies),
+                "GH_LIST_JSON": str(self.list_json(issues)),
+                "GH_FAIL_LABELLED_CREATE": "1" if fail_label else "0",
+                "PATH": f"{self.bin}:{env.get('PATH', '')}",
+            }
+        )
+        cmd = [
+            "bash",
+            str(RECONCILE),
+            "--repo",
+            "vladm3105/aidoc-flow-framework",
+            "--run-url",
+            "https://github.com/vladm3105/aidoc-flow-framework/actions/runs/1",
+            "--assignee",
+            "vladm3105",
+        ]
+        if dry_run:
+            cmd.append("--dry-run")
+        result = subprocess.run(
+            cmd, input=verdict_kv, capture_output=True, text=True, check=False, env=env
+        )
+        return result, self.calls.read_text()
+
+    @staticmethod
+    def stale_kv(count=10, files=STALE_SET) -> str:
+        return (
+            f"verdict=stale\nstale_count={count}\ncanon=ci/v2.15.0\n"
+            f"stale_files={files}\ndrift_summary=8 drift, 4 fetch/scope error(s), "
+            "0 pin error(s) (warning-only)\n"
+        )
+
+    def test_stale_with_no_prior_issue_creates_and_assigns(self):
+        result, calls = self.reconcile(self.stale_kv(), [])
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("issue create", result.stdout)
+        self.assertIn("--label ci", result.stdout)
+        self.assertIn("--add-assignee vladm3105", result.stdout)
+        self.assertNotIn("issue comment", result.stdout)
+        # The lookup's flags are load-bearing and easy to "tidy away" later, so
+        # they are asserted rather than left to the stub to ignore. Dropping
+        # `--limit 200` ages the tracking issue off page 1 and opens a
+        # duplicate; dropping `--state all` breaks the reopen contract.
+        self.assertIn("--state all", calls)
+        self.assertIn("--limit 200", calls)
+        self.assertIn("--json number,title,state,body", calls)
+
+    def test_stale_with_unchanged_set_edits_silently(self):
+        result, _ = self.reconcile(self.stale_kv(), self.open_issue_fixture())
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("issue edit 412", result.stdout)
+        self.assertNotIn("issue comment", result.stdout)
+        self.assertNotIn("issue create", result.stdout)
+
+    def test_generated_body_round_trips_through_the_state_reader(self):
+        """The body this script writes must be readable by the block parser it
+        reads with. Nothing else proves the writer and reader agree — if the
+        fence name or a key drifted, every previous-verdict field would come
+        back empty and the reader would comment on EVERY run, with the rest of
+        the suite still green."""
+        first, _ = self.reconcile(self.stale_kv(), [], dry_run=False)
+        self.assertEqual(first.returncode, 0, first.stderr)
+        generated = self.written_bodies()[0]
+        self.assertIn("```pin-currency-state", generated)
+
+        # The GFM table must be terminated by a blank line, or the remedy
+        # paragraph below it is absorbed into the table as junk rows.
+        table_end = generated.index("| `standards-drift.yml` | `ci/v2.14.0` |")
+        after = generated[table_end:].split("\n", 1)[1]
+        self.assertTrue(after.startswith("\n"), "no blank line terminates the table")
+        self.assertIn("--repin", generated)
+
+        # Feed it straight back as the stored body: identical verdict, so the
+        # comment trigger must NOT fire.
+        issues = [{"number": 412, "title": TITLE, "state": "OPEN", "body": generated}]
+        second, _ = self.reconcile(self.stale_kv(), issues)
+        self.assertEqual(second.returncode, 0, second.stderr)
+        self.assertIn("updated silently", second.stdout)
+        self.assertNotIn("issue comment", second.stdout)
+
+    def test_stamp_preserves_the_state_block_and_appends_when_absent(self):
+        """A stamp-only week must not regenerate the body: that would clear the
+        stored stale set, so the next identical `stale` reading would look like
+        clean → stale and emit a spurious comment."""
+        kv = (
+            "verdict=unresolved\nstale_count=0\ncanon=\nstale_files=\n"
+            "drift_summary=8 drift, 4 fetch/scope error(s), 0 pin error(s)\n"
+        )
+        result, _ = self.reconcile(kv, self.open_issue_fixture(), dry_run=False)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        stamped = self.written_bodies()[0]
+        self.assertIn(f"stale_files={STALE_SET}", stamped)
+        self.assertIn("stale_count=10", stamped)
+        self.assertEqual(stamped.count("last verified "), 1)
+        self.assertNotIn("last verified 2026-07-27T10:30:00Z", stamped)
+
+        # And when the line has been hand-edited away, it must be APPENDED —
+        # not silently skipped while the notice claims the stamp succeeded.
+        self.bodies.write_text("")
+        issues = self.open_issue_fixture()
+        for issue in issues:
+            if issue["title"] == TITLE:
+                issue["body"] = issue["body"].replace("last verified 2026-07-27T10:30:00Z\n", "")
+        result, _ = self.reconcile(kv, issues, dry_run=False)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        appended = self.written_bodies()[0]
+        self.assertEqual(appended.count("last verified "), 1)
+        self.assertIn(f"stale_files={STALE_SET}", appended)
+
+    def test_stale_with_changed_count_edits_and_comments(self):
+        """A count moving 10 → 15 must notify. Without this the change would be
+        a silent body edit, which defeats having an assignee at all."""
+        grown = STALE_SET + ",codeql.yml@ci/v2.14.0"
+        result, _ = self.reconcile(self.stale_kv(count=11, files=grown), self.open_issue_fixture())
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("issue edit 412", result.stdout)
+        self.assertIn("issue comment 412", result.stdout)
+
+    def test_stale_with_closed_issue_reopens_rather_than_recreating(self):
+        """The stale → clean → stale cycle recurs once per canon release, so
+        create-on-stale would produce one issue per release, not one issue."""
+        issues = self.open_issue_fixture()
+        for issue in issues:
+            if issue["title"] == TITLE:
+                issue["state"] = "CLOSED"
+        result, _ = self.reconcile(self.stale_kv(), issues)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("issue reopen 412", result.stdout)
+        self.assertIn("issue comment 412", result.stdout)
+        self.assertNotIn("issue create", result.stdout)
+
+    def test_clean_with_open_issue_closes_and_comments(self):
+        kv = (
+            "verdict=clean\nstale_count=0\ncanon=ci/v2.15.0\nstale_files=\n"
+            "drift_summary=0 drift, 0 fetch/scope error(s), 0 pin error(s)\n"
+        )
+        result, _ = self.reconcile(kv, self.open_issue_fixture())
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("issue close 412", result.stdout)
+        self.assertIn("issue comment 412", result.stdout)
+
+    def test_silent_verdicts_stamp_without_touching_state(self):
+        """`skipped` and `unresolved` must not open, close or reopen anything —
+        but they still stamp, so the READER's own staleness is visible in the
+        artifact it maintains."""
+        for verdict in ("skipped", "unresolved"):
+            with self.subTest(verdict=verdict):
+                self.calls.write_text("")
+                kv = (
+                    f"verdict={verdict}\nstale_count=0\ncanon=\nstale_files=\n"
+                    "drift_summary=8 drift, 4 fetch/scope error(s), 0 pin error(s)\n"
+                )
+                result, _ = self.reconcile(kv, self.open_issue_fixture())
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIn("issue edit 412", result.stdout)
+                for forbidden in ("issue close", "issue reopen", "issue create"):
+                    self.assertNotIn(forbidden, result.stdout)
+
+        # The steady state: creation happens only on `stale`, so a silent
+        # verdict normally finds no artifact to stamp. That is a no-op, not an
+        # error — the stamp's visibility claim is scoped to an issue that exists.
+        with self.subTest(verdict="skipped", issue="absent"):
+            self.calls.write_text("")
+            kv = (
+                "verdict=skipped\nstale_count=0\ncanon=\nstale_files=\n"
+                "drift_summary=8 drift, 4 fetch/scope error(s), 0 pin error(s)\n"
+            )
+            result, _ = self.reconcile(kv, [])
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("nothing to stamp", result.stdout)
+            self.assertNotIn("issue edit", result.stdout)
+
+    def test_labelled_create_failure_still_produces_an_issue(self):
+        """An unknown label makes `gh issue create` error, and this runs
+        unattended. The retry drops the LABEL only — never the create itself,
+        which `|| true` would have done."""
+        result, calls = self.reconcile(self.stale_kv(), [], dry_run=False, fail_label=True)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        creates = [c for c in calls.splitlines() if c.startswith("issue create")]
+        self.assertEqual(len(creates), 2, calls)
+        self.assertIn("--label ci", creates[0])
+        self.assertNotIn("--label", creates[1])
+        self.assertIn("::warning::", result.stdout + result.stderr)
+        # This is the only test that reaches the REAL post-create assignee
+        # branch — the dry-run test above is satisfied by a printed literal, so
+        # without this assertion R8's notification path has no coverage on the
+        # code that actually ships.
+        self.assertTrue(
+            any(
+                c.startswith("issue edit") and "--add-assignee vladm3105" in c
+                for c in calls.splitlines()
+            ),
+            calls,
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(0 if unittest.main(exit=False).result.wasSuccessful() else 1)


### PR DESCRIPTION
PR 2 of 4 for `PIN-CURRENCY-NO-READER`. Plan: [`plans/PIN-CURRENCY-READER-PLAN.md`](plans/PIN-CURRENCY-READER-PLAN.md) (merged as PR 1).

## What this is

The weekly `standards-drift` run already detects stale `@ci/v*` pins correctly and names the `--repin` remedy. **Nothing read it.** This ships the reader. It adds **no second detector** — the entry that requested this explicitly forbids one.

## Why it parses a log rather than calling an API

The signal exists on exactly one surface. Measured, not assumed:

| Candidate | Verdict |
| --- | --- |
| Reusable job `outputs:` | does not exist — canon declares `inputs:` only |
| Check-run annotations API | returned **10 of the job's 22** warnings and **0** of the ten pin-currency lines — they are emitted at the script's tail |
| `$GITHUB_STEP_SUMMARY` | never written by the drift script |
| The run **log** | complete |

## Contents

- `scripts/read-pin-currency-log.sh` — log in, `verdict`/`stale_count`/`canon`/`stale_files`/`drift_summary` out. Four verdicts (`stale`, `clean`, `unresolved`, `skipped`); a truncated log or a **malformed canon token** exits non-zero. The token check is load-bearing: if canon's `VERSION` fetch returns an error page rather than failing, its `ver_cmp` falls through to equal and prints `all pins current ✅`, and honouring that false clean would **close** the tracking issue on a transient.
- `scripts/reconcile-pin-currency-issue.sh` — reconciles exactly one issue: created on `stale`, edited in place, **reopened** rather than duplicated, closed when clean. Takes canon's own `GH="${GH:-gh}"` injection point, so `--dry-run` is driven by a stub rather than a live authenticated read.
- `.github/workflows/pin-currency-reader.yml` — `workflow_run` on `standards-drift` completion + `workflow_dispatch`. A **local override, not a canon caller**; delete it when canon ships its own reader.
- `tests/conformance/test_repo_scripts.py` — registers the new tests into a suite that actually executes. `tests/unit/` is run by no hook and no workflow, so without this they would guard nothing after merge.

**Both halves are extracted from the YAML on purpose.** `workflow_run` and `workflow_dispatch` each require the file on the **default branch**, so nothing end-to-end can run on this PR. Extraction is what makes the load-bearing logic testable pre-merge.

## Verification

Pre-merge (all green):

| # | Check | Result |
| --- | --- | --- |
| V1 | `unittest tests.unit.test_pin_currency_reader` | 17 pass (8 parse + 9 reconcile) |
| V2 | conformance count with vs without the shim | 253 → **271** |
| V3 | parse the stale fixture | `verdict=stale`, `stale_count=10`, `canon=ci/v2.15.0` |
| V4 | `GH=<stub> … --dry-run`, six scenarios | expected call sequence, zero live writes |
| V5 | V1 with `gh`, `curl`, `wget` all poisoned | passes — the suite runs on every commit, so it must work offline |
| V6 | `actionlint` / `yamllint` / `shellcheck -S warning` | clean |
| V7 | `pre-commit run --all-files` | clean |
| V8 | conformance | 271, OK |
| V9 | acceptance deterministic | 64, 0 failures |

**V10–V15 cannot run until this merges** (both triggers need the file on `main`). They gate PR 3, which is what closes the TODO entry — so the entry cannot close on unverified work. V15 waits up to seven days for a Monday run and is a post-hoc observation, never a gate.

## Review

Rule 2 adversarial self-review, 3 agents. **14 load-bearing findings, all fixed before push**; recorded as Pass 6 in the plan's review log. The four that would have shipped real defects:

- **The completion gate proved the wrong thing.** It grepped the prefix `check-standards-drift:`, which the script also emits in an opening header — 24 lines ahead of pin-currency. A log truncated in that window parsed as `skipped` and exited 0 with ten stale pins in the real run. Reachable: `workflow_run: completed` fires while the log archive is still assembling, and a partial archive is non-empty.
- **The `--repin` remedy was swallowed into the markdown table** on every issue the tool would ever open — command substitution strips the blank line that terminates a GFM table.
- **A `workflow_dispatch` `run_id` reached three `run:` blocks by interpolation**, with `GH_TOKEN` in scope and `issues: write` on the job token. `actionlint` does not flag this.
- **A failed `jq` read routed to CREATE** — `gh --jq` uses gh's built-in jq, so the guarded list call passed while the unguarded extractions left `issue_number` empty, which is indistinguishable from "no issue exists".

Four test guards were also vacuous (the stub ignored `--state all` / `--limit 200`; the assignee assertion tested a dry-run literal; no test read a generated body). Every guard added or repaired was **mutation-tested** — defect reintroduced, guard confirmed to fail, defect reverted.

## Governance

- **Rule 1: 2 doc surfaces** — `CHANGELOG.md` and the plan file. Headroom left deliberately.
- **Governance PR — not auto-mergeable.** The auto-merge exception list is defined by reference to the governance list, which includes plan files. Needs a founder merge.
- Plan Status → `IN PROGRESS`, not `IMPLEMENTED`: V10–V15 run only after this merges.
- No PR 3 leak (`DECISIONS.md` / `FRAMEWORK-TODO.md` / `HANDOFF.md`) and no PR 4 leak (`CLAUDE.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
