### PR TITLE
docs: record the doc-maintainer pause and retract the wrong diagnosis (D-0072)

### DIFF
--- a/plans/DECISIONS.md
+++ b/plans/DECISIONS.md
@@ -10,6 +10,72 @@ graduation.
 
 ---
 
+## D-0072 — Pause a pilot that cannot pass its own gate; and weight a failure census before naming a root cause
+
+**2026-07-30.** Decisions from PR `#397`, which set `kill_switch: true` on the
+`doc-maintainer` caller adopted in `#382`. **Supersedes the diagnosis recorded in
+`#396`** (see point 2); supersedes nothing else.
+
+**1. Pause, rather than narrow the config or un-adopt.** The caller was red on
+23 of 47 runs across four independent upstream defects. `kill_switch: true` makes
+canon exit cleanly before any LLM call (`doc-maintainer.yml:340-345`), so the
+workflow is green at zero cost while the caller, its config and its conventions
+stay in place — resume is a one-line flip. Un-adopting would have discarded the
+28/28 canon manifest parity `#382` established, and narrowing the config could
+not have worked: `max_edits_per_pr: 1` and an empty `low_risk_paths` between them
+address 12 of the 23 failures and leave the rest. **The reason to pause is not
+that it was red — it is that the pilot could not produce the evidence it exists
+to produce.** A dry-run pilot's output is dry-run cycles carrying coherent
+proposals, and `aidoc-flow-ci#352` means no plan containing a low-risk edit can
+ever complete one. Running it therefore costs LLM calls and CI noise and returns
+nothing.
+
+⚠️ **The bar here is self-imposed, and earlier framing overstated its
+authority.** `#382` and `#397` both cite IPLAN-0025 §3 P4 ("≥5 dry-run cycles…")
+as *the* graduation gate for this caller. Read at source, P4 is written against
+the **operations** repo as the sole pilot consumer, and §6 puts sibling-consumer
+onboarding explicitly out of scope — *"each consumer onboards at its own pace
+post-graduation."* No plan document binds this repo to P4's numbers. It remains a
+sensible bar to hold ourselves to; it is not a requirement we are failing.
+
+**2. The prior diagnosis was wrong, and the error was structural.** `#396`
+recorded this repo's half of the bug as five paths in
+`auto_merge.high_risk_paths` missing from `allowed_paths`, to be fixed by
+aligning the lists. That fix would have changed nothing. `planner.py:187` rejects
+a non-allowlisted path *before* classification is reached; `planner.py:197`
+already treats anything not low-risk as high-risk; and `high_risk_paths` is never
+shown to the model and never widens the allowlist. The five entries are inert
+defence-in-depth and caused **none** of the 23 failures. They are now documented
+as deliberate in the config itself, because the next reader will otherwise
+re-derive the same wrong conclusion from the same evidence.
+
+The misreading was not carelessness — it was **manufactured by canon's error
+message**. `duplicate or non-allowlisted plan path: <path>` covers two conditions
+in one string, and the single most common failure (9 of 23) names
+`plans/HANDOFF.md`, which *is* allowlisted. An allowlist-shaped message about an
+allowlisted path reads unambiguously as a config mismatch. **When a message names
+a condition, verify the named artifact actually violates it before acting.**
+
+**3. Census before root cause; a sample will mis-weight it.** The first pass here
+sampled failures and named `#352` as "the blocker", then wrote that framing into
+three files. A full census over all 23 failures put `#352` at 3 and `#353` at 15.
+Both statements are true — `#352` is the *graduation* blocker because it is the
+terminal gate that can never pass, while `#353` is the dominant *observed*
+failure — but conflating them produced a **resume condition that would have
+returned a majority-red pilot**, since it named `#352` alone. The corrected
+condition requires `#352` **and** `#353`. **A root cause is a claim about a
+distribution; derive the distribution first.**
+
+**4. Report a guard that is working when its blast radius is wrong.** Two
+failures were apply's *"deleted/replaced more than 30 % of README.md"* guard. The
+guard is correct and should not be relaxed — but like the planner's, it aborts
+the whole run instead of dropping the entry. That is the same defect as `#353`,
+so it was added there as evidence rather than filed as a fourth issue.
+**Correct-but-over-broad enforcement is still a defect worth reporting**, and it
+belongs on the issue that already argues the general shape.
+
+---
+
 ## D-0071 — Adoption is a separate dimension from pinning; and an asserted absence is the cheapest defect to file and the hardest to verify
 
 **2026-07-29.** Decisions from CANON-PARITY-001 (PR `#378`), which adopted the

--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -24,41 +24,32 @@
 
 ## Open
 
-### `[ci]` `DOC-MAINTAINER-RED-ON-EVERY-PUSH` — the adopted dry-run caller has failed every `push` run since it landed, unwatched
+### `[docs]` `HANDOFF-OVER-SIZE` — the handoff is ~425 lines against a ~200-line target, and the overflow is durable content in the wrong file
 
-- *Context:* found 2026-07-30 while confirming the `ci/v2.16.0` migration was
-  complete (it is — 17/17 call sites). `doc-maintainer.yml` was adopted in #382
-  on 2026-07-29; since then **20 failures / 41 runs**. `schedule` runs succeed
-  because they find nothing to do; **every `push` run fails**. Two distinct
-  causes, measured across five failing runs:
-  `planner: duplicate or non-allowlisted plan path: <X>` (4 of 5) and
-  `apply: refusing autonomous full-file generation over 200 KB: CHANGELOG.md`
-  (which is 276 KB and only grows).
-- *Fix shape:* **ours** — `.github/doc-maintainer.json` lists five paths in
-  `auto_merge.high_risk_paths` that are absent from `allowed_paths`
-  (`CLAUDE.md`, `plans/DECISIONS.md`, `plans/FRAMEWORK-TODO.md`,
-  `plans/HERMES-BACKLOG.md`, `framework/governance/DECISIONS.md`), so the
-  planner proposes them and the gate rejects them. Decide whether each should
-  be maintainable at all, then align the two lists.
-  **Canon's** — the error message conflates *duplicate* with *non-allowlisted*
-  (`plans/HANDOFF.md` **is** allowlisted, so its failures are the duplicate
-  branch), and the 200 KB refusal fires on an allowlisted **low-risk** path with
-  no chunking path. Both belong on `aidoc-flow-ci`; **not yet filed.**
-- *Note:* this is the same unread-surface class `PIN-CURRENCY-NO-READER` closed,
-  one level worse — that one was warning-only, this one is red.
+- *Context:* noted 2026-07-30 while regenerating for #397. Target is well under ~200
+  lines. The bulk is **`## Durable traps` (~250 lines)** — content the rule says to keep,
+  but keep *small*, and which the file's own header already routes elsewhere: "a trap
+  already recorded in `CLAUDE.md` is not repeated here."
+- *Fix shape:* graduate settled traps to `CLAUDE.md` in tag-sized batches (the
+  acceptance-harness and local-hooks blocks are the largest self-contained ones), and
+  prune `## Stale advice` rows whose sources no longer exist. Its own change — it would
+  breach another PR's 3-surface cap. Re-measure with `wc -l`; do not trust a number
+  written here.
 
-### `[docs]` `DOC-MAINTAINER-ADOPTION-CLAIM-STALE` — two docs still say the caller is unadopted and its secrets absent
+### `[docs]` `DOC-MAINTAINER-ADOPTION-CLAIM-STALE` — `CLAUDE.md` still says sixteen call sites across fifteen files
 
 - *Context:* found 2026-07-30. `CLAUDE.md` says "**sixteen** `aidoc-flow-ci` call
   sites across fifteen files"; the real count has been **17 across 16** since #382
-  added `doc-maintainer.yml`. `plans/HANDOFF.md` called it "the one canon surface
-  still unadopted" and claimed `LITELLM_DOC_API_KEY` / `LITELLM_BASE_URL` exist on
-  `aidoc-flow-operations` "but not here" — `gh secret list` shows **both present
-  on this repo**. Only `AIDOC_FLOW_BOT_ID` / `AIDOC_FLOW_BOT_KEY` are missing, and
-  those are live-mode only.
-- *Fix shape:* HANDOFF corrected in the same change as this entry. **`CLAUDE.md`
-  is not** — fold the count fix into the plan's PR 4, which already edits
-  `CLAUDE.md`, rather than spending a governance PR on one number.
+  added `doc-maintainer.yml`. The `plans/HANDOFF.md` half of this entry (the
+  "still unadopted" and "secrets absent" claims) was corrected in #396 — `gh secret
+  list` shows `LITELLM_BASE_URL` and `LITELLM_DOC_API_KEY` both present here; only
+  `AIDOC_FLOW_BOT_ID` / `AIDOC_FLOW_BOT_KEY` are missing, and those are live-mode
+  only.
+- *Fix shape:* fold the count fix into the pin-currency plan's PR 4, which already
+  edits `CLAUDE.md`, rather than spending a governance PR on one number. Re-count before
+  editing — do not copy the number from here. Sites, then files:
+  `grep -rho 'aidoc-flow-ci/\.github/workflows/[^@]*@ci/v[0-9.]*' .github/workflows/ | wc -l`
+  and `grep -rl 'aidoc-flow-ci/\.github/workflows/.*@ci/v' .github/workflows/ | wc -l`.
 
 ### `[harness]` `IDHASH-GUARD-GLOB-NARROW` — the `#342` regression guard scans 41 of 52 plugin SKILLs and 36 of 39 Hermes references → [#385](https://github.com/vladm3105/aidoc-flow-framework/issues/385)
 
@@ -1197,6 +1188,49 @@ check that was already running and already right.
 - *Status:* SHIPPED (spec 0.32.3, 2026-06-29 — BeeLocal docs sweep).
 
 ## Closed
+
+### `[ci]` `DOC-MAINTAINER-RED-ON-EVERY-PUSH` — ✅ CLOSED (2026-07-30, PR #397) — the adopted dry-run caller was red on nearly every push, unwatched
+
+- *Context:* found 2026-07-30 while confirming the `ci/v2.16.0` migration was
+  complete (it is — 17/17 call sites). `doc-maintainer.yml` was adopted in #382 on
+  2026-07-29; **23 failures / 47 runs**, 12 of 13 `push` runs, across **four**
+  independent upstream defects — not the two originally recorded.
+- *Resolution:* `kill_switch: true` (PR #397, D-0072). Verified in production: the
+  merge's own push run went green — `kill_switch=true; exiting cleanly (no LLM cost
+  incurred)`. `CHANGELOG.md` also removed from `allowed_paths` (281 KB, past the
+  200 KB apply refusal). **Resume requires `aidoc-flow-ci` #352 AND #353** — #353
+  alone is 15 of the 23, so #352 alone returns a majority-red pilot.
+- *Correction — the original fix shape in this entry was wrong.* It named five
+  paths in `auto_merge.high_risk_paths` absent from `allowed_paths` as "ours" and
+  proposed aligning the lists. That is a no-op: `planner.py:187` rejects a
+  non-allowlisted path before classification, `planner.py:197` already treats
+  anything not low-risk as high-risk, and `high_risk_paths` is never shown to the
+  model. Those five caused **none** of the 23 failures; they are deliberate
+  defence-in-depth and are now documented as such in the config. The misreading
+  came from canon's message conflating *duplicate* with *non-allowlisted* — see
+  D-0072 point 2.
+- *Filed upstream:* [#352](https://github.com/vladm3105/aidoc-flow-ci/issues/352)
+  (Step 9 `set -e` — the graduation blocker),
+  [#353](https://github.com/vladm3105/aidoc-flow-ci/issues/353) (one bad entry reds
+  the run; `validation.rejected` declared and never written; the 30 %-deletion
+  guard added as evidence),
+  [#354](https://github.com/vladm3105/aidoc-flow-ci/issues/354) (200 KB refusal vs
+  an install template shipping `CHANGELOG.md` as low-risk, while canon's own
+  changelog is 363 KB).
+
+### `[docs]` `FEEDBACK-READBACK-FALSE-NEGATIVE` — ✅ CLOSED (2026-07-30, filed) — the cross-repo comment readback can report a published comment as empty
+
+- *Context:* found 2026-07-30 while filing the three canon issues above.
+  `operations/docs/AGENT_FEEDBACK_INTAKE.md:201` (and the `submit-feedback` skill
+  §5) prescribe `gh issue view <N> --json comments --jq '.comments[-1].body|length'`
+  as proof a comment published. It returned **0** for a comment that had published
+  in full (3,629 chars, confirmed via `gh api …/issues/comments/<id>`), and
+  returned the right value on a later read — read-after-write lag, not a broken
+  command. The doc calls a non-zero length "the only proof it published", so an
+  agent following it literally re-posts and duplicates.
+- *Resolution:* filed as
+  [aidoc-flow-operations#290](https://github.com/vladm3105/aidoc-flow-operations/issues/290)
+  with the id-anchored readback as the suggested fix. Not this repo's to fix.
 
 ### `[ci]` `ACCEPTANCE-TIER-REQUIRED-CHECK` — ✅ CLOSED (2026-07-27) — promote the acceptance gate to a required status check
 

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -31,41 +31,34 @@ semantics, the runner split incl. why `sast-scan` is the `ubuntu-latest` excepti
 ## Where we are — 2026-07-30
 
 Framework spec `0.40.0`, Claude Code plugin `0.24.0`, Hermes `0.12.0` — **no version
-stream moved today**. `main` clean at `c77ff3f4`. **Open PRs: 0. Open issues: 2** —
+stream moved today**. **Open PRs: 0. Open issues: 2** —
 [#385](https://github.com/vladm3105/aidoc-flow-framework/issues/385) and
 [#386](https://github.com/vladm3105/aidoc-flow-framework/issues/386), both unchanged.
 
-**The pin-currency reader shipped.**
-[#392](https://github.com/vladm3105/aidoc-flow-framework/pull/392) (`d3d7f845`) is PR 2
-of `plans/PIN-CURRENCY-READER-PLAN.md`: two scripts under `scripts/`, the
-`workflow_run` wrapper, five fixtures, 19 unit tests, and the
-`tests/conformance/test_repo_scripts.py` registration shim.
-[#394](https://github.com/vladm3105/aidoc-flow-framework/pull/394) (`c77ff3f4`) fixed a
-defect the post-merge verification found. The upstream half is filed as
-[aidoc-flow-ci#351](https://github.com/vladm3105/aidoc-flow-ci/issues/351) — five
-measured defects, body read back at 9179 chars.
+**`doc-maintainer` is PAUSED, and CI is green again.**
+[#397](https://github.com/vladm3105/aidoc-flow-framework/pull/397) set
+`kill_switch: true`. Verified in production, not assumed: the merge's own `push` run
+succeeded with `doc-maintainer kill_switch=true; exiting cleanly (no LLM cost incurred)`.
+Only one other `push` run had gone green since adoption, and that one passed by
+proposing nothing; this is the first that is green *by design*. The caller, its config
+and its conventions all stay in place; resume is a one-line flip.
 
-**V10–V14 all pass, so PR 3 is unblocked.** Measured, not assumed:
+It had 23 failures / 47 runs across **four** independent upstream defects — not the two
+previously recorded, and **not** the config mismatch this repo was blamed for (retracted;
+see Next tasks item 2 and **D-0072 §2**). The full census lives in D-0072 and in
+`.github/doc-maintainer-conventions.md`, which is kept current for the resume; do not
+copy it here.
 
-| # | Result |
-|---|---|
-| V10 | issue #393 created — 10 file rows, `--repin` command, `last verified` line, assignee set, `ci` label applied |
-| V11 | re-dispatch → edited in place; **1** issue, **0** new comments |
-| V12 | closed by hand → **reopened** and commented; still 1 issue |
-| V13 | label fallback, via the stub |
-| V14 | `standards-drift` dispatched → reader run with **`event=workflow_run`** |
+**Resume requires ci#352 AND ci#353** — #353 alone is 15 of the 23, so flipping on #352
+alone returns a majority-red pilot. #352 is the smaller count and still the blocker for
+*graduation*: no plan containing a low-risk edit can complete a dry run, which is the
+path a dry-run pilot exists to validate.
 
-**pending — V15 (schedule→`workflow_run` chain) unconfirmed until the first Monday run.**
-It was never a gate. V14 proved the `workflow_run` chain itself off a *dispatched*
-upstream; V15 only adds that a *scheduled* upstream chains the same way. Whoever sees
-the first Monday `standards-drift` run should check that a `pin-currency-reader` run
-followed it, then delete this paragraph.
-
-**V14 also verified the `clean` → close path live**, which the plan recorded as
-"deliberately absent" and stub-only. It became testable because canon `main` and every
-caller here now sit at `ci/v2.16.0`, so a live run reports `clean`. Issue #393 is the
-tool's own artifact — **closed, and correct to leave closed.** It reopens by itself the
-next time canon tags a release, which is the designed behaviour, not a bug.
+**Pin-currency reader (#392/#394) shipped earlier; V10–V14 all passed, so PR 3 is
+unblocked.** **V15 (schedule→`workflow_run` chain) is still unconfirmed** — it was never
+a gate; V14 proved the chain off a *dispatched* upstream. Whoever sees the first Monday
+`standards-drift` run should check a `pin-currency-reader` run followed it, then delete
+this paragraph.
 
 ## Next tasks — prioritized
 
@@ -90,22 +83,19 @@ The full queue is `plans/FRAMEWORK-TODO.md` (`## Open`) and
      copying that figure —
      `grep -rcE '^\s*uses: vladm3105/aidoc-flow-ci' .github/workflows/*.yml`.
    - The plan's §PR sequencing is the contract; read it rather than this summary.
-2. **`doc-maintainer` is ADOPTED and RED — it fails every `push` run, unwatched.**
-   → `FRAMEWORK-TODO.md` `DOC-MAINTAINER-RED-ON-EVERY-PUSH`.
+2. **`doc-maintainer` — nothing to do here; it is paused and waiting on upstream.**
+   Watch `aidoc-flow-ci` #352 and #353. When **both** ship in a released `ci/vX.Y.Z`:
+   re-pin this caller, flip `kill_switch` → `false` in `.github/doc-maintainer.json`,
+   and watch the next few `push` runs. Do **not** flip on #352 alone.
 
-   ⚠️ **Earlier handoffs said this surface was "still unadopted" and that its LiteLLM
-   secrets did not exist here. Both were false, and the claim survived several
-   regenerations.** `doc-maintainer.yml` was adopted in dry-run by #382 on 2026-07-29
-   (canon manifest parity 28/28), and `gh secret list` shows `LITELLM_BASE_URL` **and**
-   `LITELLM_DOC_API_KEY` present on this repo. Only `AIDOC_FLOW_BOT_ID` /
-   `AIDOC_FLOW_BOT_KEY` are absent, and those are **live-mode only** — dry-run does not
-   need them. Verify with `gh secret list` before repeating any secrets claim here.
+   ⚠️ **Do not re-file the `high_risk_paths` / `allowed_paths` mismatch as a defect.**
+   It is deliberate, inert, and documented in the config itself; #396 recorded it as a
+   bug and was wrong. D-0072 point 2 explains why the error message manufactures that
+   misreading.
 
-   The real state: **20 failures / 41 runs** since adoption. `schedule` runs succeed
-   (nothing to do); every `push` run fails, on two distinct causes — a planner
-   allowlist/duplicate rejection, and a 200 KB refusal on `CHANGELOG.md` (276 KB). The
-   config half is ours to fix; the conflated error message and the size refusal belong
-   upstream and are **not yet filed**. See the TODO entry for the measurements.
+   `gh secret list` shows `LITELLM_BASE_URL` **and** `LITELLM_DOC_API_KEY` present here;
+   only `AIDOC_FLOW_BOT_ID` / `AIDOC_FLOW_BOT_KEY` are absent, and those are **live-mode
+   only**. Verify with `gh secret list` before repeating any secrets claim.
 3. **`FRAMEWORK-TODO.md` hygiene — bigger than "pick a convention".** The queue is
    unreliable in *two* directions: entries marked `✅ CLOSED` sit under `## Open` (so it
    **overstates** what is open), and `## Closed` holds unmarked entries that read as
@@ -373,6 +363,15 @@ These cost real defects in merged code, each found only by looking at the artifa
   Apply the label by *retry* (labelled, then unlabelled + `::warning::`) — never
   `|| true`, which makes the whole creation non-fatal. Set the assignee *after*
   creation, so its failure cannot take the create with it.
+- **The prescribed comment-readback can report a published comment as empty.**
+  `gh issue view <N> --json comments --jq '.comments[-1].body|length'` returned **0**
+  for a comment that had published in full (3,629 chars via
+  `gh api …/issues/comments/<id>`), and the correct value on a later read —
+  read-after-write lag. The feedback contract calls a non-zero length "the only proof it
+  published", and the symptom is **identical to the `--body -` bug**, so the natural
+  reaction is to re-post and duplicate. Anchor the check to the id in the URL `gh`
+  returned, or retry before concluding anything. Filed as
+  [aidoc-flow-operations#290](https://github.com/vladm3105/aidoc-flow-operations/issues/290).
 - **`gh issue list` defaults to `--limit 30`**, and this repo is past #390. A tracking
   issue that has aged off page 1 is invisible to an exact-title lookup, and the run
   creates a duplicate. `--state all --limit 200`, and never `--search` (tokenized and
@@ -400,6 +399,18 @@ directory:** `gh api repos/<r>/contents/.github/workflows --jq '.[].name'`.
 - **Write the scan before the census.** A surface count went 9 → 19 → the truth of
   **25**, because both manual passes sampled one file instead of the tree. A hand-built
   census of a class is a sample that gets reported as a total.
+- **A root cause is a claim about a distribution — derive the distribution first**
+  (**D-0072 §3**). A sampled read of `doc-maintainer`'s failures named ci#352 "the
+  blocker" and that framing reached three files; the full census put #352 at 3 of 23 and
+  #353 at 15. Both are true in their own sense, but conflating them produced a **resume
+  condition that would have returned a majority-red pilot**. Loop every failing run and
+  bucket the errors before naming a cause.
+- **When an error names a condition, check the named artifact actually violates it**
+  (**D-0072 §2**). Canon's `duplicate or non-allowlisted plan path: <path>` covers two
+  conditions in one string, and its most frequent instance named a path that **is**
+  allowlisted. An allowlist-shaped message about an allowlisted path read as a config
+  mismatch, and that misdiagnosis was written into the backlog as this repo's bug. One
+  `jq '.allowed_paths'` falsified it.
 - **Mutation-test a negative-property guard.** `test_no_inprompt_hashing.py` passed a
   live reintroduction on first write: markdownlint reflows those surfaces into single
   long lines, so the correction and the regression shared a line and a line-scoped


### PR DESCRIPTION
The record for [#397](https://github.com/vladm3105/aidoc-flow-framework/pull/397) (merged), which paused the `doc-maintainer` pilot. **Governance PR — founder merges.** Three doc surfaces, exactly at Rule 1's cap.

## What this records

| Surface | Change |
|---|---|
| `plans/DECISIONS.md` | **D-0072**, four points — why pause rather than narrow or un-adopt; why the prior diagnosis was wrong and why the error was *structural*; census-before-root-cause; and reporting a guard that works but over-reaches |
| `plans/FRAMEWORK-TODO.md` | `DOC-MAINTAINER-RED-ON-EVERY-PUSH` → `## Closed` with the merge ref **and an explicit correction of its own fix shape**. `DOC-MAINTAINER-ADOPTION-CLAIM-STALE` narrowed to the half still open. Two new entries: `FEEDBACK-READBACK-FALSE-NEGATIVE` (closed, filed upstream) and `HANDOFF-OVER-SIZE` |
| `plans/HANDOFF.md` | Volatile sections regenerated. Item 2 rewritten from *"red, fix the config"* to *"paused, watch ci#352 **and** ci#353, do not re-file the `high_risk_paths` mismatch"* |

## The retraction, because it is the point of the PR

`#396` recorded this repo's half of the bug as five paths in `auto_merge.high_risk_paths` missing from `allowed_paths`, fixable by aligning the lists. **That fix would have changed nothing.** `planner.py:187` rejects a non-allowlisted path *before* classification is reached; `planner.py:197` already treats anything not low-risk as high-risk; `high_risk_paths` is never shown to the model and never widens the allowlist. Those five caused **none** of the 23 failures.

The misreading was manufactured, not careless: canon's `duplicate or non-allowlisted plan path: <path>` covers two conditions in one string, and its most frequent instance (9 of 23) named `plans/HANDOFF.md` — which **is** allowlisted. An allowlist-shaped message about an allowlisted path reads unambiguously as a config mismatch. D-0072 §2 records the generalizable form: **when an error names a condition, check that the named artifact actually violates it.**

## Verification

- The `#397` merge's own `push` run went green — `kill_switch=true; exiting cleanly (no LLM cost incurred)`. Verified in production, not assumed.
- Census re-derived from all 23 failing runs: 9 duplicate / 6 non-allowlisted / 3 × 200 KB / 3 × Step 9 / 2 × 30 %-deletion. Consistent across all six surfaces (three here, three merged in #397).
- Re-count commands in the TODO entry executed, not just written: 17 sites / 16 files.

## Review

Multi-agent self-review per OPS-0065 (code-reviewer, documentation-specialist) — 0 critical, 2 medium, 3 low, folded in one cycle.

- **Medium 1 — an overstated authority claim, inherited.** D-0072 and the handoff cited IPLAN-0025 §3 P4 as this caller's graduation gate. Read at source, P4 is written against the **operations** repo, and §6 puts sibling-consumer onboarding explicitly out of scope (*"each consumer onboards at its own pace post-graduation"*). No plan binds this repo to those numbers. The framing came from #382 and was carried into #397; D-0072 now marks the bar as self-imposed and says so in a ⚠️ note rather than silently dropping it.
- **Medium 2 — the handoff committed the defect it was filing.** The regenerated file restated the #396 retraction twice and copied the 5-row census that `CHANGELOG.md` and `doc-maintainer-conventions.md` already carry — the exact duplication `HANDOFF-OVER-SIZE` is about. Both collapsed to pointers, cutting **12 of the 23 lines** this PR had added (436 → 424).
- **Lows:** a stale line count, a TODO entry over the file's own 3-line convention, and a re-count command that printed per-file counts needing manual summation. All fixed; the replacement commands were run.

## Note on the earlier PR

`#397` is merged and carries the IPLAN-0025 §3 P4 framing in `CHANGELOG.md` and `.github/doc-maintainer-conventions.md`. Correcting those would be a 4th and 5th surface, so D-0072 carries the qualification instead — the changelog is an append-only dated record and is correct to leave as written.
