### PR TITLE
fix(ci): pause the doc-maintainer pilot — four upstream defects, none fixable here

### DIFF
--- a/.github/doc-maintainer-conventions.md
+++ b/.github/doc-maintainer-conventions.md
@@ -5,13 +5,42 @@ Consumed by `scripts/doc-maintainer/planner.py` as part of its planning prompt. 
 *this repository's* documentation discipline; it does not attempt to change the
 planner's task, output format, allowed paths, or safety rules.
 
-**Status: dry-run pilot.** `.github/doc-maintainer.json` sets `dry_run: true`. The flow
-proposes edits as a PR comment plus a patch artifact and changes nothing. Graduation to
-live requires ≥5 dry-run cycles with coherent proposals, zero allowlist violations and
-zero infrastructure errors (IPLAN-0025 §3 P4), **and** the two founder-tier
-prerequisites that are not yet in place: `AIDOC_FLOW_BOT_ID`/`AIDOC_FLOW_BOT_KEY` on
-this repo, and `aidoc-flow-bot[bot]` added to
-`.github/ai-review/config.json#trust.ai_review`.
+**Status: dry-run pilot, PAUSED 2026-07-30.** `.github/doc-maintainer.json` sets
+`kill_switch: true`, so the flow exits cleanly before any LLM call and this file is not
+read. It is kept current for the resume.
+
+The pause is not a retreat from the pilot — it is that four independent upstream defects
+stacked on one caller. Measured over this caller's first 47 runs (2026-07-30, adoption in
+PR #382 → pause): **23 failures**, 12 of 13 `push` runs, distributed as
+
+| Failures | Cause | Upstream |
+|---:|---|---|
+| 9 | planner rejects a **repeated** `plans/HANDOFF.md` entry. The path **is** allowlisted, so this is the duplicate branch — reported under a message that says `non-allowlisted`, which is how the cause was long misread as a config mismatch | [#353](https://github.com/vladm3105/aidoc-flow-ci/issues/353) |
+| 6 | planner rejects a genuinely non-allowlisted path — `plans/PIN-CURRENCY-READER-PLAN.md` ×3, `CLAUDE.md` ×2, **this conventions file** ×1 | [#353](https://github.com/vladm3105/aidoc-flow-ci/issues/353) |
+| 3 | apply refuses `CHANGELOG.md` at its 200 KB full-file-regeneration limit | [#354](https://github.com/vladm3105/aidoc-flow-ci/issues/354) |
+| 3 | Step 9 dies silently while rendering the dry-run patch | [#352](https://github.com/vladm3105/aidoc-flow-ci/issues/352) |
+| 2 | apply's *"agent deleted/replaced more than 30 % of README.md"* guard. The guard is correct; it reds the whole run instead of dropping the entry | reported on [#353](https://github.com/vladm3105/aidoc-flow-ci/issues/353) |
+
+**#352 is the smallest of these by count and still the one that blocks graduation.**
+Step 9 renders with `diff`, which exits 1 whenever files differ, and GitHub's `bash -e`
+kills the step before the `[ rc -le 1 ]` guard can forgive it. Its loop reads
+`.low_risk_set[]`, so **no plan containing a low-risk edit can ever complete a dry run** —
+and the IPLAN-0025 §3 P4 gate exists precisely to exercise that low-risk auto-apply path.
+(A plan of *only* high-risk edits does survive Step 9 and post a real proposal; that is
+why the pilot is not merely "always red", but it exercises the wrong path.) The failure
+count also climbed without new commits, because canon's reconciler treats a failed run as
+un-maintained and re-dispatches the SHA each cron tick.
+
+**Resume requires #352 *and* #353** — #353 alone is 15 of the 23 failures, so flipping the
+switch on #352 alone would return a majority-red pilot; the 30 %-deletion class should be
+understood by then too. Then: both ship in a released `ci/vX.Y.Z`, this caller is
+re-pinned to it, and `kill_switch` → `false`. Graduation to live additionally requires the
+IPLAN-0025 §3 P4 gate — ≥5 dry-run cycles with coherent proposals, zero allowlist
+violations, zero infrastructure errors — **and** the two founder-tier prerequisites that
+are not yet in place: `AIDOC_FLOW_BOT_ID`/`AIDOC_FLOW_BOT_KEY` on this repo, and
+`aidoc-flow-bot[bot]` added to `.github/ai-review/config.json#trust.ai_review`.
+(`LITELLM_BASE_URL` and `LITELLM_DOC_API_KEY` **are** present on this repo — an earlier
+handoff claimed otherwise.)
 
 ## Paths this repository forbids editing — never propose changes here
 
@@ -29,13 +58,13 @@ a preference:
 | `plans/DECISIONS.md`, `framework/governance/DECISIONS.md` | A decision log is authored by whoever made the decision, with their reasoning. Proposing entries here would fabricate provenance. Classified high-risk as defence-in-depth in case the allowlist is ever widened. |
 | `plans/FRAMEWORK-TODO.md`, `plans/HERMES-BACKLOG.md` | Work queues. Whether an item is open is a judgment about reality, not a documentation fact. |
 | `CLAUDE.md` | The working agreement. Changes are governance PRs with a founder in the loop. |
+| `CHANGELOG.md` | **Removed from `allowed_paths` 2026-07-30.** Structurally the wrong shape for a whole-file rewrite: the changelog is append-only, and the only correct edit is an insert under `## [Unreleased]`, which needs the head of the file. The size limit merely makes that unavoidable — at 281 KB it is past the apply step's hard 200 KB full-file-regeneration refusal, so proposing it is a guaranteed failed run ([aidoc-flow-ci#354](https://github.com/vladm3105/aidoc-flow-ci/issues/354)). The **per-platform** changelogs (91 KB, 33 KB) remain in scope and keep the same `## [Unreleased]` discipline. |
 
 ## What each maintained document is for
 
 | Document | Purpose | What a good proposal looks like |
 |---|---|---|
-| `CHANGELOG.md` | Project-level, **Keep a Changelog** format, semver. New work goes under `## [Unreleased]` in a dated `### Added/Changed/Fixed —` subsection | A concise user-visible entry for a merged change that has none. Include file paths and what was measured; this repo's changelog records evidence, not intentions |
-| `platforms/hermes/CHANGELOG.md`, `platforms/claude-code-plugin/CHANGELOG.md` | Per-platform streams, versioned independently of the project and of the spec | An entry when `platforms/<name>/**` changed but its own changelog did not |
+| `platforms/hermes/CHANGELOG.md`, `platforms/claude-code-plugin/CHANGELOG.md` | Per-platform streams, **Keep a Changelog** format, versioned independently of the project and of the spec. New work goes under `## [Unreleased]` | An entry when `platforms/<name>/**` changed but its own changelog did not. Include file paths and what was measured; this repo's changelogs record evidence, not intentions |
 | `README.md` | Stable entry-point guidance + the Status block | Correct a statement the merged PR falsified. Do not restate the changelog |
 | `ROADMAP.md` | Now/Next/Later + a recently-shipped log | Move an item to shipped when a merge demonstrably completed it. **High-risk**: it encodes intent and priority, so propose rather than assert |
 | `docs/**` | Detailed operational and technical material (`PROJECT.md`, `PARITY.md`, `TAGGING.md`, `REPO_STRUCTURE.md`, `SKILL_AUTHORING.md`) | Update a fact the change falsified — a parity row, a layout entry, a policy detail |
@@ -43,6 +72,17 @@ a preference:
 
 ## House rules for any proposal
 
+- **One entry per path — never propose the same file twice.** Combine everything you
+  would say about a file into a single entry. A repeated path is the single most common
+  way this flow has failed here — 9 of its 23 failures were a second `plans/HANDOFF.md`
+  entry, which the planner rejects as `duplicate or non-allowlisted` and which costs the
+  whole plan, not just the repeat
+  ([aidoc-flow-ci#353](https://github.com/vladm3105/aidoc-flow-ci/issues/353)).
+- **The allowed-paths list is closed.** Propose nothing outside it, including files
+  named in the forbidden table above and this conventions file itself. A single
+  out-of-list path discards the entire plan — 6 of the 23 failures were exactly this
+  (`plans/PIN-CURRENCY-READER-PLAN.md`, `CLAUDE.md`, and this file), and the allowlist
+  is handed to you verbatim in the prompt, so there is no ambiguity to resolve.
 - **Update only what the merged PR actually changed.** Behavior, interfaces,
   configuration, operations, architecture, governance or release-visible facts. A typo
   fix, a test-only change or an invisible refactor needs no doc update, and proposing

--- a/.github/doc-maintainer.json
+++ b/.github/doc-maintainer.json
@@ -2,22 +2,22 @@
   "$schema": "https://aidoc-flow.io/schemas/doc-maintainer-config-v1.json",
   "version": 1,
   "dry_run": true,
-  "kill_switch": false,
+  "_comment_kill_switch": "PAUSED 2026-07-30 after 23 failures / 47 runs across FOUR independent upstream failure modes: 15 planner rejections (aidoc-flow-ci#353 — 9 duplicate `plans/HANDOFF.md`, 6 non-allowlisted), 3 apply 200 KB refusals (#354), 3 silent Step 9 deaths (#352), 2 apply 30%-deletion guard trips (reported on #353). #352 is the smallest by count and still the graduation blocker: Step 9 renders with `diff`, which exits 1 whenever files differ, and GitHub's `bash -e` kills the step before the `[ rc -le 1 ]` guard forgives it — and because its loop reads `.low_risk_set[]`, no plan containing a low-risk edit can ever complete a dry run, which is exactly what the IPLAN-0025 SS3 P4 gate exists to exercise. RESUME REQUIRES #352 AND #353 — #353 alone is 15 of the 23 failures, so flipping on #352 only would return a majority-red pilot. Full rationale: .github/doc-maintainer-conventions.md, Status section.",
+  "kill_switch": true,
   "allowed_paths": [
     "README.md",
-    "CHANGELOG.md",
     "ROADMAP.md",
     "docs/**",
     "plans/HANDOFF.md",
     "platforms/hermes/CHANGELOG.md",
     "platforms/claude-code-plugin/CHANGELOG.md"
   ],
+  "_comment_allowed_paths": "CHANGELOG.md is deliberately absent. It is well past apply.py's hard 200 KB full-file-regeneration refusal (281 KB measured 2026-07-30, and it only grows), so every plan selecting it is a guaranteed red run (aidoc-flow-ci#354). It is also the wrong shape for this tool regardless of size: the changelog is append-only and the only correct edit is an insert under `## [Unreleased]`, which needs the head of the file, not a whole-file rewrite. The per-platform changelogs (91 KB, 33 KB) stay in scope and are under the limit.",
   "max_edits_per_pr": 4,
   "max_prs_per_day": 2,
   "auto_merge": {
     "low_risk_paths": [
       "README.md",
-      "CHANGELOG.md",
       "docs/**",
       "platforms/hermes/CHANGELOG.md",
       "platforms/claude-code-plugin/CHANGELOG.md"
@@ -30,6 +30,7 @@
       "plans/HERMES-BACKLOG.md",
       "framework/governance/DECISIONS.md",
       "CLAUDE.md"
-    ]
+    ],
+    "_comment_high_risk_paths": "Five of these — plans/DECISIONS.md, plans/FRAMEWORK-TODO.md, plans/HERMES-BACKLOG.md, framework/governance/DECISIONS.md, CLAUDE.md — are intentionally NOT in allowed_paths: defence-in-depth if the allowlist is ever widened, per doc-maintainer-conventions.md. (ROADMAP.md and plans/HANDOFF.md ARE allowlisted, and their high-risk classification is load-bearing.) The five are not drift: planner.py:187 rejects a non-allowlisted path before classification is reached, planner.py:197 already treats anything not low-risk as high-risk, and high_risk_paths is never shown to the model and never widens the allowlist — so listing them is inert today and correct tomorrow."
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,70 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed — the doc-maintainer dry-run pilot is paused; canon cannot render a dry-run patch (2026-07-30)
+
+**No version moves** — `.github/doc-maintainer.json` + `.github/doc-maintainer-conventions.md` only.
+
+- `kill_switch: true`. The caller adopted in #382 was red on nearly every `push` since
+  it landed — **23 failures / 47 runs**, 12 of 13 `push` runs — across **four
+  independent failure modes**, none of them fixable from this repo:
+
+  | Failures | Cause | Upstream |
+  |---:|---|---|
+  | 9 | planner rejects a **repeated** `plans/HANDOFF.md` entry — the path **is** allowlisted, so this is the duplicate branch reported as `non-allowlisted` | [#353](https://github.com/vladm3105/aidoc-flow-ci/issues/353) |
+  | 6 | planner rejects a genuinely non-allowlisted path (`plans/PIN-CURRENCY-READER-PLAN.md` ×3, `CLAUDE.md` ×2, the conventions file itself ×1) | [#353](https://github.com/vladm3105/aidoc-flow-ci/issues/353) |
+  | 3 | apply refuses `CHANGELOG.md` at the 200 KB full-file-regeneration limit | [#354](https://github.com/vladm3105/aidoc-flow-ci/issues/354) |
+  | 3 | Step 9 dies silently rendering the dry-run patch | [#352](https://github.com/vladm3105/aidoc-flow-ci/issues/352) |
+  | 2 | apply's *"agent deleted/replaced more than 30 % of README.md"* guard — the guard is right, but it reds the run instead of dropping the entry | reported on #353 |
+
+  **#352 is the smallest of these by count and still the one that blocks graduation.**
+  `doc-maintainer.yml` Step 9 renders the patch with `diff`, which exits 1 whenever files
+  differ, and GitHub's `bash -e` kills the step before the `[ rc -le 1 ]` guard can
+  forgive it — reproduced under GitHub's exact shell (`bash --noprofile --norc -eo
+  pipefail`), not inferred. Because Step 9's loop reads `.low_risk_set[]`, **no plan
+  containing a low-risk edit can ever complete a dry run**, and the IPLAN-0025 §3 P4
+  graduation gate exists precisely to exercise that low-risk auto-apply path. Introduced
+  at `ci/v2.0.0` (2026-07-13), when patch rendering replaced the count-only stub; every
+  release since carries it, `ci/v2.16.0` included.
+- **Why pause rather than narrow the config.** Config-only mitigations were considered
+  and are insufficient: `max_edits_per_pr: 1` would make a duplicate structurally
+  impossible (−9) and emptying `low_risk_paths` would leave Step 9's loop always empty
+  (−3), but neither touches the 6 non-allowlisted rejections or the 2 deletion-guard
+  failures, and emptying `low_risk_paths` buys green by abandoning the only path
+  graduation is meant to validate. The precise claim is therefore **not** "no config
+  change can make this green" — it is that no config change here makes it green *while
+  exercising the low-risk path*. Leaving it red was not free either: canon's reconciler
+  counts a **failed** run as un-maintained (`reconcile.py:98-104`), so it re-dispatched
+  each failing SHA every cron tick inside its 90-minute lookback — ~3 extra full LLM
+  planning calls per merge, all discarded, with the failure count climbing without new
+  commits.
+- **Resume needs #352 *and* #353**, not #352 alone: #353 accounts for 15 of the 23
+  failures, so flipping the switch on #352 alone would return a majority-red pilot. The
+  30 %-deletion class should be understood by then too.
+- `CHANGELOG.md` removed from `allowed_paths` and `auto_merge.low_risk_paths`. At
+  281 KB it exceeds the apply step's hard 200 KB full-file-regeneration refusal, so
+  every plan selecting it was a guaranteed red run. It is the
+  wrong shape for the tool at any size — the changelog is append-only and the only
+  correct edit is an insert under `## [Unreleased]`. Filed as
+  [aidoc-flow-ci#354](https://github.com/vladm3105/aidoc-flow-ci/issues/354), which also
+  records that canon's own install template ships `CHANGELOG.md` as a low-risk path
+  while canon's own changelog is 363 KB. The per-platform changelogs (91 KB, 33 KB)
+  stay in scope.
+- Conventions gain two house rules, one per planner failure class: **one entry per path**
+  (the 9 repeated-`plans/HANDOFF.md` rejections) and **the allowed-paths list is closed**
+  (the 6 out-of-allowlist proposals, one of which was the conventions file itself). Both
+  are mitigations for [#353](https://github.com/vladm3105/aidoc-flow-ci/issues/353), not
+  fixes — the planner discards the whole plan either way.
+- **Not changed, deliberately:** `CLAUDE.md`, `plans/DECISIONS.md`,
+  `plans/FRAMEWORK-TODO.md`, `plans/HERMES-BACKLOG.md` and
+  `framework/governance/DECISIONS.md` remain in `auto_merge.high_risk_paths` while absent
+  from `allowed_paths`. That mismatch was on record as this repo's half of the bug; it is
+  neither half. `planner.py:187` rejects a non-allowlisted path *before* classification
+  is ever reached, and `high_risk_paths` is never shown to the model and never widens the
+  allowlist — so the five entries are inert defence-in-depth, and they caused none of the
+  23 failures. Now documented in the config so the next reader does not re-file it as
+  drift.
+
 ### Fixed — the pin-currency close comment rendered literal backslashes (2026-07-30)
 
 **No version moves** — `scripts/reconcile-pin-currency-issue.sh` only.


### PR DESCRIPTION
Fixes the red `doc-maintainer` caller adopted in #382. The cause is entirely upstream — **four independent defects**, none fixable from this repo.

## The census

I re-derived this from all 23 failures rather than a sample:

| Failures | Cause | Upstream |
|---:|---|---|
| 9 | planner rejects a **repeated** `plans/HANDOFF.md` entry — the path **is** allowlisted, so this is the duplicate branch, reported under a message that says `non-allowlisted` | [#353](https://github.com/vladm3105/aidoc-flow-ci/issues/353) |
| 6 | planner rejects a genuinely non-allowlisted path (`plans/PIN-CURRENCY-READER-PLAN.md` ×3, `CLAUDE.md` ×2, the conventions file itself ×1) | [#353](https://github.com/vladm3105/aidoc-flow-ci/issues/353) |
| 3 | apply refuses `CHANGELOG.md` at its 200 KB full-file-regeneration limit | [#354](https://github.com/vladm3105/aidoc-flow-ci/issues/354) |
| 3 | Step 9 dies silently rendering the dry-run patch | [#352](https://github.com/vladm3105/aidoc-flow-ci/issues/352) |
| 2 | apply's *"deleted/replaced more than 30 % of README.md"* guard — correct guard, but it reds the run instead of dropping the entry | reported on [#353](https://github.com/vladm3105/aidoc-flow-ci/issues/353) |

## Why #352 is the smallest by count and still the blocker

Step 9 renders the patch with `diff`, which exits **1 whenever files differ** — the normal case. GitHub's `bash -e` kills the step before the `[ "$rc" -le 1 ]` guard can forgive it, so the guard is unreachable dead code. Reproduced under GitHub's exact shell, not inferred:

```console
$ bash --noprofile --norc -eo pipefail repro.sh; echo "step exit=$?"
step exit=1          # "REACHED-GUARD" never prints
```

Its loop reads `.low_risk_set[]`, so **no plan containing a low-risk edit can ever complete a dry run** — and the IPLAN-0025 §3 P4 gate exists precisely to exercise that low-risk auto-apply path. Introduced at `ci/v2.0.0`, when patch rendering replaced the count-only stub.

*(A plan of only high-risk edits does survive Step 9 and post a real proposal. So the pilot is not literally "always red" — it just can only ever exercise the path that does not need validating.)*

## Why pause rather than narrow the config

Config-only mitigations were evaluated and are insufficient: `max_edits_per_pr: 1` makes a duplicate structurally impossible (−9), emptying `low_risk_paths` leaves Step 9's loop always empty (−3), but neither touches the 6 non-allowlisted rejections or the 2 deletion-guard failures — and emptying `low_risk_paths` buys green by abandoning the only path graduation is meant to validate. The honest claim is not "no config change can make this green", but that **none makes it green while exercising the low-risk path**.

Leaving it red was not free either: canon's reconciler counts a *failed* run as un-maintained (`reconcile.py:98-104`) and re-dispatched each failing SHA every cron tick inside its 90-minute lookback — ~3 extra full LLM planning calls per merge, all discarded, with the failure count climbing without new commits.

## What changed

| Change | Why |
|---|---|
| `kill_switch: true` | Canon exits cleanly before any LLM call → green, zero cost. Caller + config stay in place. |
| `CHANGELOG.md` out of `allowed_paths` + `low_risk_paths` | Structurally wrong shape for a whole-file rewrite: append-only, and the only correct edit is an insert under `## [Unreleased]`. The 200 KB refusal merely makes that unavoidable. |
| Conventions: one house rule per planner failure class, plus pause + resume condition | Mitigations for #353, not fixes — the planner discards the whole plan either way. |

**Resume requires #352 *and* #353.** #353 alone is 15 of the 23 failures, so flipping the switch on #352 only would return a majority-red pilot.

## What did NOT change, deliberately

`plans/DECISIONS.md`, `plans/FRAMEWORK-TODO.md`, `plans/HERMES-BACKLOG.md`, `framework/governance/DECISIONS.md` and `CLAUDE.md` stay in `auto_merge.high_risk_paths` while absent from `allowed_paths`. That mismatch was on record as this repo's half of the bug — **it is neither half.** `planner.py:187` rejects a non-allowlisted path *before* classification is reached, and `high_risk_paths` is never shown to the model and never widens the allowlist. Inert defence-in-depth; it caused none of the 23 failures. Now documented in the config so the next reader does not re-file it as drift. The backlog entry asserting otherwise is corrected in a follow-up.

## Review

Multi-agent self-review per OPS-0065 (code-reviewer, documentation-specialist, code-reviewer/adversarial-judge) — 2 critical + 4 medium + 3 low, all folded in one cycle. **The critical findings were mine:** the changelog entry contradicted itself on the failure count (21 vs 23), and all three files framed #352 as the dominant cause when it is 3 of 23 — which had also produced a resume condition that would have returned a majority-red pilot. The adversarial pass additionally showed my "succeeds only when it has nothing to do" claim is false for high-risk-only plans, and that config-only mitigations existed and had not been evaluated. I re-derived the census and both corrections independently before folding.

Two upstream artifacts were corrected as a result: [#352](https://github.com/vladm3105/aidoc-flow-ci/issues/352) carried the same overstated blast radius (I had written "every tag from `ci/v0.0.1-ruletest`"; `ci/v1.4.0`–`v1.9.5` ship a count-only stub with no `diff`, and `ci/v0.0.1-ruletest` was tagged *after* `v2.0.0` — a version-sort artifact I misread as chronological), and the previously-unfiled 30 %-deletion class is now reported on [#353](https://github.com/vladm3105/aidoc-flow-ci/issues/353).

## Verification

- Failure census re-derived from all 23 failing runs, not sampled.
- `kill_switch: true` → `skip=true` + `exit 0` at `doc-maintainer.yml:340-345`; every later step gated `skip != 'true'` — green by construction, confirmed against source.
- Canon's own `planner.py:109-125` config validation replayed against the new JSON: passes; `CHANGELOG.md` matches neither list; `low_risk_paths ⊆ allowed_paths`; the five named paths are exactly the `high_risk_paths ∖ allowed_paths` set.
- Full pre-commit suite passed, including the framework/platform conformance suite.

Not a governance PR — no governance surface touched. The decision record and the backlog correction follow separately.
