### PR TITLE
docs: doc-maintainer is adopted and red, not unadopted — correct it and capture

### DIFF
--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -24,6 +24,42 @@
 
 ## Open
 
+### `[ci]` `DOC-MAINTAINER-RED-ON-EVERY-PUSH` — the adopted dry-run caller has failed every `push` run since it landed, unwatched
+
+- *Context:* found 2026-07-30 while confirming the `ci/v2.16.0` migration was
+  complete (it is — 17/17 call sites). `doc-maintainer.yml` was adopted in #382
+  on 2026-07-29; since then **20 failures / 41 runs**. `schedule` runs succeed
+  because they find nothing to do; **every `push` run fails**. Two distinct
+  causes, measured across five failing runs:
+  `planner: duplicate or non-allowlisted plan path: <X>` (4 of 5) and
+  `apply: refusing autonomous full-file generation over 200 KB: CHANGELOG.md`
+  (which is 276 KB and only grows).
+- *Fix shape:* **ours** — `.github/doc-maintainer.json` lists five paths in
+  `auto_merge.high_risk_paths` that are absent from `allowed_paths`
+  (`CLAUDE.md`, `plans/DECISIONS.md`, `plans/FRAMEWORK-TODO.md`,
+  `plans/HERMES-BACKLOG.md`, `framework/governance/DECISIONS.md`), so the
+  planner proposes them and the gate rejects them. Decide whether each should
+  be maintainable at all, then align the two lists.
+  **Canon's** — the error message conflates *duplicate* with *non-allowlisted*
+  (`plans/HANDOFF.md` **is** allowlisted, so its failures are the duplicate
+  branch), and the 200 KB refusal fires on an allowlisted **low-risk** path with
+  no chunking path. Both belong on `aidoc-flow-ci`; **not yet filed.**
+- *Note:* this is the same unread-surface class `PIN-CURRENCY-NO-READER` closed,
+  one level worse — that one was warning-only, this one is red.
+
+### `[docs]` `DOC-MAINTAINER-ADOPTION-CLAIM-STALE` — two docs still say the caller is unadopted and its secrets absent
+
+- *Context:* found 2026-07-30. `CLAUDE.md` says "**sixteen** `aidoc-flow-ci` call
+  sites across fifteen files"; the real count has been **17 across 16** since #382
+  added `doc-maintainer.yml`. `plans/HANDOFF.md` called it "the one canon surface
+  still unadopted" and claimed `LITELLM_DOC_API_KEY` / `LITELLM_BASE_URL` exist on
+  `aidoc-flow-operations` "but not here" — `gh secret list` shows **both present
+  on this repo**. Only `AIDOC_FLOW_BOT_ID` / `AIDOC_FLOW_BOT_KEY` are missing, and
+  those are live-mode only.
+- *Fix shape:* HANDOFF corrected in the same change as this entry. **`CLAUDE.md`
+  is not** — fold the count fix into the plan's PR 4, which already edits
+  `CLAUDE.md`, rather than spending a governance PR on one number.
+
 ### `[harness]` `IDHASH-GUARD-GLOB-NARROW` — the `#342` regression guard scans 41 of 52 plugin SKILLs and 36 of 39 Hermes references → [#385](https://github.com/vladm3105/aidoc-flow-framework/issues/385)
 
 - *Context:* surfaced 2026-07-30 while correcting a `CLAUDE.md` claim that no

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -84,17 +84,28 @@ The full queue is `plans/FRAMEWORK-TODO.md` (`## Open`) and
    - **PR 4** = `CLAUDE.md` (the annotation-cap trap at the granularity M1 supports,
      plus the concurrency inventory's **fourth** shape — `cancel-in-progress: false`
      under a fixed group, which `pin-currency-reader.yml` introduced) and the plan's
-     Status → `IMPLEMENTED`.
+     Status → `IMPLEMENTED`. **Fold one more `CLAUDE.md` correction in while it is
+     open:** it says "sixteen call sites across fifteen files"; the real count is
+     **17 across 16** since #382 added `doc-maintainer.yml`. Re-count rather than
+     copying that figure —
+     `grep -rcE '^\s*uses: vladm3105/aidoc-flow-ci' .github/workflows/*.yml`.
    - The plan's §PR sequencing is the contract; read it rather than this summary.
-2. **`doc-maintainer` — founder-blocked, not declined.** The one canon surface still
-   unadopted. `LITELLM_DOC_API_KEY`, `AIDOC_FLOW_BOT_ID`, `AIDOC_FLOW_BOT_KEY` exist on
-   `aidoc-flow-operations` but **not here**, and a personal account has no org secrets
-   to inherit (the API returns 422). Dry-run needs only the LiteLLM doc key:
-   `export LITELLM_BASE_URL LITELLM_DOC_API_KEY; bash install/set-litellm-secrets.sh
-   --repos "vladm3105/aidoc-flow-framework" --doc`. Live mode additionally needs App
-   permissions raised to PR/Issues write, `aidoc-flow-bot[bot]` in
-   `.github/ai-review/config.json#trust.ai_review`, and a hand-authored
-   `.github/doc-maintainer-conventions.md`.
+2. **`doc-maintainer` is ADOPTED and RED — it fails every `push` run, unwatched.**
+   → `FRAMEWORK-TODO.md` `DOC-MAINTAINER-RED-ON-EVERY-PUSH`.
+
+   ⚠️ **Earlier handoffs said this surface was "still unadopted" and that its LiteLLM
+   secrets did not exist here. Both were false, and the claim survived several
+   regenerations.** `doc-maintainer.yml` was adopted in dry-run by #382 on 2026-07-29
+   (canon manifest parity 28/28), and `gh secret list` shows `LITELLM_BASE_URL` **and**
+   `LITELLM_DOC_API_KEY` present on this repo. Only `AIDOC_FLOW_BOT_ID` /
+   `AIDOC_FLOW_BOT_KEY` are absent, and those are **live-mode only** — dry-run does not
+   need them. Verify with `gh secret list` before repeating any secrets claim here.
+
+   The real state: **20 failures / 41 runs** since adoption. `schedule` runs succeed
+   (nothing to do); every `push` run fails, on two distinct causes — a planner
+   allowlist/duplicate rejection, and a 200 KB refusal on `CHANGELOG.md` (276 KB). The
+   config half is ours to fix; the conflated error message and the size refusal belong
+   upstream and are **not yet filed**. See the TODO entry for the measurements.
 3. **`FRAMEWORK-TODO.md` hygiene — bigger than "pick a convention".** The queue is
    unreliable in *two* directions: entries marked `✅ CLOSED` sit under `## Open` (so it
    **overstates** what is open), and `## Closed` holds unmarked entries that read as


### PR DESCRIPTION
Found while confirming the `ci/v2.16.0` migration was complete. **It is** — 17/17 call sites at `@ci/v2.16.0`, canon `main` at `ci/v2.16.0`, and two live `standards-drift` runs today both reported `all pins current ✅`.

Two doc surfaces, neither a governance surface.

## The correction

`plans/HANDOFF.md` said `doc-maintainer` was *"the one canon surface still unadopted"* and that its LiteLLM secrets existed on `aidoc-flow-operations` **but not here**. Both false, and the claim survived several regenerations — including one I did earlier today:

- `doc-maintainer.yml` was adopted in dry-run by **#382** on 2026-07-29, taking canon manifest parity to 28/28.
- `gh secret list` shows `LITELLM_BASE_URL` **and** `LITELLM_DOC_API_KEY` present on this repo. Only `AIDOC_FLOW_BOT_ID` / `AIDOC_FLOW_BOT_KEY` are absent, and those are **live-mode only** — dry-run does not need them.

The handoff now carries an explicit warning about the false claim and a `gh secret list` instruction, so the next regeneration cannot copy it forward silently.

## The finding

The real state is worse than "unadopted": **20 failures / 41 runs** since adoption. `schedule` runs succeed because they find nothing to do; **every `push` run fails** — including the one this session's own handoff merge triggered. Nobody was watching it. Two distinct causes, measured across five failing runs:

| Error | Owner |
|---|---|
| `planner: duplicate or non-allowlisted plan path: <X>` (4 of 5) | mostly **ours** |
| `apply: refusing autonomous full-file generation over 200 KB: CHANGELOG.md` (276 KB) | **canon's** |

**Ours:** `.github/doc-maintainer.json` lists five paths in `auto_merge.high_risk_paths` that are absent from `allowed_paths` — `CLAUDE.md`, `plans/DECISIONS.md`, `plans/FRAMEWORK-TODO.md`, `plans/HERMES-BACKLOG.md`, `framework/governance/DECISIONS.md`. The planner proposes them; the gate rejects them.

**Canon's:** the message conflates *duplicate* with *non-allowlisted* — `plans/HANDOFF.md` **is** allowlisted, so its failures are the duplicate branch, which the wording hides. And the 200 KB refusal fires on an allowlisted **low-risk** path with no chunking path, on a file that only grows.

Neither canon-side defect is filed yet; the TODO entry says so rather than implying it is handled.

This is the same unread-surface class `PIN-CURRENCY-NO-READER` closed this session, one level worse — that one was warning-only, this one is red.

## Deliberately not fixed here

`CLAUDE.md` says "sixteen call sites across fifteen files"; the real count is **17 across 16**. It is a governance surface, and the plan's **PR 4 already edits `CLAUDE.md`** — so the handoff routes the fix there with a re-count command rather than spending a governance PR on one number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
