### PR TITLE
docs(handoff): refresh for the #406 guard merge; SDD corpus audit becomes task 1

### DIFF
--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -798,7 +798,7 @@
 
 ## Closed
 
-### `[harness]` `IDHASH-GUARD-GLOB-NARROW` — ✅ CLOSED (2026-07-31, PR #406) — the guard was green partly because it did not look where a violation survived → [#385](https://github.com/vladm3105/aidoc-flow-framework/issues/385)
+### `[harness]` `IDHASH-GUARD-GLOB-NARROW` — ✅ CLOSED (2026-07-31, `371f6261` PR #406) — the guard was green partly because it did not look where a violation survived → [#385](https://github.com/vladm3105/aidoc-flow-framework/issues/385)
 
 - *Context:* surfaced 2026-07-30 while correcting a `CLAUDE.md` claim that no
   surface computes SHA-256 in-prompt (PR #387). `test_no_inprompt_hashing.py`

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -30,49 +30,43 @@ yet, and graduates it once it has.
 
 ## Where we are — 2026-07-31
 
-Framework spec `0.40.0`, Claude Code plugin `0.24.0`, Hermes `0.12.0` — **no version
-stream moved today**. **Open PRs: 0. Open issues: 2** —
-[#385](https://github.com/vladm3105/aidoc-flow-framework/issues/385) and
-[#386](https://github.com/vladm3105/aidoc-flow-framework/issues/386), both unchanged.
+Framework spec `0.40.0`, plugin `0.24.0`, **Hermes `0.12.0` → `0.12.1`**.
+**Open PRs: 0. Open issues: 2** —
+[#386](https://github.com/vladm3105/aidoc-flow-framework/issues/386) and
+[#405](https://github.com/vladm3105/aidoc-flow-framework/issues/405). #385 is **closed**.
 
-**Last merge: [#403](https://github.com/vladm3105/aidoc-flow-framework/pull/403), squash
-`b44279a1` — the `FRAMEWORK-TODO.md` status-hygiene sweep.** The queue is now
-trustworthy in both directions and states its own convention. *(This refresh ships as
-its own follow-up PR, so `git log` shows one commit after `b44279a1` touching only this
-file. That is expected, not a missed merge.)*
+**Last merge: [#406](https://github.com/vladm3105/aidoc-flow-framework/pull/406), squash
+`371f6261` — the in-prompt-hashing guard now reaches the file that was still hashing.**
+Both roots `rglob`; `batch-remediation-script.md` calls `compute_element_hash()`; a
+coverage census walks each root *independently of the scan's own patterns*; exempt
+filenames are pinned as a literal set. **Six mutations verified to fail**, including two
+the review found: broadening the exemption to `\.md$` (which silently emptied the scan)
+and deleting a whole root.
 
-**`plans/FRAMEWORK-TODO.md` is a reliable input again — Open 52 → 30, Closed 37 → 60,
-90 entries throughout.** Three defects, not the two the last handoff named: 7 `✅ CLOSED`
-entries sat under `## Open`; 22 entries under `## Closed` carried no heading marker at
-all; and **22 more declared their state only in a body `*Status:*` line** — the form
-nobody had named. That third form does not pattern-match (`SHIPPED`, `CORE SHIPPED`,
-`CORE SUBSUMED`, `DOC LEG ✅ SHIPPED, enforcement leg deferred`, `Closed by …`), and the
-deferral that keeps an entry open is often a trailing clause on an otherwise
-finished-looking line. Each was read in full: 16 closed, **6 carry live legs** and now
-say so in the heading under a new `⏳ OPEN ON RESIDUAL (…)` marker. The file's
-`> **Rules:**` block states the whole contract — read it before touching the queue;
-do not re-derive it from here.
+**#385 was closed as filed, not as titled — the property does NOT hold platform-wide.**
+It named the plugin-SKILL and Hermes-reference halves; both are shut.
+`agent-skills/**/SKILL.md` is reached by **no root**, and
+`sdd-orchestrator/SKILL.md:667` still instructs `first 4 chars of SHA256(...)` — matched
+by the guard's own regex, invisible only for want of a root. `:1183` is a *second,
+different* gap: the `INSTRUCTION` regex matches "**hex** of SHA256" and misses
+"**chars** of". A green run of this guard is still not evidence that no surface hashes.
 
-Also landed there: 18 `PR #TBD, merge SHA TBD` placeholders resolved (`CLEANUP-PR-A`…`-F`
-= PRs #129/#131/#130/#133/#132/#135, non-sequential), and the new `[ci]`
-`PIN-CURRENCY-READER-HAS-NO-READER` entry that the last session flagged as held by no
-queue.
+**The session's real finding is that the remediation *method* is the defect.** #342 fixed
+9 reference files and declared the property closed — it missed a 10th and left 6 files
+with a stale `import hashlib`. #385 fixed the 10th, declared it closed, and missed 2 more
+surfaces plus 3 import sites. Three passes, each bounded by whatever the author grepped
+for, each declared complete, each wrong. A fourth hand-patch repeats it. Hence
+`SDD-CORPUS-UNVERIFIED` (task 1) — **founder call taken 2026-07-31 to stop patching and
+audit the corpus instead.**
 
-**`doc-maintainer` is PAUSED, and CI is green again.**
-[#397](https://github.com/vladm3105/aidoc-flow-framework/pull/397) set
-`kill_switch: true`. Verified in production, not assumed: the merge's own `push` run
-succeeded with `doc-maintainer kill_switch=true; exiting cleanly (no LLM cost incurred)`.
-Only one other `push` run had gone green since adoption, and that one passed by
-proposing nothing; this is the first that is green *by design*. The caller, its config
-and its conventions all stay in place; resume is a one-line flip.
-
-It had 23 failures / 47 runs across four independent upstream defects; the census lives
-in D-0072 and in `.github/doc-maintainer-conventions.md`, kept current for the resume.
-
-**Resume requires ci#352 AND ci#353** — #353 alone is 15 of the 23, so flipping on #352
-alone returns a majority-red pilot. #352 is the smaller count and still the blocker for
-*graduation*: no plan containing a low-risk edit can complete a dry run, which is the
-path a dry-run pilot exists to validate.
+**⚠️ `Hermes pytest` is RED on `main` and it is not this repo's regression.**
+`pyproject.toml` declares `mcp[cli]>=1.0.0` — a floor with no ceiling — and
+`hermes.yml:40` runs `pip install -e .`, so CI resolves to whatever the SDK last
+published. A release renamed `Tool.inputSchema` → `input_schema`; collection dies at
+`tool_registry.py:790`. **It is not a required context, so it does not block merges** —
+PR #406 merged over it by founder direction. Captured as `HERMES-MCP-FLOATING-DEP`. Do not
+re-diagnose it from scratch, and do not date it to a version without measuring: local
+`mcp 1.22.0` still exposes `inputSchema`, so the rename postdates 1.22.0.
 
 **V15 (schedule→`workflow_run` chain) is still unconfirmed** — it was never a gate; V14
 proved the chain off a *dispatched* upstream only. `standards-drift` runs Mondays at
@@ -81,42 +75,45 @@ the latest `standards-drift` run and check a `pin-currency-reader` run followed 
 `event=workflow_run`, then delete this paragraph. A failure there is a new bug against
 the merged workflow, not a reopening of the plan.
 
+**`doc-maintainer` is PAUSED and CI is green** (`kill_switch: true`, #397). 23 failures /
+47 runs across four upstream defects; census in D-0072 and
+`.github/doc-maintainer-conventions.md`. **Resume requires ci#352 AND ci#353** — #353
+alone is 15 of the 23, so flipping on #352 alone returns a majority-red pilot.
+
 ## Next tasks — prioritized
 
-The full queue is `plans/FRAMEWORK-TODO.md` (`## Open`) and
-`plans/HERMES-BACKLOG.md`. This is only the ordering a fresh session should use.
+The full queue is `plans/FRAMEWORK-TODO.md` (`## Open`) and `plans/HERMES-BACKLOG.md`.
+This is only the ordering a fresh session should use.
 
-1. **Watch [aidoc-flow-ci#351](https://github.com/vladm3105/aidoc-flow-ci/issues/351) —
+1. **`SDD-CORPUS-UNVERIFIED` — the sdd-orchestrator corpus ships runnable Python that
+   nothing parses, executes, or checks. START WITH THE FOUNDER DECISION; it gates the
+   plan.** Census: **45 fenced Python blocks — 3 do not parse, 10 carry unused imports,
+   10 call a locally-defined function with too few positional arguments.** `grep -rl
+   agent-skills tests/ .github/workflows/ .pre-commit-config.yaml` returns only
+   markdown-lint, pre-commit formatting, and a text-regex guard. `SKILL.md:1155` points
+   agents at these files for "the complete scripts."
+   - **Decision needed first:** make that Python genuinely executable and tested, demote
+     it to explicitly-marked non-runnable pseudocode, or extract it to real `.py` files
+     under test. The answer changes what the gate asserts.
+   - **Then build the gate BEFORE touching content** — it enumerates the work
+     mechanically instead of a human guessing at its bounds. The TODO entry carries the
+     assertions and the five known instances to fold in (`SKILL.md:667`, the `:1183`
+     regex gap, the 4th guard root, 3 files / 4 stale imports, `hash4()`'s arity).
+   - Non-trivial → needs a `plans/` plan with the two-cycle gap review.
+2. **Watch [aidoc-flow-ci#351](https://github.com/vladm3105/aidoc-flow-ci/issues/351) —
    when canon ships its own reader, DELETE ours.** `.github/workflows/pin-currency-reader.yml`
    plus `scripts/read-pin-currency-log.sh` and `scripts/reconcile-pin-currency-issue.sh`
    are the "add a custom workflow" override mode, not a permanent local surface (plan
    R9). Nothing else in a live queue says so — the statement otherwise survives only
    inside the merged plan, which is why it is here.
-2. **`doc-maintainer` — nothing to do here; it is paused and waiting on upstream.**
-   Watch `aidoc-flow-ci` #352 and #353. When **both** ship in a released `ci/vX.Y.Z`:
-   re-pin this caller, flip `kill_switch` → `false` in `.github/doc-maintainer.json`,
-   and watch the next few `push` runs. Do **not** flip on #352 alone.
-
-   ⚠️ **Do not re-file the `high_risk_paths` / `allowed_paths` mismatch as a defect.**
-   It is deliberate, inert, and documented in the config itself; #396 recorded it as a
-   bug and was wrong. D-0072 point 2 explains why the error message manufactures that
-   misreading.
-
-   `gh secret list` shows `LITELLM_BASE_URL` **and** `LITELLM_DOC_API_KEY` present here;
-   only `AIDOC_FLOW_BOT_ID` / `AIDOC_FLOW_BOT_KEY` are absent, and those are **live-mode
-   only**. Verify with `gh secret list` before repeating any secrets claim.
-3. **[#385](https://github.com/vladm3105/aidoc-flow-framework/issues/385) — the `#342`
-   regression guard scans less than it claims.**
-   `tests/conformance/platforms/test_no_inprompt_hashing.py:99`/`:103` use
-   `glob("doc-*/SKILL.md")` and a non-recursive `glob("*.md")`, so **41 of 52** plugin
-   SKILLs and **36 of 39** Hermes references are scanned. The 3 unscanned Hermes files
-   are all of `references/batch-brd-processing/`, and
-   `batch-remediation-script.md:24` still computes element IDs with its own
-   `hashlib.sha256` routine that diverges from the normative transform on four points.
-   The 11 unscanned plugin SKILLs are clean today — that half is latent. The guard's own
-   docstring (`:92`) forbids narrowing coverage by glob, which is what happened. Fix is
-   `rglob` both + point the script at `rehash --compute`; the issue carries the census
-   command. **A green run of this guard is not evidence that no surface hashes.**
+3. **[#405](https://github.com/vladm3105/aidoc-flow-framework/issues/405) —
+   `sync-version-refs.sh` rewrites historical "shipped in vX" claims.** The
+   `hermes/v<prev>` / `claude-code-plugin/v<prev>` fanout at `:347-355` is an unanchored
+   global sed carrying neither of the two `HAZARD` notes the script already has (`:141`,
+   `:209`). It corrupted `docs/PARITY.md:65` on **three consecutive bumps**; #406 fixed
+   that instance by rewording, not the class. `docs/PARITY.md:43` is latent behind it.
+   Fix shape: anchor the replace (the `$ cat VERSION` awk block at `:367` is the model)
+   or fail when a bump would rewrite more occurrences than the known current-state rows.
 4. **[#386](https://github.com/vladm3105/aidoc-flow-framework/issues/386) — the
    framework-spec token gates five files on `CLAUDE.md`'s own state.** The mechanism
    and the hand-edit hazard are in `CLAUDE.md` § "Durable traps → Local hooks and
@@ -125,14 +122,21 @@ The full queue is `plans/FRAMEWORK-TODO.md` (`## Open`) and
    writing only `CLAUDE.md`, but this one cannot take that shape unchanged, because
    its `prev` is load-bearing elsewhere. Derive the gating `prev` from a fanout target
    nobody hand-edits (`docs/PARITY.md`), and give `CLAUDE.md` its own block.
-5. **Hermes parity — the residual arc.** `plans/HERMES-BACKLOG.md`: remaining
+5. **`doc-maintainer` — nothing to do; it is paused and waiting on upstream.** Watch
+   `aidoc-flow-ci` #352 and #353. When **both** ship in a released `ci/vX.Y.Z`: re-pin,
+   flip `kill_switch` → `false`, watch the next few `push` runs.
+
+   ⚠️ **Do not re-file the `high_risk_paths` / `allowed_paths` mismatch as a defect.**
+   It is deliberate, inert, and documented in the config itself; #396 recorded it as a
+   bug and was wrong. D-0072 point 2 explains why the error message manufactures that
+   misreading.
+6. **Hermes parity — the residual arc.** `plans/HERMES-BACKLOG.md`: remaining
    plugin-vs-Hermes deltas plus quality-loop Phase 2 (cross-invocation resume / G-R1,
    the parallel-review global lock).
-6. **Everything else** is in `FRAMEWORK-TODO.md` by tag (`[ci]`, `[lint]`,
-   `[template]`, `[harness]`, `[example-corpus]`, `[docs]`, `[skill]`, `[sync]`),
-   including the D54 and Engramory consumer-feedback batches. **30 open entries, and
-   the section now means what it says** (#403) — an entry under `## Open` with no
-   `⏳ OPEN ON RESIDUAL` marker is genuinely open work. Nothing there is blocking.
+7. **Everything else** is in `FRAMEWORK-TODO.md` by tag (`[ci]`, `[lint]`, `[template]`,
+   `[harness]`, `[example-corpus]`, `[docs]`, `[skill]`, `[sync]`, `[hermes]`), including
+   the D54 and Engramory consumer-feedback batches. An entry under `## Open` with no
+   `⏳ OPEN ON RESIDUAL` marker is genuinely open work (#403). Nothing there is blocking.
 
 **Standing:** the example corpus is regenerated wholesale after framework changes, so
 corpus-remediation findings are deferred to that regen rather than fixed in place.
@@ -146,12 +150,12 @@ remaining source was this file have been deleted rather than carried forward.
 
 | Stale claim | Reality |
 |---|---|
-| "`--admin` is required on every PR" (the `ai-review` self-cancel, `aidoc-flow-ci#322`) | **Fixed at `ci/v2.16.0`.** #378, #380, #392 and #394 all reached mergeable with no `--admin` |
-| "Branch protection requires the phantom `Lint / format / security hooks`, so every PR is BLOCKED" | **Fixed.** The six required contexts, read from the API on 2026-07-30, are `call / Lint / format / security hooks`, `call / composition`, `call / ai-review`, `call / verify`, `Framework + platform conformance`, `Acceptance tier (deterministic)`. `call / trust` is **not** required |
+| "no authoring surface computes SHA-256 in-prompt any more" (`ROADMAP.md:113`, `platforms/hermes/CHANGELOG.md` `[0.12.0]` heading, `plans/IDGEN-NO-GENERATOR-PLAN.md`) | **Still false, in a narrower way.** #406 closed the plugin-SKILL and Hermes-reference halves; `agent-skills/**/SKILL.md` is reached by no root and `sdd-orchestrator/SKILL.md:667` still hashes. `ROADMAP.md` also dates the claim to Hermes `0.12.0`, which was never true |
+| "`--admin` is required on every PR" (the `ai-review` self-cancel, `aidoc-flow-ci#322`) | **Fixed at `ci/v2.16.0`.** #378, #380, #392, #394 and #406 all reached mergeable with no `--admin` |
+| "Branch protection requires the phantom `Lint / format / security hooks`, so every PR is BLOCKED" | **Fixed.** The six required contexts, re-read from the API on 2026-07-31, are `call / Lint / format / security hooks`, `call / composition`, `call / ai-review`, `call / verify`, `Framework + platform conformance`, `Acceptance tier (deterministic)`. `call / trust` and `Hermes pytest` are **not** required |
 | `AIDOC-CI-COMPOSITION-CHECK-PRHEAD` — "`call / composition` is structurally unsatisfiable on a PR head" | **Stale.** composition reports success on PR heads. A reviewer once read this entry as proof that required checks gate nothing here, and it nearly killed a correct plan |
 | "the acceptance deterministic tier has 3 pre-existing failures on `main`" | **Fixed** (#365, #371/#372). 0 failures / 64, and the tier is now a **required** context |
 | `NO-PIN-CURRENCY-CHECK` — "this repo runs `check-pin-currency.sh` nowhere" | **Retracted, it was false** — the check runs on every weekly `standards-drift`. The generalised lesson is in `CLAUDE.md` § "Durable traps → Process" |
 | `PIN-CURRENCY-NO-READER` — "the fix is a workflow that **runs the script** and opens an issue" | **Superseded and now SHIPPED** (#392). Running the script would be the second detector the same entry forbids; the reader consumes the completed run's **log** |
-| `PIN-CURRENCY-READER-PLAN.md:465`/`:469` — "a live `clean` check is deliberately absent … the `clean` path is verified only by V4's stub" | **Overtaken by events.** Canon `main` and every caller here are both `ci/v2.16.0`, so a live run reports `clean` — V14 exercised close-on-clean for real. This is the stale row most likely to be hit, because item 1 above sends the next session into that same plan |
-| `FRAMEWORK-TODO.md`'s closed `HANDOFF-OVER-SIZE` entry — "the check-run annotation-cap trap **stays** in the handoff, because `PIN-CURRENCY-READER-PLAN.md` PR 4 is chartered to propagate it" | **Done — PR 4 is the merge described above.** The trap now lives in `CLAUDE.md` § "Durable traps → Reading CI output" and is gone from here. That TODO line is history inside a `✅ CLOSED` entry and was deliberately left unedited: correcting it would have made a fourth doc surface against Rule 1's cap of three |
+| `PIN-CURRENCY-READER-PLAN.md:465`/`:469` — "a live `clean` check is deliberately absent … the `clean` path is verified only by V4's stub" | **Overtaken by events.** Canon `main` and every caller here are both `ci/v2.16.0`, so a live run reports `clean` — V14 exercised close-on-clean for real. This is the stale row most likely to be hit, because task 2 above sends the next session into that same plan |
 | `plans/PLAN-*.md` as the governance-PR plan glob (`CHANGELOG.md`, `CI-CANON-V2.16-MIGRATION-PLAN.md:468`/`:784`) | **Fixed in `CLAUDE.md`** (#387/#390). The glob is a **suffix** — `plans/*-PLAN.md`. Merged plans and the CHANGELOG keep the old string as history; `CLAUDE.md` is the live rule |


### PR DESCRIPTION
Session-wrap handoff regeneration after #406 (`371f6261`). Volatile sections
rewritten, durable core kept, 161 lines against the ~200 target.

## Ground truth

Hermes `0.12.0` → `0.12.1`; #385 closed; open issues now #386 and #405; 0 open PRs.

## Three things a fresh session must not re-derive

- **#385 closed as *filed*, not as *titled*.** The plugin-SKILL and
  Hermes-reference halves are shut. `agent-skills/**/SKILL.md` is reached by no
  root and `sdd-orchestrator/SKILL.md:667` still hashes, with `:1183` a second,
  different gap (the regex matches "hex of", not "chars of"). The `ROADMAP.md:113`
  and hermes-`[0.12.0]` claims that the property holds are now listed as stale
  advice, so the next session finds the correction where it will hit the claim.
- **`Hermes pytest` is red on `main` and is not this repo's regression** — an
  unpinned `mcp[cli]>=1.0.0` floor plus a path-filtered workflow, so the SDK's
  `inputSchema` → `input_schema` rename sat unobserved. Not a required context.
  The entry also records that the rename **postdates** the locally-installed
  `1.22.0`, so a future session measures the version instead of assuming it.
- **The remediation *method* is the defect.** #342 fixed 9 files and declared it
  closed, missing a 10th and 6 stale imports; #385 fixed the 10th, declared it
  closed, and missed 2 surfaces and 3 import sites. `SDD-CORPUS-UNVERIFIED` is
  task 1 and opens with the founder decision that gates its plan.

## Also

Stamps the merge SHA into the `IDHASH-GUARD-GLOB-NARROW` closure, which carried
only the PR number — the closure contract asks for the strongest ref available,
and the SHA only existed after the merge.

## Verification

Every factual claim re-derived mechanically rather than carried forward: the three
`VERSION` files, issue/PR states via `gh`, the merge SHA on `main`, the
**45 blocks / 3 unparseable / 10 unused-import / 10 arity** census, the six
required contexts, and the `SKILL.md:1155` quote. `pre-commit --all-files` clean
and idempotent on a second pass.

Two doc surfaces, neither a governance surface.
