### PR TITLE
fix(ci): pin-currency close comment published literal backslashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — the pin-currency close comment rendered literal backslashes (2026-07-30)
+
+**No version moves** — `scripts/reconcile-pin-currency-issue.sh` only.
+
+- The `stale → clean` close comment was built by `printf` inside a **single-quoted**
+  string with `\`` before each backtick. There, a backslash is not an escape — it is a
+  literal backslash, so the comment published as ``All \`@ci/v*\` pins are current``.
+  Measured on the real close comment of [#393](https://github.com/vladm3105/aidoc-flow-framework/issues/393)
+  during the post-merge V10–V14 verification of #392, not inferred. The reopen and
+  changed-set comments were already correct, which is why only one of the three paths
+  showed it.
+- The regression guard sweeps **all five** markdown-emitting paths (create, silent
+  edit, reopen, close, changed-set) rather than the one that broke, since each builds
+  its markdown separately. Sweeping only four left the changed-set comment — the most
+  frequent of them — a mutation survivor.
+  Mutation-verified: reintroducing the escape fails the test.
+
 ### Added — the pin-currency verdict finally has a reader (2026-07-30)
 
 **No version moves** — local CI surface only. PR 2 of the four-PR sequence in

--- a/scripts/reconcile-pin-currency-issue.sh
+++ b/scripts/reconcile-pin-currency-issue.sh
@@ -275,7 +275,10 @@ if [ "$verdict" = clean ]; then
   render_resolved_body >"$body_file"
   gh_write issue edit "$issue_number" --repo "$REPO" --body-file "$body_file" \
     || warn "could not update body of #${issue_number} before closing"
-  printf 'All \`@ci/v*\` pins are current as of \`%s\` (canon \`%s\`). Closing.\n\nSource run: %s\n' \
+  # Bare backticks: this is a single-quoted string, so a backslash before one is
+  # NOT an escape — it is a literal backslash, and it renders as `\` in the
+  # comment. Measured on issue #393's real close comment.
+  printf 'All `@ci/v*` pins are current as of `%s` (canon `%s`). Closing.\n\nSource run: %s\n' \
     "$NOW" "$canon" "${RUN_URL:-(not recorded)}" >"$comment_file"
   gh_write issue comment "$issue_number" --repo "$REPO" --body-file "$comment_file" \
     || warn "could not comment on #${issue_number}"

--- a/tests/unit/test_pin_currency_reader.py
+++ b/tests/unit/test_pin_currency_reader.py
@@ -199,8 +199,8 @@ class ParseLogTests(unittest.TestCase):
 
 
 class ReconcileIssueTests(unittest.TestCase):
-    """Nine cases: six reconciliation scenarios, the label fallback, and two that
-    assert generated body CONTENT rather than the call sequence."""
+    """Ten cases: six reconciliation scenarios, the label fallback, and three
+    that assert generated body CONTENT rather than the call sequence."""
 
     @classmethod
     def setUpClass(cls):
@@ -378,6 +378,43 @@ class ReconcileIssueTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("issue close 412", result.stdout)
         self.assertIn("issue comment 412", result.stdout)
+
+    def test_no_generated_markdown_contains_an_escaped_backtick(self):
+        r"""These strings are built by `printf` inside SINGLE quotes, where a
+        backslash before a backtick is a literal backslash rather than an
+        escape — so it renders as `\` to a human reading the issue. Caught on
+        issue #393's real close comment during post-merge verification; every
+        comment and body path is swept here so it cannot come back in one of
+        the branches the others do not exercise."""
+        clean_kv = (
+            "verdict=clean\nstale_count=0\ncanon=ci/v2.15.0\nstale_files=\n"
+            "drift_summary=0 drift, 0 fetch/scope error(s), 0 pin error(s)\n"
+        )
+        closed = self.open_issue_fixture()
+        for issue in closed:
+            if issue["title"] == TITLE:
+                issue["state"] = "CLOSED"
+        for label, kv, issues in (
+            ("close", clean_kv, self.open_issue_fixture()),
+            ("create", self.stale_kv(), []),
+            ("silent-edit", self.stale_kv(), self.open_issue_fixture()),
+            ("reopen", self.stale_kv(), closed),
+            # The changed-set comment is a SEPARATE printf from the reopen one,
+            # and it is the most frequent commenting path — it fires on every
+            # canon release that shifts the set. Sweeping the other four leaves
+            # it a mutation survivor.
+            (
+                "changed-set",
+                self.stale_kv(count=11, files=STALE_SET + ",codeql.yml@ci/v2.14.0"),
+                self.open_issue_fixture(),
+            ),
+        ):
+            with self.subTest(path=label):
+                self.bodies.write_text("")
+                result, _ = self.reconcile(kv, issues, dry_run=False)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                written = "".join(self.written_bodies())
+                self.assertNotIn("\\`", written, f"{label} path emits an escaped backtick")
 
     def test_silent_verdicts_stamp_without_touching_state(self):
         """`skipped` and `unresolved` must not open, close or reopen anything —


### PR DESCRIPTION
Follow-up to [#392](https://github.com/vladm3105/aidoc-flow-framework/pull/392), found during its **post-merge V10–V14 verification** — not a gap that should have been caught pre-merge. It is only observable in a real published comment.

## The defect

The `stale → clean` close comment was built by `printf` inside a **single-quoted** format string with a backslash before each backtick. In single quotes bash does not treat backslash as an escape, so it is a literal backslash. Issue [#393](https://github.com/vladm3105/aidoc-flow-framework/issues/393)'s real close comment reads:

```
All \`@ci/v*\` pins are current as of \`2026-07-30T15:26:23Z\` (canon \`ci/v2.16.0\`). Closing.
```

Measured on the artifact, not inferred.

The reopen and changed-set comments already used bare backticks, which is why only one of the three paths showed it. **The heredoc bodies are unaffected and deliberately keep their escapes** — `render_body` and `render_resolved_body` use *unquoted* `<<EOF`, where a bare backtick would be command substitution, so the backslash there is required. Verified rather than assumed.

## The guard

Sweeps **all five** markdown-emitting paths — create, silent edit, reopen, close, changed-set — since each builds its markdown separately. Mutation-verified at each of the three comment `printf`s:

| mutated | result |
| --- | --- |
| close (`:281`) | FAILED ✅ |
| reopen (`:347`) | FAILED ✅ |
| changed-set (`:363`) | FAILED ✅ |

My first version swept only four and left the changed-set comment a mutation survivor — the review caught it, and it is the **most frequent** commenting path, since it fires on every canon release that shifts the set.

## Verification

- 19 unit tests, conformance 272, `pre-commit run --all-files` clean, `shellcheck -S warning` clean.
- Not a governance PR — no plan file, no `DECISIONS.md`, no `CLAUDE.md`. 1 doc surface (`CHANGELOG.md`).

## Post-merge verification status of #392

V10–V14 **all pass**, so PR 3 of the plan is unblocked:

| # | Result |
| --- | --- |
| V10 | issue #393 created; 10 file rows, `--repin` command, `last verified` line, assignee set, `ci` label applied |
| V11 | re-dispatch → edited in place; **1** issue, **0** new comments |
| V12 | closed by hand → **reopened** and commented; still 1 issue |
| V13 | label fallback, via the stub |
| V14 | `standards-drift` dispatched → reader run with **`event=workflow_run`** |

V14 also closed #393 on a live `clean` verdict — which incidentally verifies the close path the plan recorded as *"deliberately absent"* and stub-only, because canon `main` and every caller now sit at `ci/v2.16.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
