### PR TITLE
docs: graduate the annotation-cap trap + the fourth concurrency shape (PIN-CURRENCY-NO-READER PR 4/4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -442,14 +442,29 @@ reasoning, defended by a comment arguing it was safe, until it became required
 on 2026-07-27. **Any change that makes one of the seven required must take the
 allowlist in the same PR.**
 
-The surfaces adopted by CANON-PARITY-001 add two more shapes, so "does it
-cancel?" is now a three-way question, not two: `markdown-lint` already ships
+"Does it cancel?" is a **four**-way question, not two, and the shapes arrived
+from different work: CANON-PARITY-001's adopted surfaces added two, and
+`pin-currency-reader.yml` (#392) added the fourth. `markdown-lint` already ships
 canon's `#329` allowlist (it is a required context *for other consumers*, and the
 template is uniform), while `dep-scan`, `sast-scan` and `trivy-scan` carry **no
 `concurrency:` block at all** — they never cancel, which is the safest state and
 needs no allowlist. `codeql` keeps plain `cancel-in-progress: true`, which is why
-it stays in the seven above. **Count the exemption by shape, not by filename:**
-absent block ≠ allowlist ≠ bare `true`.
+it stays in the seven above.
+
+**The fourth shape is `cancel-in-progress: false` under a fixed group, and it is
+serialization — not an absent block written out longhand.**
+`pin-currency-reader.yml:55-57` pins `group: pin-currency-reader` so that a
+`workflow_run` and a concurrent `workflow_dispatch` cannot both find no open
+issue and both create one. **Never re-derive it as "nothing to cancel, so
+nothing to fix"** — that is verbatim the argument this repo uses to justify
+carrying **no** `concurrency:` block at all, so a sweep reading it that way
+deletes the block and reintroduces the duplicate-issue race. Rationale:
+`plans/DECISIONS.md` D-0073 §7, and the workflow file states it at the block —
+including the caveat that serialization is **not** a guarantee every upstream
+verdict is read, since GitHub queues at most one *pending* run per group.
+
+**Count the exemption by shape, not by filename:** absent block ≠ `#329`
+allowlist ≠ bare `true` ≠ `false` under a fixed group.
 
 Runner split — deliberate, do not "normalize":
 
@@ -767,6 +782,29 @@ fresh to have settled, and never repeats one that is already here.
   reviewer correctly derived a **23rd** warning from the v2.16.0 source and concluded
   the measured **22** was wrong. **Read the `adopted canon pin` notice in the run's
   own log before citing line numbers at it.**
+- **The check-run annotations API truncates at 10 per annotation level, keeping the
+  earliest — so it is not a substitute for the log when what you want is emitted
+  late.** Check-run `89950624082` emitted **22** `##[warning]` lines and the API
+  returned **10 warnings**; **none** of the ten `pin-currency:` lines survived, because
+  they are emitted at the drift script's tail. Below the cap the API is complete and is
+  the cheaper surface — **a level returning exactly 10 is the truncation signal; fewer
+  than 10 at a level means that level is whole.**
+  - **Verify with
+    `--jq 'group_by(.annotation_level)|map({(.[0].annotation_level):length})|add'`,
+    never bare `length`** — the response length is **11**, 10 `warning` plus 1
+    `notice`, so a bare count reads as off-by-one and the trap gets discarded as false.
+  - **"Earliest" is which annotations survive, not the order they come back in.** The
+    response is sorted by *descending* `start_line`, so `.[0]` is the **last** survivor
+    (measured: `.[0]` at line 88; the earliest survivor, line 79, is second-to-last).
+    Check "keeps the earliest" against `.[-1]`, or it reads as refuted and a true trap
+    gets discarded.
+  - That surviving `notice` is also the evidence the cap applies **per annotation
+    level**: a full 10 warnings did not crowd it out. **Per-step vs per-job vs per-run
+    stays unattributable** from this measurement — the whole drift script is one `run:`
+    step, so the three are indistinguishable here. Claim per-level; do not claim
+    per-step.
+  - The `22` is dated to `ci/v2.14.0` per the bullet above and **does not travel**;
+    `v2.16.0` emits more, so the truncation conclusion holds a fortiori.
 - **Canon's pin-currency check false-greens two ways, and one would make a reader
   close a tracking issue.** `check-pin-currency.sh:62` greps `@ci/v…` literally, so a
   **SHA-pinned** caller is invisible and it reports `all pins current ✅` — while the

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -35,15 +35,15 @@ stream moved today**. **Open PRs: 0. Open issues: 2** —
 [#385](https://github.com/vladm3105/aidoc-flow-framework/issues/385) and
 [#386](https://github.com/vladm3105/aidoc-flow-framework/issues/386), both unchanged.
 
-**Last merge: [#401](https://github.com/vladm3105/aidoc-flow-framework/pull/401) — PR 3
-of `PIN-CURRENCY-NO-READER`, the close-out.** It recorded **D-0073** (rationale lives
-there; not restated here) and moved the TODO entry to `## Closed` against the merges
-that shipped the work, `d3d7f845` (#392) and `c77ff3f4` (#394). *(This file is written
+**Last merge: [#402](https://github.com/vladm3105/aidoc-flow-framework/pull/402) — PR 4
+of `PIN-CURRENCY-NO-READER`, the last of four. `PIN-CURRENCY-NO-READER` is now closed
+end to end.** It graduated the annotation-cap trap and the concurrency inventory's
+**fourth** shape (`cancel-in-progress: false` under a fixed group = serialization) into
+`CLAUDE.md`, and moved the plan's Status to `IMPLEMENTED`. Three things it leaves
+behind, all below: the two watch items (V15, and ci#351) and one queue entry that no
+queue yet holds (next tasks item 3). *(This file is written
 inside the PR it describes, so it carries the PR number and no squash SHA — that SHA
 does not exist until merge. `git log -1 -- plans/HANDOFF.md` gives it.)*
-
-**Only PR 4 of that plan remains** — see Next tasks item 1. It is the sole reason the
-`## Unsettled trap` section below still exists.
 
 **`doc-maintainer` is PAUSED, and CI is green again.**
 [#397](https://github.com/vladm3105/aidoc-flow-framework/pull/397) set
@@ -73,34 +73,13 @@ the merged workflow, not a reopening of the plan.
 The full queue is `plans/FRAMEWORK-TODO.md` (`## Open`) and
 `plans/HERMES-BACKLOG.md`. This is only the ordering a fresh session should use.
 
-1. **`PIN-CURRENCY-NO-READER` — PR 4, the last of four. Governance PR; the founder
-   merges.** Two surfaces, both still outstanding:
-   - **`CLAUDE.md`** — (a) the annotation-cap trap, stated at the granularity M1
-     actually supports, which is why § "Unsettled trap" below still exists; and (b) the
-     concurrency inventory's **fourth** shape — `cancel-in-progress: false` under a
-     fixed group, which `pin-currency-reader.yml` introduced. Today § "Unified CI"
-     describes three shapes (absent block / `#329` allowlist / bare `true`) and calls
-     it a three-way question; PR 4 makes it four. The rationale is in **D-0073 §7**,
-     including the sentence it must *not* be written as.
-   - **The plan's Status → `IMPLEMENTED`** (it reads `IN PROGRESS`, describing PR 2 as
-     open — stale on both counts).
-   - What is **not** PR 4's to carry: the call-site count (landed by
-     `HANDOFF-OVER-SIZE`; `CLAUDE.md` says **seventeen across sixteen** with its
-     re-count commands beside it) and any D-0073 content beyond the trap — the decision
-     log already holds it.
-   - **Also PR 4's, and easy to miss:** the plan's own `## Docs to update` boxes for
-     PR 3 stay unticked after this merge (ticking them here would have been a fourth
-     surface), and its **V1 row still says 17 tests** where the suite now runs 18 —
-     `#394`'s regression guard. PR 4 is already editing that file, so both cost
-     nothing.
-   - The plan's §PR sequencing is the contract; read it rather than this summary.
-2. **Watch [aidoc-flow-ci#351](https://github.com/vladm3105/aidoc-flow-ci/issues/351) —
+1. **Watch [aidoc-flow-ci#351](https://github.com/vladm3105/aidoc-flow-ci/issues/351) —
    when canon ships its own reader, DELETE ours.** `.github/workflows/pin-currency-reader.yml`
    plus `scripts/read-pin-currency-log.sh` and `scripts/reconcile-pin-currency-issue.sh`
    are the "add a custom workflow" override mode, not a permanent local surface (plan
    R9). Nothing else in a live queue says so — the statement otherwise survives only
    inside the merged plan, which is why it is here.
-3. **`doc-maintainer` — nothing to do here; it is paused and waiting on upstream.**
+2. **`doc-maintainer` — nothing to do here; it is paused and waiting on upstream.**
    Watch `aidoc-flow-ci` #352 and #353. When **both** ship in a released `ci/vX.Y.Z`:
    re-pin this caller, flip `kill_switch` → `false` in `.github/doc-maintainer.json`,
    and watch the next few `push` runs. Do **not** flip on #352 alone.
@@ -113,7 +92,7 @@ The full queue is `plans/FRAMEWORK-TODO.md` (`## Open`) and
    `gh secret list` shows `LITELLM_BASE_URL` **and** `LITELLM_DOC_API_KEY` present here;
    only `AIDOC_FLOW_BOT_ID` / `AIDOC_FLOW_BOT_KEY` are absent, and those are **live-mode
    only**. Verify with `gh secret list` before repeating any secrets claim.
-4. **`FRAMEWORK-TODO.md` hygiene — bigger than "pick a convention".** The queue is
+3. **`FRAMEWORK-TODO.md` hygiene — bigger than "pick a convention".** The queue is
    unreliable in *two* directions: entries marked `✅ CLOSED` sit under `## Open` (so it
    **overstates** what is open), and `## Closed` holds unmarked entries that read as
    live backlog — `[gate] Component-decomposition gate missing between PRD and ADR`,
@@ -129,7 +108,15 @@ The full queue is `plans/FRAMEWORK-TODO.md` (`## Open`) and
    awk '/^## Closed/{c=1} c&&/^### /{e++} c&&/✅ CLOSED/{m++} END{print e, m}' plans/FRAMEWORK-TODO.md
    ```
 
-5. **[#385](https://github.com/vladm3105/aidoc-flow-framework/issues/385) — the `#342`
+   **Add one entry while you are in there:** *give the pin-currency reader its own
+   reader*. D-0073 §3 names it a live open risk with a concrete instance —
+   `pin-currency-reader.yml:67` skips the reader when the upstream `standards-drift`
+   run concludes failure, so the pin verdict goes unread exactly when something else
+   has already broken — and the plan deliberately left it out of scope. It is recorded
+   in `DECISIONS.md` only; no queue holds it, which is the failure mode
+   `GOV-TODO-ISSUE-SPLIT` exists to prevent.
+
+4. **[#385](https://github.com/vladm3105/aidoc-flow-framework/issues/385) — the `#342`
    regression guard scans less than it claims.**
    `tests/conformance/platforms/test_no_inprompt_hashing.py:99`/`:103` use
    `glob("doc-*/SKILL.md")` and a non-recursive `glob("*.md")`, so **41 of 52** plugin
@@ -141,7 +128,7 @@ The full queue is `plans/FRAMEWORK-TODO.md` (`## Open`) and
    docstring (`:92`) forbids narrowing coverage by glob, which is what happened. Fix is
    `rglob` both + point the script at `rehash --compute`; the issue carries the census
    command. **A green run of this guard is not evidence that no surface hashes.**
-6. **[#386](https://github.com/vladm3105/aidoc-flow-framework/issues/386) — the
+5. **[#386](https://github.com/vladm3105/aidoc-flow-framework/issues/386) — the
    framework-spec token gates five files on `CLAUDE.md`'s own state.** The mechanism
    and the hand-edit hazard are in `CLAUDE.md` § "Durable traps → Local hooks and
    tooling"; do not restate them here. Outstanding here is only the **fix shape**:
@@ -149,10 +136,10 @@ The full queue is `plans/FRAMEWORK-TODO.md` (`## Open`) and
    writing only `CLAUDE.md`, but this one cannot take that shape unchanged, because
    its `prev` is load-bearing elsewhere. Derive the gating `prev` from a fanout target
    nobody hand-edits (`docs/PARITY.md`), and give `CLAUDE.md` its own block.
-7. **Hermes parity — the residual arc.** `plans/HERMES-BACKLOG.md`: remaining
+6. **Hermes parity — the residual arc.** `plans/HERMES-BACKLOG.md`: remaining
    plugin-vs-Hermes deltas plus quality-loop Phase 2 (cross-invocation resume / G-R1,
    the parallel-review global lock).
-8. **Everything else** is in `FRAMEWORK-TODO.md` by tag (`[ci]`, `[lint]`,
+7. **Everything else** is in `FRAMEWORK-TODO.md` by tag (`[ci]`, `[lint]`,
    `[template]`, `[harness]`, `[example-corpus]`, `[docs]`, `[skill]`, `[sync]`),
    including the D54 and Engramory consumer-feedback batches. Nothing there is
    blocking.
@@ -160,24 +147,6 @@ The full queue is `plans/FRAMEWORK-TODO.md` (`## Open`) and
 **Standing:** the example corpus is regenerated wholesale after framework changes, so
 corpus-remediation findings are deferred to that regen rather than fixed in place.
 IPLAN ↔ iplanic integration is deferred (`plans/IPLAN-IPLANIC-DEFERRED.md`).
-
-## Unsettled trap — not yet in `CLAUDE.md`
-
-One item is deliberately held here because PR 4 above is chartered to propagate it.
-Delete this whole section when PR 4 lands.
-
-- **The check-run annotations API silently truncates at 10 warnings, keeping the
-  earliest.** Measured on check-run `89950624082`: the job emitted **22** `##[warning]`
-  lines and the API returns **10** — dropping all ten `pin-currency:` lines, because
-  they are emitted at the drift script's tail. So **`gh api …/annotations` is not a
-  substitute for the log** when the thing you want is emitted late.
-  - **The response length is 11, not 10** — 10 `warning` plus 1 `notice`. Verify with
-    `--jq 'group_by(.annotation_level)|map({(.[0].annotation_level):length})|add'`, not
-    `length`, or this trap reads as false and gets discarded.
-  - That surviving `notice` **is** evidence the cap is applied **per annotation level**:
-    a full 10 warnings did not crowd it out. What stays unattributable from this run is
-    per-step vs per-job vs per-run — the whole script is one `run:` step, so those three
-    are indistinguishable here. PR 4 may claim per-level, not per-step.
 
 ## Stale advice — a fresh session will find these referenced, and they are FIXED
 
@@ -194,4 +163,5 @@ remaining source was this file have been deleted rather than carried forward.
 | `NO-PIN-CURRENCY-CHECK` — "this repo runs `check-pin-currency.sh` nowhere" | **Retracted, it was false** — the check runs on every weekly `standards-drift`. The generalised lesson is in `CLAUDE.md` § "Durable traps → Process" |
 | `PIN-CURRENCY-NO-READER` — "the fix is a workflow that **runs the script** and opens an issue" | **Superseded and now SHIPPED** (#392). Running the script would be the second detector the same entry forbids; the reader consumes the completed run's **log** |
 | `PIN-CURRENCY-READER-PLAN.md:465`/`:469` — "a live `clean` check is deliberately absent … the `clean` path is verified only by V4's stub" | **Overtaken by events.** Canon `main` and every caller here are both `ci/v2.16.0`, so a live run reports `clean` — V14 exercised close-on-clean for real. This is the stale row most likely to be hit, because item 1 above sends the next session into that same plan |
+| `FRAMEWORK-TODO.md`'s closed `HANDOFF-OVER-SIZE` entry — "the check-run annotation-cap trap **stays** in the handoff, because `PIN-CURRENCY-READER-PLAN.md` PR 4 is chartered to propagate it" | **Done — PR 4 is the merge described above.** The trap now lives in `CLAUDE.md` § "Durable traps → Reading CI output" and is gone from here. That TODO line is history inside a `✅ CLOSED` entry and was deliberately left unedited: correcting it would have made a fourth doc surface against Rule 1's cap of three |
 | `plans/PLAN-*.md` as the governance-PR plan glob (`CHANGELOG.md`, `CI-CANON-V2.16-MIGRATION-PLAN.md:468`/`:784`) | **Fixed in `CLAUDE.md`** (#387/#390). The glob is a **suffix** — `plans/*-PLAN.md`. Merged plans and the CHANGELOG keep the old string as history; `CLAUDE.md` is the live rule |

--- a/plans/PIN-CURRENCY-READER-PLAN.md
+++ b/plans/PIN-CURRENCY-READER-PLAN.md
@@ -4,7 +4,7 @@
 | -------------- | ---------------------------------------------------------------------- |
 | Task           | `PIN-CURRENCY-NO-READER` (`plans/FRAMEWORK-TODO.md`, `[ci]`)            |
 | Type           | feature                                                                |
-| Status         | IN PROGRESS — 2026-07-30. PR 1 merged (plan); **PR 2 open** (scripts, workflow, fixtures, tests, registration shim). PR 3 gated on V10–V14; PR 4 last. Reviewed over 5 passes, zero load-bearing findings outstanding |
+| Status         | IMPLEMENTED — 2026-07-31. #383 (plan), #392 + #394 (scripts, workflow, fixtures, tests, registration shim, and the published-artifact fix) and #401 (D-0073 + TODO closure) are **merged**; PR 4 is this change itself (`CLAUDE.md` trap + fourth concurrency shape + this Status + the handoff), written inside the PR it describes and therefore carrying no merge ref of its own. V1–V14 and V16 pass; **V15 is not a gate** and stays unconfirmed until the first Monday `schedule` run (2026-08-03) — a failure there is a new bug against the merged workflow, not a reopening of this plan |
 | Depends on     | D-0070 (`@ci/v2.16.0` pins), D-0071 (CANON-PARITY-001)                 |
 | Feeds          | an upstream feature request on `aidoc-flow-ci`                          |
 | Version impact | none — no version stream moves (local CI surface only)                  |
@@ -329,7 +329,7 @@ surfaces**, and this work touches five plus the plan. It also requires the plan 
 | 1 | this plan file only; merges **before** implementation starts | 1 | **yes** — a plan file. Rule 2 self-review applies; not auto-mergeable |
 | 2 | the three new source files, five fixtures, the test, the registration shim, `CHANGELOG.md`, and this plan's Status → **`IN PROGRESS`** | 2 | **yes** — it touches the plan file |
 | 3 | `plans/DECISIONS.md` (`D-00NN`), `plans/FRAMEWORK-TODO.md` (→ `## Closed`), `plans/HANDOFF.md`. **Opens only after V10–V14 pass** | 3 | **yes** — `DECISIONS.md` |
-| 4 | `CLAUDE.md` (the annotation-cap trap at the granularity M1 supports, plus the concurrency inventory's **fourth** shape), and this plan's Status → **`IMPLEMENTED`** | 2 | **yes** — `CLAUDE.md`; founder-merge |
+| 4 | `CLAUDE.md` (the annotation-cap trap at the granularity M1 supports, plus the concurrency inventory's **fourth** shape), this plan's Status → **`IMPLEMENTED`**, and `plans/HANDOFF.md` (the trap is deleted from there as it graduates, and the volatile half is regenerated) | 3 | **yes** — `CLAUDE.md`; founder-merge |
 
 **All four are governance PRs and none is auto-mergeable.** An earlier draft named only
 PR 4 as excluded. `CLAUDE.md` defines a governance PR as one touching `DECISIONS.md`,
@@ -343,7 +343,10 @@ move in the same change as the state change, and forbids `IMPLEMENTED` on unveri
 work. PR 2's end-to-end verification (V10–V15) runs only *after* it merges (R1), so PR 2
 can set only `IN PROGRESS`; `IMPLEMENTED` (C37) belongs to PR 4, once V10–V14 have
 actually passed. PR 3 cannot absorb it — it is already at Rule 1's cap of three surfaces.
-PR 2 and PR 4 sit at two each.
+PR 2 sits at two. **PR 4 shipped at three, not the two this table originally projected**
+— the handoff refresh is mandatory at every merge, and the trap PR 4 graduates has to be
+deleted from the handoff in the same change that writes it into `CLAUDE.md`. At the cap,
+not over it.
 
 **PR 3 is gated on verification, and V15 is not part of that gate.** The TODO entry must
 not close on unverified work, so PR 3 opens only after **V10–V14** pass. V15 waits for
@@ -445,7 +448,7 @@ Split by what can run before the merge and what structurally cannot (R1).
 
 | #  | Check (command or observable) | Expected result | Maps to |
 | -- | ----------------------------- | --------------- | ------- |
-| V1 | `python3 -m unittest tests.unit.test_pin_currency_reader -v` | 17 pass: 8 parse cases (4 verdicts + 4 must-fail shapes) and 9 reconcile cases (six scenarios, the label fallback, and two asserting generated body content). Grew from 6 + 7 during PR 2's self-review — see §Review log Pass 6 | Task 1, Task 2 |
+| V1 | `python3 -m unittest tests.unit.test_pin_currency_reader -v` | **18** pass: 8 parse cases (4 verdicts + 4 must-fail shapes) and 10 reconcile cases (six scenarios, the label fallback, two asserting generated body content, and #394's guard that **no** generated markdown contains an escaped backtick, `:382`). Grew from 6 + 7 during PR 2's self-review — see §Review log Pass 6. Re-count with `grep -c 'def test_' tests/unit/test_pin_currency_reader.py` rather than trusting this figure | Task 1, Task 2 |
 | V2 | `python3 -m unittest discover -s tests/conformance` before vs. after the registration shim | the test count **increases** by the new cases, proving the shim reaches `tests/unit/` | R6 |
 | V3 | `bash scripts/read-pin-currency-log.sh tests/unit/fixtures/standards_drift_stale.log` | `verdict=stale`, `stale_count=10`, `canon=ci/v2.15.0` | Task 1 |
 | V4 | `GH=<stub> bash scripts/reconcile-pin-currency-issue.sh --dry-run` across the six scenarios in Task 2 | the expected create / edit / edit+comment / reopen / close / stamp-only sequence; **zero** live API writes, and no `gh` or network needed | Task 2 |
@@ -475,14 +478,16 @@ which is what forces the reopen contract rather than create-on-stale (R5).
 Per §PR sequencing, not in one PR.
 
 - [x] `CHANGELOG.md` — entry *(PR 2)*
-- [ ] `plans/DECISIONS.md` — `D-00NN`: why the log, why not annotations, why the reader
-      fails loudly *(PR 3)*
-- [ ] `plans/FRAMEWORK-TODO.md` — entry → `## Closed` with the merge ref *(PR 3)*
-- [ ] `plans/HANDOFF.md` — regenerate volatile part; add the annotation-cap trap and the
-      version-provenance trap *(PR 3)*
-- [ ] `CLAUDE.md` — the annotation cap, stated at the granularity M1 actually
+- [x] `plans/DECISIONS.md` — **`D-0073`**: why the log, why not annotations, why the
+      reader fails loudly *(PR 3, #401)*
+- [x] `plans/FRAMEWORK-TODO.md` — entry → `## Closed` with the merge ref *(PR 3, #401)*
+- [x] `plans/HANDOFF.md` — regenerate volatile part; add the annotation-cap trap and the
+      version-provenance trap *(PR 3, #401 — the version-provenance trap had already
+      graduated to `CLAUDE.md` in #399, so PR 3 carried only the annotation cap; PR 4
+      graduates that one too and regenerates this file again on the same merge)*
+- [x] `CLAUDE.md` — the annotation cap, stated at the granularity M1 actually
       supports, **and** the concurrency inventory's fourth shape *(PR 4, founder)*
-- [ ] `ROADMAP.md` — not applicable (no milestone moves)
+- [x] `ROADMAP.md` — not applicable (no milestone moves)
 
 ## Risks
 


### PR DESCRIPTION
PR 4 of the four chartered in [`plans/PIN-CURRENCY-READER-PLAN.md`](plans/PIN-CURRENCY-READER-PLAN.md) §"PR sequencing" — the last one. `PIN-CURRENCY-NO-READER` closes end to end with this merge.

**Three surfaces — Rule 1's cap, not over it.**

| Surface | Change |
|---|---|
| `CLAUDE.md` | the check-run annotation-cap trap graduates to § "Durable traps → Reading CI output"; § "Unified CI" gains the concurrency inventory's **fourth** shape |
| `plans/PIN-CURRENCY-READER-PLAN.md` | Status → `IMPLEMENTED`; V1 row 17 → **18** tests; `## Docs to update` boxes closed out; the PR-4 row corrected from two surfaces to three |
| `plans/HANDOFF.md` | `## Unsettled trap` deleted as it graduates; volatile half regenerated |

### The trap, at the granularity the measurement supports

The check-run annotations API truncates at **10 per annotation level**, keeping the earliest — so it is **not** a substitute for the log when what you want is emitted late. Check-run `89950624082` emitted 22 `##[warning]` lines; the API returned 10, and **none** of the ten `pin-currency:` lines survived, because they come from the drift script's tail.

Stated per-level, never per-step — the whole script is one `run:` step, so per-step / per-job / per-run is unattributable from this measurement (D-0073 §1). Two things review added, both re-measured live before writing:

- **The response is sorted by *descending* `start_line`**, so `.[0]` is the *last* survivor. A reader checking "keeps the earliest" against `.[0]` sees the opposite and discards a true trap. Check `.[-1]`.
- **The scope qualifier is back in the headline.** Below the cap the API is complete and is the cheaper surface; exactly 10 at a level is the truncation signal, fewer than 10 means that level is whole. Without it the entry reads as "never use annotations."

### The fourth concurrency shape

`cancel-in-progress: false` under a fixed group is **serialization** — it stops a `workflow_run` and a concurrent `workflow_dispatch` from both finding no open issue and each creating one. `CLAUDE.md` now records it, and records the sentence it must **not** be rewritten as, because "nothing to cancel, so nothing to fix" is verbatim this repo's justification for carrying *no* `concurrency:` block at all (D-0073 §7).

The count is four; the shapes arrived from different work, and the text no longer credits CANON-PARITY-001 with the shape `pin-currency-reader.yml` (#392) introduced.

### Verification

- `pre-commit run --all-files` — clean (markdownlint, conformance suite, version-ref sync, docs reminder).
- `python3 -m unittest tests.unit.test_pin_currency_reader` — **18 tests OK**, which is what the corrected V1 row claims. The 18th is #394's guard that no generated markdown contains an escaped backtick (`:382`).
- The annotation cap, its per-level scope and the response ordering were re-measured against check-run `89950624082` before the claim was written.

### No `CHANGELOG.md` entry

Docs-only; no code or CI surface moves. Matches #399 (`CLAUDE.md` + two plans files) and #401, both of which shipped without one. Adding one would also push this to four surfaces.

### Left deliberately, and where it went instead

- `FRAMEWORK-TODO.md`'s closed `HANDOFF-OVER-SIZE` entry still says the trap "stays in the handoff." Correcting it would be a **fourth** surface, so the handoff's § "Stale advice" carries a row saying it is done.
- D-0073 §3's *give the reader its own reader* — a live open risk (`pin-currency-reader.yml:67` skips the reader when the upstream run fails) recorded in `DECISIONS.md` and held by no queue. Routed to the next `FRAMEWORK-TODO.md` hygiene sweep, which is handoff item 3.

**Governance PR — the founder merges.** Not auto-merged.

Multi-agent self-review per OPS-0065 (code-reviewer ×2 + adversarial judge): APPROVE WITH FIXES, 6 load-bearing findings, all folded before push.
