### PR TITLE
fix(lint): diagnose the linter's own prerequisites — PLUGIN-PREPROD-001 PR 2

### DIFF
--- a/.github/workflows/doc-review.yml
+++ b/.github/workflows/doc-review.yml
@@ -50,11 +50,22 @@ jobs:
         run: PYTHONPATH=tools python -m sdd_doc_lint tools/sdd_doc_lint/fixtures/valid
 
       - name: Negative — broken fixtures must fail the gate
+        # Require exactly 1 ("error findings"). Any non-zero used to count as
+        # success, which silently accepts the codes that mean the linter never
+        # examined the fixtures: 2 (usage error / registry unavailable) and 3
+        # (missing prerequisite — PyYAML absent, or Python below the floor).
+        # Those report "gate works" while proving nothing about the gate.
         run: |
-          if PYTHONPATH=tools python -m sdd_doc_lint tools/sdd_doc_lint/fixtures/broken; then
+          set +e
+          PYTHONPATH=tools python -m sdd_doc_lint tools/sdd_doc_lint/fixtures/broken
+          rc=$?
+          set -e
+          if [ "$rc" -eq 1 ]; then
+            echo "broken fixtures failed as expected — gate works"
+          elif [ "$rc" -eq 0 ]; then
             echo "::error::broken fixtures unexpectedly passed the gate"; exit 1
           else
-            echo "broken fixtures failed as expected — gate works"
+            echo "::error::linter exited $rc — it never gated the fixtures"; exit 1
           fi
 
       - name: Gate SDD documents under docs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,47 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — the linter diagnoses its own prerequisites, and the review hook stops importing project-supplied code (2026-07-31)
+
+**PLUGIN-PREPROD-001 PR 2 of 5.** No version bump on any stream; the plugin's
+`0.24.0 → 0.25.0` cut is PR 5.
+
+- **PyYAML and the Python ≥3.11 floor are declared in code and diagnosed.**
+  Either absent, `sdd_doc_lint` died with a traceback exiting **1** — the same
+  code the plugin's review hook reads as "this document has structural
+  findings", so a machine without PyYAML got a Python traceback injected into
+  model context labelled as a lint finding. Both now print one line naming the
+  cause and exit **3**, distinct from 2 (already "argparse usage error" *and*
+  "registry unavailable"). The floor check runs before the `enum.StrEnum` import
+  it protects, so the message names the version rather than an unfamiliar symbol.
+  Stock macOS ships 3.9 as `/usr/bin/python3`, so both cases have a real
+  population.
+- **New `--warn-exit` flag exits 1 on any finding, not only error-severity
+  ones**, and the review hook passes it — warning findings could never reach the
+  model before, though `verbose` mode documented that they would. The default
+  contract (0 unless an error) is unchanged; CI gates on it.
+- **The review hook no longer extends `PYTHONPATH` with the inherited value.**
+  A `yaml/` package on any inherited entry was imported by the bundled linter
+  and **executed** — measured during a real hook run, with the hook still
+  exiting 0 and writing nothing. `.envrc` is repository content and direnv
+  exports it. This is the second vector of the same finding whose first half
+  (a package in the working directory) closed in PR 1.
+- **A PR 1 regression test had been silently disarmed by the guard above.** It
+  provoked a linter crash by shadowing PyYAML with an `ImportError` — exactly
+  what the new guard catches — so the hook's `rc == 1` branch was never entered
+  and its assertions passed because nothing was produced rather than because it
+  was filtered. It runs against a stub interpreter now, which states the
+  contract instead of arranging for a crash and hoping it lands on 1.
+- **`doc-review.yml`'s negative step required only "non-zero"**, which this
+  change makes reachable with a second code that means the linter never examined
+  the fixtures; it requires exactly 1.
+- Twelve mutants, each killed by exactly one test; two survived a first pass and
+  the tests that now kill them record why. Two defects found during review are
+  captured rather than fixed — [#412](https://github.com/vladm3105/aidoc-flow-framework/issues/412)
+  (single-file linting reports every cross-document trace tag as an ERROR) and
+  `LINT-FINDING-MESSAGES-UNBOUNDED` — both in `plans/FRAMEWORK-TODO.md` with
+  reproductions and fix shapes.
+
 ### Fixed — the in-prompt-hashing guard could not see the file that was still hashing (2026-07-31)
 
 **Hermes `0.12.0` → `0.12.1`.** No framework-spec or plugin change.

--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -288,6 +288,59 @@
 - *Fix shape:* scope the assertion to the `[Unreleased]` section, or to lines
   that are not inside a quotation — not by deleting the historical text.
 
+### `[lint]` `LINT-TRACE-RES-SINGLE-FILE` — linting one file reports every cross-document trace tag as an ERROR → [#412](https://github.com/vladm3105/aidoc-flow-framework/issues/412)
+
+- *Context:* found 2026-07-31 by review during PLUGIN-PREPROD-001 PR 2, in the
+  plugin's own `verbose` hook path. `_check_trace_resolution`
+  (`tools/sdd_doc_lint/__init__.py:1782`) resolves `@<layer>:` tags against
+  `doc_index`, which is built from **the paths passed on this invocation**. Lint
+  one file and every upstream tag it emits is unresolvable by construction:
+  `python3 -m sdd_doc_lint examples/url-shortener/docs/06_SPEC/SPEC-01.md` yields
+  **66** `TRACE-RES-001` ERRORs — `references unknown document (no corpus member
+  has doc_id 'ADR-01')` while `docs/05_ADR/ADR-01.md` sits right there — against
+  **0** for `…/docs`. Every layer-02..08 document in the shipped corpus behaves
+  the same.
+- *Blast radius:* the review hook lints exactly one file (the edited one) and
+  forwards up to 4000 bytes of findings into model context on every edit of an
+  adopted project in `verbose` mode. That budget is spent almost entirely on
+  false ERRORs, and `--warn-exit` (PR 2) does not cause this — the exit code was
+  already 1. Also reached by any consumer linting a single path.
+- *Fix shape:* gate `TRACE-RES-001`'s cross-document arm on a whole-corpus run,
+  the way `_check_forward_coverage` already gates itself
+  (`__init__.py:1961-1963` returns `[]` when the corpus has no SPEC or IPLAN,
+  "which also covers the single-file `on_author` case"). Same idea, applied to
+  the tag resolver: an unresolvable tag is only evidence of a defect when the
+  corpus was whole. NOT in PLUGIN-PREPROD-001's scope — a linter-semantics
+  change with its own design, deliberately not folded into a dependency-guard PR.
+
+### `[lint]` `LINT-FINDING-MESSAGES-UNBOUNDED` — finding messages interpolate unbounded document-controlled text, and the hook forwards them to the model
+
+- *Context:* found 2026-07-31 by security review during PLUGIN-PREPROD-001 PR 2.
+  `STY02` interpolates the raw section heading
+  (`tools/sdd_doc_lint/__init__.py:571-576`; `_SECTION_HEADING` at `:267`
+  captures the whole rest of the line), and `PROV01` the raw `id_state`
+  frontmatter value (`:645-650`). Both are bounded only by the hook's 1 MiB file
+  gate. Demonstrated: a BRD with a ~7 KB hostile heading fills the hook's entire
+  4000-byte findings budget with attacker-chosen prose inside
+  `<untrusted-tool-output>`.
+- *Not a PR 2 regression, but PR 2 widened it.* Such a document reached the model
+  before only if it also carried an ERROR; `--warn-exit` makes warnings-only
+  documents (largely BRDs) reachable too. **Envelope integrity holds either way**
+  — `tr -d '<>'` plus the line-anchored grammar filter were verified against a
+  multi-line breakout attempt, and only the first line survived. What is
+  unbounded is plain prose inside a correctly-formed envelope.
+- *Fix shape:* truncate at the source — `heading[:80]` in the `STY02` message and
+  the same for `PROV01` — so the bound holds for every consumer (CI logs and
+  pre-commit too), not only the hook. The finding stays actionable: the line
+  number and word count carry it. Deferred deliberately: it moves linter output,
+  so it needs a blast-radius pass over `tests/acceptance/expected_warnings/`
+  and the golden fixtures first.
+- *Also here, same class, latent:* `STALE01` interpolates raw `last_audited_spec`
+  (`:1294-1299`) but is **unreachable through the plugin today only by accident**
+  — `_framework_version` (`:1239-1246`) reads `registry.parent.parent/VERSION`
+  and `platforms/claude-code-plugin/framework/VERSION` does not exist. A future
+  sync that adds that file makes it reachable with nothing to notice.
+
 ### `[lint]` `LINT-LOCAL-REGISTRY-NO-TEMPLATES` — a project-local registry without its layer templates silently disables the structural checks
 
 - *Context:* found 2026-07-31 while building

--- a/platforms/claude-code-plugin/hooks/sdd-doc-review.sh
+++ b/platforms/claude-code-plugin/hooks/sdd-doc-review.sh
@@ -145,7 +145,10 @@ msg="Edited a ${artifact} document (<untrusted-filename>${safe_base}</untrusted-
 #
 # Exit codes: 1 = findings *or* a crash — the two are told apart by the finding
 # grammar below, never by the exit code; 0 = clean; anything else = the linter
-# declined to run, so say nothing.
+# declined to run, so say nothing. 3 in particular means a missing prerequisite
+# (Python below 3.11, or no PyYAML): the linter names it on stderr, and this
+# hook stays silent because it is advisory and must not nag about the host's
+# setup on every edit. `README.md` documents the prerequisites.
 if [ "$review_hook" = "verbose" ] && [ "$adopted" -eq 1 ]; then
   plugin_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." 2>/dev/null && pwd)"
   # Regular files only. A directory, a device, or a FIFO at the edited path
@@ -167,13 +170,23 @@ if [ "$review_hook" = "verbose" ] && [ "$adopted" -eq 1 ]; then
     #     and compiles that registry's `id_patterns` as regexes over document
     #     text. From the plugin root it always resolves the bundled registry, so
     #     a planted one cannot inject a catastrophically-backtracking pattern.
-    #   * an empty or `.` entry in an inherited PYTHONPATH still means "the CWD",
-    #     which PYTHONSAFEPATH does not strip; from here that is the plugin root.
+    #   * PYTHONPATH is REPLACED, not extended. Appending the inherited value
+    #     left a hole the size of the one above it: a `yaml/` package on any
+    #     inherited entry is imported by the linter and executes. Measured — a
+    #     planted `yaml/__init__.py` ran during a real hook invocation, with the
+    #     hook still exiting 0 and writing nothing, so nothing observable said
+    #     so. `.envrc`, a devcontainer or a shell profile all set PYTHONPATH,
+    #     and the first is repository content. The linter needs only the plugin
+    #     root; an installed PyYAML comes from site-packages either way, and an
+    #     absent one is now diagnosed rather than substituted.
     # Invoking `__main__.py` by absolute path is NOT an alternative — it fails
     # the relative imports.
+    # `--warn-exit` is what makes WARNING findings reachable at all: without it
+    # the linter exits 0 on a warnings-only document, and the `rc -eq 1` test
+    # below would drop every one of them while `verbose` mode claims otherwise.
     raw="$(cd "$plugin_root" 2>/dev/null &&
-      PYTHONSAFEPATH=1 PYTHONPATH="${plugin_root}${PYTHONPATH:+:$PYTHONPATH}" \
-        python3 -m sdd_doc_lint "$abs_path" 2>&1)"
+      PYTHONSAFEPATH=1 PYTHONPATH="$plugin_root" \
+        python3 -m sdd_doc_lint --warn-exit "$abs_path" 2>&1)"
     rc=$?
     # rc is captured on the UNPIPED run on purpose: through a pipeline $? would
     # be grep's status, and grep exits 1 when *nothing* matched — inverting the

--- a/platforms/claude-code-plugin/sdd_doc_lint/__init__.py
+++ b/platforms/claude-code-plugin/sdd_doc_lint/__init__.py
@@ -15,9 +15,60 @@ LLM `-audit` skill; this is the fast, repeatable gate beneath it.
 
 Text-based on purpose: the checks work on an instance document whether it is
 authored as Markdown or YAML.
+
+Importing this package **exits the process** (``SystemExit``,
+``EXIT_MISSING_PREREQUISITE``) when the interpreter is below ``MIN_PYTHON`` or
+PyYAML cannot be imported, after printing one line naming the cause. Deliberate:
+the package cannot function without either, every consumer is a short-lived CLI,
+and the alternative — an ``ImportError`` traceback exiting 1 — is
+indistinguishable from "this document has error findings" to the callers that
+only read the exit code.
 """
 
 from __future__ import annotations
+
+import sys
+
+#: The interpreter floor, and the exit code every unmet prerequisite reports.
+#: ``StrEnum`` (imported below) and ``datetime.UTC`` in the sibling tools both
+#: landed in Python 3.11; stock macOS still ships 3.9 as ``/usr/bin/python3``,
+#: so this is a real user, not a hypothetical one.
+#:
+#: Exit **3**, deliberately not 2: 2 already means both "argparse usage error"
+#: and "registry unavailable" (see ``__main__``), and overloading it a third
+#: time would defeat the point of telling failure modes apart. Callers that
+#: only distinguish 0/1 — the plugin's review hook is the live example — treat
+#: 3 as "the linter declined to run" and stay silent.
+MIN_PYTHON = (3, 11)
+EXIT_MISSING_PREREQUISITE = 3
+
+
+def python_floor_error(version_info: tuple[int, ...] | None = None) -> str | None:
+    """Return a one-line diagnostic if the interpreter is too old, else ``None``.
+
+    Split out as a plain function taking the version so it is testable: the
+    branch it guards can never be exercised on an interpreter new enough to run
+    the test suite.
+    """
+    found = tuple(version_info if version_info is not None else sys.version_info)[:2]
+    if found >= MIN_PYTHON:
+        return None
+    return (
+        "sdd-doc-lint: needs Python {}.{} or newer (running {}.{}); the linter uses "
+        "enum.StrEnum. Stock macOS ships 3.9 as /usr/bin/python3 — run it with a "
+        "newer interpreter.".format(*MIN_PYTHON, *found)
+    )
+
+
+# Checked BEFORE `from enum import StrEnum`, which is the import that would
+# otherwise fail: on 3.9 the user would get an ImportError naming a symbol they
+# have never heard of instead of the version they need. Everything above this
+# line must stay parseable on the floor it names, or the diagnostic is
+# unreachable — `tests/conformance/test_lint_runtime_guards.py` locks both.
+_floor_error = python_floor_error()
+if _floor_error is not None:
+    print(_floor_error, file=sys.stderr)
+    raise SystemExit(EXIT_MISSING_PREREQUISITE)
 
 import hashlib
 import os
@@ -27,7 +78,25 @@ from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
 
-import yaml
+# PyYAML is the linter's one third-party dependency and the plugin bundles no
+# installer, so "not installed" is the expected state on a fresh machine rather
+# than a broken one. Unguarded it died with a traceback at exit 1 — the same
+# code as "this document has error findings" — which is what B4 was about.
+# Catch ImportError, not just ModuleNotFoundError: a present-but-broken install
+# fails the same way for the user and needs the same one-line answer.
+try:
+    import yaml
+except ImportError as exc:
+    # First line, bounded: a broken install's message can be multi-line and can
+    # carry the absolute path of the site-packages that failed, which would both
+    # break the one-line contract and publish host layout into a CI log.
+    _why = str(exc).splitlines()[0][:200] if str(exc) else exc.__class__.__name__
+    print(
+        f"sdd-doc-lint: PyYAML is required but could not be imported ({_why}); "
+        "install it with `python3 -m pip install pyyaml`.",
+        file=sys.stderr,
+    )
+    raise SystemExit(EXIT_MISSING_PREREQUISITE) from exc
 
 # Shared @-tag trace primitives (CFB-PR-2 DD-1). The forward coverage engine
 # reuses the SAME token→doc reduction, layer order, and `@`-tag regex as the

--- a/platforms/claude-code-plugin/sdd_doc_lint/__main__.py
+++ b/platforms/claude-code-plugin/sdd_doc_lint/__main__.py
@@ -1,7 +1,16 @@
 """CLI: python -m sdd_doc_lint [--registry PATH] [--mode build|gate-code]
-       [--skip-coverage-gate] <path> [<path> ...]
+       [--skip-coverage-gate] [--warn-exit] <path> [<path> ...]
 
-Exit 0 = no error-level findings; 1 = error findings; 2 = usage error.
+Exit codes:
+
+* **0** — no error-level findings (and, under ``--warn-exit``, no findings at all)
+* **1** — error findings; with ``--warn-exit``, warning findings too
+* **2** — usage error, *or* the registry could not be read
+* **3** — a runtime prerequisite is missing: Python is below the floor, or PyYAML
+  cannot be imported. Raised at package import, before any linting. Kept distinct
+  from 2 so a caller can tell "the linter declined to run" from "your document is
+  wrong" — see ``sdd_doc_lint.EXIT_MISSING_PREREQUISITE``.
+
 The framework registry is located automatically (upward search for
 ``framework/registry/LAYER_REGISTRY.yaml``, or ``$SDD_REGISTRY`` / ``--registry``),
 so the same code runs from the canonical repo or a vendored platform copy.
@@ -50,6 +59,13 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="suppress the forward-coverage gate entirely (CFB-PR-2 DD-9 — the "
         "transient-migration escape hatch)",
+    )
+    parser.add_argument(
+        "--warn-exit",
+        action="store_true",
+        help="exit 1 when any finding is emitted, not only error-severity ones; the "
+        "default contract (0 unless an error) is what CI gates on, so callers that "
+        "want to see warnings — the plugin's review hook — opt in here",
     )
     parser.add_argument(
         "--active-layers",
@@ -115,7 +131,11 @@ def main(argv: list[str] | None = None) -> int:
         elif not findings:
             print("sdd-doc-lint: no structural findings.")
 
-    return 1 if any(f.severity == "error" for f in findings) else 0
+    if any(f.severity == "error" for f in findings):
+        return 1
+    # Without this, a warning is emitted and then reported as success, so a
+    # caller that speaks only on a non-zero exit can never surface one.
+    return 1 if (args.warn_exit and findings) else 0
 
 
 if __name__ == "__main__":

--- a/platforms/hermes/CHANGELOG.md
+++ b/platforms/hermes/CHANGELOG.md
@@ -14,7 +14,20 @@ this platform adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
-_Nothing yet._
+- **The vendored `sdd_doc_lint` diagnoses its own missing prerequisites instead
+  of tracebacking.** PyYAML absent, or an interpreter below Python 3.11, now
+  prints one line naming the cause and exits **3** — a code distinct from 2
+  (already both "usage error" and "registry unavailable") and from 1 ("this
+  document has error findings"). Re-vendored byte-identical from
+  `tools/sdd_doc_lint/` per PLUGIN-PREPROD-001 PR 2; Hermes declares both
+  prerequisites (`requires-python >=3.12`, `PyYAML>=6.0`), so this is a
+  robustness change, not a fix for a failure seen here.
+- **New `--warn-exit` flag on the linter CLI.** Exits 1 when *any* finding is
+  emitted, not only error-severity ones. Off by default: the existing contract
+  (0 unless an error) is what CI gates on and is unchanged.
+- No `platforms/hermes/VERSION` bump (PLUGIN-PREPROD-001 founder decision O2), so
+  a consumer cannot tell from the version that the vendored linter changed. This
+  entry is the record until the next Hermes release carries the signal.
 
 ## [0.12.1] — a 10th loaded reference was still hashing; 0.12.0's claim was overstated (#385) (2026-07-31)
 
@@ -27,7 +40,7 @@ PATCH. Reference-document content only; no server behaviour changes.
   merely bypass the generator — it disagreed with the normative transform in
   `governance/ID_NAMING_STANDARDS.md` on four points (no NFC; `.lower()` rather
   than `casefold`; deleted spaces instead of collapsing runs; truncation at 200
-  chars _before_ normalizing rather than 100 _after_), and hashed a
+  chars *before* normalizing rather than 100 *after*), and hashed a
   `doc:section:label` triple rather than the extracted `title`/`description`
   fields — so it computed **different IDs**.
 - **The 0.12.0 entry above says "9 loaded reference documents" and its heading
@@ -61,7 +74,7 @@ element-ID instructions.
   reachable because `sdd-orchestrator/SKILL.md` points agents at them for "the
   complete" procedure. Each carried its own normalization variant and **none**
   matched the standard. The worst, `brd-validation-automation.md`, applied
-  `re.sub(r'[^a-z0-9:]', '', inp.lower())[:200]` to the _assembled_ string —
+  `re.sub(r'[^a-z0-9:]', '', inp.lower())[:200]` to the *assembled* string —
   disagreeing on five of six steps (`lower()` not `casefold()`, no NFC, per-string
   not per-field, spaces deleted, truncation at 200 not 100). All now delegate to
   `compute_element_hash()`, so there is one algorithm.
@@ -108,7 +121,7 @@ element-ID instructions.
   remediated copy; the final failing pass break-circuits to `PARTIAL_TIMEOUT`. Off
   (the default) the review is a single pass, byte-identical to before.
   - **Outer wrapper, not a state-machine change** (`review/quality_loop.py`,
-    `run_review_quality_loop`). Each iteration is a _fresh forward saga run_
+    `run_review_quality_loop`). Each iteration is a *fresh forward saga run*
     (`run_project_review_build_saga` gains `iteration` / `quality_loop` /
     `is_final_iteration` params), so the forward-only transition table and
     `saga.schema.json` are untouched — no `framework/VERSION` change.
@@ -176,7 +189,7 @@ element-ID instructions.
   - **A2 — `review_mode` reconciled.** The `sdd_review` tool now accepts the spec
     vocabulary `team` / `single_pass` as aliases for `saga_parallel` / `prompt_only`
     (schema enum + normalization). When the arg is omitted, a profile that
-    _explicitly_ declares `review_mode` is honored; otherwise the existing
+    *explicitly* declares `review_mode` is honored; otherwise the existing
     `prompt_only` default holds (a profile present only for e.g. a glossary does not
     silently flip the review mode).
   - **A1 — prompt-injectable authoring knobs.** The creation prompt now injects a
@@ -185,7 +198,7 @@ element-ID instructions.
     author / skip), and `active_layers`. Unprofiled projects are byte-identical to
     before (empty block → omitted).
 
-  **Deferred to a follow-up (see HERMES-BACKLOG H-16):** structural _enforcement_ of
+  **Deferred to a follow-up (see HERMES-BACKLOG H-16):** structural *enforcement* of
   `active_layers` (layer skipping) and `section_toggles` (template mutation), the
   `audit_threshold` gate (its raise-only semantics need reconciling with
   `profile_contracts.resolve_threshold_precedence`'s override semantics), and
@@ -221,7 +234,7 @@ element-ID instructions.
 
 - **BDD-prompt drift guard (`tests/unit/test_bdd_prompt_yaml_conformance.py`).** A
   Hermes-side guard asserting the BDD surfaces reference `scenarios:` and contain no
-  _structural_ Gherkin markers (```gherkin fences, `Feature:`/`Scenario:`/`Background:`
+  *structural* Gherkin markers (```gherkin fences, `Feature:`/`Scenario:`/`Background:`
   declaration lines, standalone Gherkin scenario-tag lines). It deliberately does not
   grep the bare word "Gherkin" (a correct prompt says "NOT Gherkin" as an anti-drift
   line). Converts a previously CI-invisible drift class into a CI-visible one. Kept
@@ -312,7 +325,7 @@ element-ID instructions.
   lens. Added the `chg` review crew to `persona_mappings.yaml` (crew parity with the
   framework CHG crew) and removed the `HERMES_DEFERRED_LAYERS` whitelist, so the
   crew-coverage conformance test now enforces CHG like the lifecycle layers. Crew-map
-  parity only — a _live/sanctioned_ CHG saga review (adding `09_CHG` to
+  parity only — a *live/sanctioned* CHG saga review (adding `09_CHG` to
   `saga.schema.json` + a dispatch path) is a deferred follow-on; no default flow
   dispatches a `chg` review. No framework spec change.
 
@@ -367,8 +380,8 @@ element-ID instructions.
   enforces both platforms' tables against `REVIEW_SAGA.md` and validates a sample
   journal from each runner against `saga.schema.json` (the test `docs/PARITY.md`
   previously over-claimed already existed). **No version bump** — Phase 1 makes the
-  state machine _accept_ the transition (parity contract); the orchestrator does not
-  yet _write_ it (break-circuit exercise + resume is Phase 1b).
+  state machine *accept* the transition (parity contract); the orchestrator does not
+  yet *write* it (break-circuit exercise + resume is Phase 1b).
 
 ### Removed
 
@@ -397,7 +410,7 @@ element-ID instructions.
   persona profiles (`skills/personas/*.md`): dropped the dead `SYS/REQ/CTR/TSPEC`
   scoring-weight lines, removed those tokens from each persona's `doc_types`
   list, and removed the dedicated layer rows + sections (e.g. integration_lead's
-  "CTR Expertise", qa_lead's "TSPEC Quality Metrics"). _Deliberately retained:_
+  "CTR Expertise", qa_lead's "TSPEC Quality Metrics"). *Deliberately retained:*
   the `agent-skills/` historical notes documenting the layers as "cut from
   v3"/"deprecated" (accurate history) and the threshold-rules `req`/`ctr` tokens
   (unrelated meanings — rate/Currency-Transaction-Report).
@@ -441,10 +454,10 @@ element-ID instructions.
   `references/governance-load-protocol.md` — were replaced with the current single-path
   layer model (no tiers; necessary-upstream contract; MVP → PROD → NEW MVP). Skill
   `version: 2.0.0 → 2.1.0`. Doc-accuracy only — no engine/runtime change, no `framework/`
-  change. _(Deferred backlog: the ~25-file cosmetic "v3.2" string residue across the
+  change. *(Deferred backlog: the ~25-file cosmetic "v3.2" string residue across the
   inherited governance scaffold; the hand-vendored `references/` framework-doc copies
   (D-0013 delete-vs-resync); the element-ID SHA-256 residue, framework-gated by
-  PROVISIONAL-IDS-002.)_
+  PROVISIONAL-IDS-002.)*
 
 - **Element-ID alignment to the framework 4-segment hash form** (PLATFORM-ALIGN
   Part B, `0.1.0 → 0.2.0`). The runtime element-ID validators in
@@ -456,7 +469,7 @@ element-ID instructions.
   8-layer EARS/BDD prompt templates' element-ID examples + the `UCC_PROMPT_EARS`
   ID-convention legend were migrated off the legacy type-code scheme
   (`EARS.NN.<CODE>.<seq>`, `PRD.NN.US.NN`, 3-segment refs) to the 4-segment hash
-  form. _Stricter validation:_ a previously-accepted 3-segment ID now fails —
+  form. *Stricter validation:* a previously-accepted 3-segment ID now fails —
   intended (the 3-segment form was the legacy variant the framework retired).
 
 - **EARS pattern alignment** — brought the Hermes vendored EARS pattern tables
@@ -468,11 +481,11 @@ element-ID instructions.
   6-pattern model with a mixed `IF…THEN` connective. Now: the five canonical
   patterns (Ubiquitous, Event/`WHEN`, State/`WHILE`, Optional/`WHERE`,
   Unwanted/`IF`) in the uniform `the [system] shall …` form (no `THEN`); "complex"
-  reframed as _composition_ of the base patterns (the standalone `Complex` row +
+  reframed as *composition* of the base patterns (the standalone `Complex` row +
   the `CX` type code removed). Doc-only; no runtime behavior change.
-  _(Note: the prompts' legacy type-code element-ID scheme — `EARS.NN.<code>.<seq>`
+  *(Note: the prompts' legacy type-code element-ID scheme — `EARS.NN.<code>.<seq>`
   vs the framework's hash-based `EARS.NN.SS.xxxx` — is a separate, pre-existing
-  divergence, out of scope here.)_
+  divergence, out of scope here.)*
 
 ## [0.1.1] — 2026-05-21
 

--- a/platforms/hermes/sdd_doc_lint/__init__.py
+++ b/platforms/hermes/sdd_doc_lint/__init__.py
@@ -15,9 +15,60 @@ LLM `-audit` skill; this is the fast, repeatable gate beneath it.
 
 Text-based on purpose: the checks work on an instance document whether it is
 authored as Markdown or YAML.
+
+Importing this package **exits the process** (``SystemExit``,
+``EXIT_MISSING_PREREQUISITE``) when the interpreter is below ``MIN_PYTHON`` or
+PyYAML cannot be imported, after printing one line naming the cause. Deliberate:
+the package cannot function without either, every consumer is a short-lived CLI,
+and the alternative — an ``ImportError`` traceback exiting 1 — is
+indistinguishable from "this document has error findings" to the callers that
+only read the exit code.
 """
 
 from __future__ import annotations
+
+import sys
+
+#: The interpreter floor, and the exit code every unmet prerequisite reports.
+#: ``StrEnum`` (imported below) and ``datetime.UTC`` in the sibling tools both
+#: landed in Python 3.11; stock macOS still ships 3.9 as ``/usr/bin/python3``,
+#: so this is a real user, not a hypothetical one.
+#:
+#: Exit **3**, deliberately not 2: 2 already means both "argparse usage error"
+#: and "registry unavailable" (see ``__main__``), and overloading it a third
+#: time would defeat the point of telling failure modes apart. Callers that
+#: only distinguish 0/1 — the plugin's review hook is the live example — treat
+#: 3 as "the linter declined to run" and stay silent.
+MIN_PYTHON = (3, 11)
+EXIT_MISSING_PREREQUISITE = 3
+
+
+def python_floor_error(version_info: tuple[int, ...] | None = None) -> str | None:
+    """Return a one-line diagnostic if the interpreter is too old, else ``None``.
+
+    Split out as a plain function taking the version so it is testable: the
+    branch it guards can never be exercised on an interpreter new enough to run
+    the test suite.
+    """
+    found = tuple(version_info if version_info is not None else sys.version_info)[:2]
+    if found >= MIN_PYTHON:
+        return None
+    return (
+        "sdd-doc-lint: needs Python {}.{} or newer (running {}.{}); the linter uses "
+        "enum.StrEnum. Stock macOS ships 3.9 as /usr/bin/python3 — run it with a "
+        "newer interpreter.".format(*MIN_PYTHON, *found)
+    )
+
+
+# Checked BEFORE `from enum import StrEnum`, which is the import that would
+# otherwise fail: on 3.9 the user would get an ImportError naming a symbol they
+# have never heard of instead of the version they need. Everything above this
+# line must stay parseable on the floor it names, or the diagnostic is
+# unreachable — `tests/conformance/test_lint_runtime_guards.py` locks both.
+_floor_error = python_floor_error()
+if _floor_error is not None:
+    print(_floor_error, file=sys.stderr)
+    raise SystemExit(EXIT_MISSING_PREREQUISITE)
 
 import hashlib
 import os
@@ -27,7 +78,25 @@ from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
 
-import yaml
+# PyYAML is the linter's one third-party dependency and the plugin bundles no
+# installer, so "not installed" is the expected state on a fresh machine rather
+# than a broken one. Unguarded it died with a traceback at exit 1 — the same
+# code as "this document has error findings" — which is what B4 was about.
+# Catch ImportError, not just ModuleNotFoundError: a present-but-broken install
+# fails the same way for the user and needs the same one-line answer.
+try:
+    import yaml
+except ImportError as exc:
+    # First line, bounded: a broken install's message can be multi-line and can
+    # carry the absolute path of the site-packages that failed, which would both
+    # break the one-line contract and publish host layout into a CI log.
+    _why = str(exc).splitlines()[0][:200] if str(exc) else exc.__class__.__name__
+    print(
+        f"sdd-doc-lint: PyYAML is required but could not be imported ({_why}); "
+        "install it with `python3 -m pip install pyyaml`.",
+        file=sys.stderr,
+    )
+    raise SystemExit(EXIT_MISSING_PREREQUISITE) from exc
 
 # Shared @-tag trace primitives (CFB-PR-2 DD-1). The forward coverage engine
 # reuses the SAME token→doc reduction, layer order, and `@`-tag regex as the

--- a/platforms/hermes/sdd_doc_lint/__main__.py
+++ b/platforms/hermes/sdd_doc_lint/__main__.py
@@ -1,7 +1,16 @@
 """CLI: python -m sdd_doc_lint [--registry PATH] [--mode build|gate-code]
-       [--skip-coverage-gate] <path> [<path> ...]
+       [--skip-coverage-gate] [--warn-exit] <path> [<path> ...]
 
-Exit 0 = no error-level findings; 1 = error findings; 2 = usage error.
+Exit codes:
+
+* **0** — no error-level findings (and, under ``--warn-exit``, no findings at all)
+* **1** — error findings; with ``--warn-exit``, warning findings too
+* **2** — usage error, *or* the registry could not be read
+* **3** — a runtime prerequisite is missing: Python is below the floor, or PyYAML
+  cannot be imported. Raised at package import, before any linting. Kept distinct
+  from 2 so a caller can tell "the linter declined to run" from "your document is
+  wrong" — see ``sdd_doc_lint.EXIT_MISSING_PREREQUISITE``.
+
 The framework registry is located automatically (upward search for
 ``framework/registry/LAYER_REGISTRY.yaml``, or ``$SDD_REGISTRY`` / ``--registry``),
 so the same code runs from the canonical repo or a vendored platform copy.
@@ -50,6 +59,13 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="suppress the forward-coverage gate entirely (CFB-PR-2 DD-9 — the "
         "transient-migration escape hatch)",
+    )
+    parser.add_argument(
+        "--warn-exit",
+        action="store_true",
+        help="exit 1 when any finding is emitted, not only error-severity ones; the "
+        "default contract (0 unless an error) is what CI gates on, so callers that "
+        "want to see warnings — the plugin's review hook — opt in here",
     )
     parser.add_argument(
         "--active-layers",
@@ -115,7 +131,11 @@ def main(argv: list[str] | None = None) -> int:
         elif not findings:
             print("sdd-doc-lint: no structural findings.")
 
-    return 1 if any(f.severity == "error" for f in findings) else 0
+    if any(f.severity == "error" for f in findings):
+        return 1
+    # Without this, a warning is emitted and then reported as success, so a
+    # caller that speaks only on a non-zero exit can never surface one.
+    return 1 if (args.warn_exit and findings) else 0
 
 
 if __name__ == "__main__":

--- a/ruff.toml
+++ b/ruff.toml
@@ -15,4 +15,9 @@ ignore = [
 [lint.per-file-ignores]
 # Test/loader modules legitimately set sys.path before importing the package under test.
 "**/tests/**" = ["E402"]
+# The linter checks its interpreter floor and its PyYAML dependency BEFORE the
+# imports those prerequisites would otherwise break, so every later import is
+# "not at top of file" by construction (PLUGIN-PREPROD-001 PR 2). Glob covers
+# the canonical copy and both vendored mirrors.
+"**/sdd_doc_lint/__init__.py" = ["E402"]
 "**/__init__.py" = ["F401"]

--- a/tests/conformance/test_lint_runtime_guards.py
+++ b/tests/conformance/test_lint_runtime_guards.py
@@ -1,0 +1,523 @@
+"""Conformance: the linter diagnoses its own missing prerequisites, and warning
+findings can reach a caller.
+
+Locks the PLUGIN-PREPROD-001 PR 2 fixes for ``tools/sdd_doc_lint/``:
+
+* **B4 (linter half)** — PyYAML is an unguarded module-level import. Absent, the
+  linter dies with a traceback whose top line names ``yaml`` and whose exit code
+  (1) is indistinguishable from "this document has error findings". It must exit
+  **3** with a one-line diagnostic naming PyYAML.
+* **The interpreter floor is diagnosed, not tripped over.** ``enum.StrEnum``
+  landed in Python 3.11 and stock macOS still ships 3.9 as ``/usr/bin/python3``.
+  The check has to run *before* the import it protects, or the user gets an
+  ``ImportError`` traceback about a name they have never heard of.
+* **Exit 3 is distinct.** Exit 2 already carries two meanings — argparse usage
+  error, and "registry unavailable" from the ``OSError`` handler. A third would
+  defeat the point of the fix, so the other two are asserted to still be 2.
+* **L5** — warning-severity findings are unreachable today: ``__main__`` returns
+  0 unless a finding is ``error``, so the plugin's review hook (which speaks only
+  when the linter exits 1) can never surface one despite ``verbose`` mode
+  claiming to. ``--warn-exit`` makes them reachable **and the hook must pass it**
+  — the flag closes nothing on its own.
+
+The PyYAML-absent case is exercised by blocking the import in a subprocess
+(a ``sitecustomize.py`` on a scratch ``PYTHONPATH`` that raises
+``ModuleNotFoundError`` from a meta-path finder), which is a genuine absence
+rather than a stubbed module. The interpreter floor cannot be exercised on the
+running interpreter at all, so it is split into a pure helper that is called with
+a fake ``version_info`` plus a source-order assertion that the helper runs before
+the import it guards.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TOOLS = _REPO_ROOT / "tools"
+_LINT_INIT = _TOOLS / "sdd_doc_lint" / "__init__.py"
+_HOOK = _REPO_ROOT / "platforms" / "claude-code-plugin" / "hooks" / "sdd-doc-review.sh"
+_VALID_BRD = (
+    _REPO_ROOT / "tests" / "acceptance" / "fixtures" / "layer_01_brd" / "valid" / "BRD-01_golden.md"
+)
+_BROKEN_BRD = (
+    _REPO_ROOT / "tests" / "acceptance" / "fixtures" / "negative" / "brd-broken-sections.md"
+)
+
+#: A single section this long trips one `STY02` WARNING and nothing else, which
+#: is what a "warnings only" document has to be to distinguish exit 0 from 1.
+_PAD_SECTION = "\n## Pad 0\n\n" + " ".join(f"word{i}" for i in range(400)) + "\n"
+
+_EXIT_PREREQUISITE = 3
+
+
+def _scratch(case: unittest.TestCase) -> Path:
+    root = Path(tempfile.mkdtemp(prefix="aidoc-lint-guard-")).resolve()
+    case.addCleanup(shutil.rmtree, root, ignore_errors=True)
+    return root
+
+
+def _run_lint(*args: str, env: dict | None = None, cwd: Path | None = None):
+    """Invoke the canonical linter exactly as a consumer does."""
+    environ = dict(os.environ)
+    environ["PYTHONPATH"] = str(_TOOLS)
+    if env:
+        for key, value in env.items():
+            if value is None:
+                environ.pop(key, None)
+            else:
+                environ[key] = value
+    return subprocess.run(
+        [sys.executable, "-m", "sdd_doc_lint", *args],
+        capture_output=True,
+        text=True,
+        env=environ,
+        cwd=str(cwd) if cwd else str(_REPO_ROOT),
+        timeout=120,
+    )
+
+
+class LintGuardHarness(unittest.TestCase):
+    def setUp(self):
+        self.assertTrue(_VALID_BRD.is_file(), f"fixture not found: {_VALID_BRD}")
+        self.assertTrue(_BROKEN_BRD.is_file(), f"fixture not found: {_BROKEN_BRD}")
+
+    def warnings_only_doc(self, root: Path, relative: str = "BRD-01.md") -> Path:
+        """A document whose only finding is a WARNING.
+
+        Asserted here rather than assumed: if the fixture ever gains an ERROR,
+        every `--warn-exit` test below would pass for the wrong reason.
+        """
+        target = root / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(_VALID_BRD.read_text(encoding="utf-8") + _PAD_SECTION, encoding="utf-8")
+        proc = _run_lint("--format", "json", str(target))
+        findings = json.loads(proc.stdout)
+        self.assertTrue(findings, "expected at least one finding")
+        self.assertEqual(
+            [f["severity"] for f in findings],
+            ["warning"] * len(findings),
+            f"fixture is not warnings-only: {findings}",
+        )
+        return target
+
+    def block_pyyaml(self, root: Path) -> Path:
+        """A scratch directory that makes ``import yaml`` genuinely fail.
+
+        A meta-path finder rather than a stub module: a stub would have to guess
+        which exception a real absence raises, and the guard's whole job is to
+        catch the real one.
+        """
+        blocker = root / "no-pyyaml"
+        blocker.mkdir(parents=True, exist_ok=True)
+        (blocker / "sitecustomize.py").write_text(
+            "import sys\n"
+            "\n"
+            "\n"
+            "class _NoYaml:\n"
+            "    def find_spec(self, fullname, path=None, target=None):\n"
+            '        if fullname == "yaml" or fullname.startswith("yaml."):\n'
+            '            raise ModuleNotFoundError(f"No module named {fullname!r}", '
+            "name=fullname)\n"
+            "        return None\n"
+            "\n"
+            "\n"
+            "sys.meta_path.insert(0, _NoYaml())\n",
+            encoding="utf-8",
+        )
+        # Proven, not assumed: if `sitecustomize` were not picked up (site
+        # disabled, name shadowed), every assertion below would test a linter
+        # that still has PyYAML.
+        probe = subprocess.run(
+            [sys.executable, "-c", "import yaml"],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "PYTHONPATH": str(blocker)},
+            timeout=60,
+        )
+        self.assertNotEqual(probe.returncode, 0, "the PyYAML blocker did not take effect")
+        # Positive control. Without it, a host that simply has no PyYAML would
+        # let these tests pass with the blocker doing nothing at all — the
+        # blocker would be untested scaffolding and the guard unproven.
+        control = subprocess.run(
+            [sys.executable, "-c", "import yaml"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        self.assertEqual(
+            control.returncode, 0, "PyYAML is absent on this host; the blocker proves nothing"
+        )
+        return blocker
+
+    def break_pyyaml(self, root: Path) -> Path:
+        """A scratch directory where PyYAML is *present but broken*.
+
+        The guard catches ``ImportError``, not just ``ModuleNotFoundError``, and
+        says so in a comment. This is the fixture that holds it to that: a
+        module that imports and then fails is the shape a half-installed C
+        extension takes, and narrowing the guard to ``ModuleNotFoundError``
+        silently reverts that case to a traceback at exit 1.
+        """
+        broken = root / "broken-pyyaml"
+        broken.mkdir(parents=True, exist_ok=True)
+        # Multi-line and long on purpose. A real broken C extension reports the
+        # absolute path of the site-packages that failed, over several lines —
+        # which both breaks the one-line contract and publishes host layout into
+        # a CI log, so the message has to be bounded and not merely caught.
+        (broken / "yaml.py").write_text(
+            "raise ImportError(\n"
+            '    "cannot load /home/someuser/.venv/lib/python3.12/site-packages/"\n'
+            '    "_yaml.cpython-312-x86_64-linux-gnu.so: undefined symbol\\n"\n'
+            '    "referenced from libyaml.so.2\\n" + "padding " * 100\n'
+            ")\n",
+            encoding="utf-8",
+        )
+        return broken
+
+
+class MissingPyYAMLIsDiagnosed(LintGuardHarness):
+    """B4 (linter half): an absent PyYAML is named, not tracebacked."""
+
+    def test_exit_code_and_diagnostic(self):
+        root = _scratch(self)
+        blocker = self.block_pyyaml(root)
+        target = root / "BRD-01.md"
+        target.write_text(_VALID_BRD.read_text(encoding="utf-8"), encoding="utf-8")
+
+        proc = _run_lint(str(target), env={"PYTHONPATH": f"{blocker}{os.pathsep}{_TOOLS}"})
+
+        self.assertEqual(
+            proc.returncode,
+            _EXIT_PREREQUISITE,
+            f"expected exit {_EXIT_PREREQUISITE}; stderr={proc.stderr!r}",
+        )
+        self.assertIn("PyYAML", proc.stderr)
+        self.assertNotIn("Traceback", proc.stderr)
+        self.assertEqual(proc.stdout, "", f"nothing belongs on stdout: {proc.stdout!r}")
+
+    def test_a_broken_install_is_diagnosed_too(self):
+        """Present-but-broken PyYAML raises ``ImportError``, not its subclass.
+
+        Narrowing the guard to ``ModuleNotFoundError`` passes every other test
+        in this module — the blocker above raises the subclass — while sending
+        this case back to a traceback at exit 1.
+        """
+        root = _scratch(self)
+        broken = self.break_pyyaml(root)
+        target = root / "BRD-01.md"
+        target.write_text(_VALID_BRD.read_text(encoding="utf-8"), encoding="utf-8")
+
+        proc = _run_lint(str(target), env={"PYTHONPATH": f"{broken}{os.pathsep}{_TOOLS}"})
+
+        self.assertEqual(
+            proc.returncode,
+            _EXIT_PREREQUISITE,
+            f"expected exit {_EXIT_PREREQUISITE}; stderr={proc.stderr!r}",
+        )
+        self.assertIn("PyYAML", proc.stderr)
+        self.assertNotIn("Traceback", proc.stderr)
+        self.assertEqual(len(proc.stderr.strip().splitlines()), 1, proc.stderr)
+        self.assertLess(len(proc.stderr), 400, "the interpolated cause is unbounded")
+        self.assertNotIn("referenced from", proc.stderr, "only the first line belongs here")
+
+    def test_diagnostic_is_one_line(self):
+        """The plugin hook forwards nothing on exit 3, but the pre-commit and CI
+        callers show stderr verbatim — a multi-line dump there buries the cause.
+        """
+        root = _scratch(self)
+        blocker = self.block_pyyaml(root)
+        target = root / "BRD-01.md"
+        target.write_text(_VALID_BRD.read_text(encoding="utf-8"), encoding="utf-8")
+
+        proc = _run_lint(str(target), env={"PYTHONPATH": f"{blocker}{os.pathsep}{_TOOLS}"})
+
+        self.assertEqual(len(proc.stderr.strip().splitlines()), 1, proc.stderr)
+
+
+class ExitThreeIsDistinct(LintGuardHarness):
+    """Exit 2 keeps its two existing meanings; the new condition gets its own."""
+
+    def test_usage_error_is_still_two(self):
+        proc = _run_lint()  # no paths — argparse
+        self.assertEqual(proc.returncode, 2, proc.stderr)
+
+    def test_registry_unavailable_is_still_two(self):
+        root = _scratch(self)
+        target = root / "BRD-01.md"
+        target.write_text(_VALID_BRD.read_text(encoding="utf-8"), encoding="utf-8")
+
+        proc = _run_lint(str(target), env={"SDD_REGISTRY": str(root / "nope.yaml")})
+
+        self.assertEqual(proc.returncode, 2, f"stdout={proc.stdout!r} stderr={proc.stderr!r}")
+        self.assertIn("registry unavailable", proc.stderr)
+
+
+class InterpreterFloorIsDiagnosed(LintGuardHarness):
+    """The Python floor is stated and checked before the import that needs it."""
+
+    def _module(self):
+        sys.path.insert(0, str(_TOOLS))
+        self.addCleanup(lambda: sys.path.remove(str(_TOOLS)))
+        import sdd_doc_lint
+
+        return sdd_doc_lint
+
+    def test_floor_helper_rejects_old_interpreters(self):
+        mod = self._module()
+        self.assertEqual(mod.MIN_PYTHON, (3, 11))
+        message = mod.python_floor_error((3, 9, 6))
+        self.assertIsNotNone(message, "3.9 must be rejected")
+        # The ORDERED clause, not two substrings. Swapping the two format
+        # arguments produces "needs Python 3.9 or newer (running 3.11)" — which
+        # contains both and is actively misleading to the one user it is for.
+        self.assertIn("needs Python 3.11 or newer (running 3.9)", message)
+
+    def test_floor_helper_accepts_the_running_interpreter(self):
+        mod = self._module()
+        self.assertIsNone(mod.python_floor_error(tuple(sys.version_info)))
+        self.assertIsNone(mod.python_floor_error((3, 11, 0)))
+
+    def test_floor_check_precedes_the_import_it_guards(self):
+        """Source order, because a guard that runs after ``from enum import
+        StrEnum`` produces the traceback it exists to replace.
+        """
+        source = _LINT_INIT.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        floor_line = None
+        strenum_line = None
+        for node in ast.walk(tree):
+            if (
+                floor_line is None
+                and isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "python_floor_error"
+            ):
+                floor_line = node.lineno
+            if (
+                strenum_line is None
+                and isinstance(node, ast.ImportFrom)
+                and node.module == "enum"
+                and any(alias.name == "StrEnum" for alias in node.names)
+            ):
+                strenum_line = node.lineno
+        self.assertIsNotNone(floor_line, "the floor check is never called at import time")
+        self.assertIsNotNone(strenum_line, "`from enum import StrEnum` not found")
+        self.assertLess(floor_line, strenum_line)
+
+    def test_module_parses_on_the_floor_it_names(self):
+        """A guard in a file that will not compile on 3.9 never runs.
+
+        ``feature_version`` is best-effort, but it does reject the syntax most
+        likely to creep in (``match``, and 3.10+ grammar), which is enough to
+        catch the mistake that would silently disarm the diagnostic.
+        """
+        source = _LINT_INIT.read_text(encoding="utf-8")
+        try:
+            ast.parse(source, feature_version=(3, 9))
+        except SyntaxError as exc:  # pragma: no cover - the failure is the point
+            self.fail(f"{_LINT_INIT.name} does not parse under Python 3.9 syntax: {exc}")
+
+    def test_postponed_annotations_keep_the_guard_evaluable(self):
+        """Parsing is not enough — the guard's own code must *evaluate* on 3.9.
+
+        ``python_floor_error`` is annotated ``tuple[int, ...] | None``, which is
+        inert only because of ``from __future__ import annotations``. Drop that
+        line — a plausible cleanup, since ruff targets py311 — and on 3.9 the
+        ``def`` evaluates its annotations, ``TypeError`` is raised at import, and
+        the user gets a traceback at exit 1: exactly the failure this guard
+        replaces, in exactly the population it serves. The mutant still parses
+        under 3.9 grammar, so the test above does not catch it.
+        """
+        tree = ast.parse(_LINT_INIT.read_text(encoding="utf-8"))
+        future_line = None
+        helper_line = None
+        for node in ast.walk(tree):
+            if (
+                future_line is None
+                and isinstance(node, ast.ImportFrom)
+                and node.module == "__future__"
+                and any(alias.name == "annotations" for alias in node.names)
+            ):
+                future_line = node.lineno
+            if (
+                helper_line is None
+                and isinstance(node, ast.FunctionDef)
+                and node.name == "python_floor_error"
+            ):
+                helper_line = node.lineno
+        self.assertIsNotNone(
+            future_line,
+            "`from __future__ import annotations` is gone: the floor guard's own "
+            "annotations would now be evaluated at import time on the very "
+            "interpreters it exists to diagnose",
+        )
+        self.assertIsNotNone(helper_line, "`python_floor_error` not found")
+        self.assertLess(future_line, helper_line)
+
+    def test_guard_fires_end_to_end_on_an_old_interpreter(self):
+        """The guard's real path, not a proxy for it.
+
+        ``sys.version_info`` is assignable, so a ``sitecustomize`` on the
+        subprocess's path can present the running interpreter as 3.9 and the
+        import-time branch executes for real — diagnostic, exit code and all.
+        Kept alongside the source-order checks rather than replacing them: on a
+        3.12 host this passes even against the annotation mutant above.
+        """
+        root = _scratch(self)
+        fake = root / "old-python"
+        fake.mkdir()
+        (fake / "sitecustomize.py").write_text(
+            'import sys\n\nsys.version_info = (3, 9, 6, "final", 0)\n', encoding="utf-8"
+        )
+        target = root / "BRD-01.md"
+        target.write_text(_VALID_BRD.read_text(encoding="utf-8"), encoding="utf-8")
+
+        proc = _run_lint(str(target), env={"PYTHONPATH": f"{fake}{os.pathsep}{_TOOLS}"})
+
+        self.assertEqual(
+            proc.returncode,
+            _EXIT_PREREQUISITE,
+            f"expected exit {_EXIT_PREREQUISITE}; stderr={proc.stderr!r}",
+        )
+        self.assertIn("needs Python 3.11 or newer (running 3.9)", proc.stderr)
+        self.assertNotIn("Traceback", proc.stderr)
+        self.assertEqual(len(proc.stderr.strip().splitlines()), 1, proc.stderr)
+
+
+class WarningFindingsAreReachable(LintGuardHarness):
+    """L5: ``--warn-exit`` makes warning-severity findings observable."""
+
+    def test_warnings_only_document_exits_zero_by_default(self):
+        """The default contract is unchanged — CI depends on it."""
+        root = _scratch(self)
+        target = self.warnings_only_doc(root)
+        self.assertEqual(_run_lint(str(target)).returncode, 0)
+
+    def test_warnings_only_document_exits_one_under_warn_exit(self):
+        root = _scratch(self)
+        target = self.warnings_only_doc(root)
+        proc = _run_lint("--warn-exit", str(target))
+        self.assertEqual(proc.returncode, 1, f"stdout={proc.stdout!r} stderr={proc.stderr!r}")
+        self.assertIn("STY02", proc.stdout)
+
+    def test_clean_document_still_exits_zero_under_warn_exit(self):
+        root = _scratch(self)
+        target = root / "BRD-01.md"
+        target.write_text(_VALID_BRD.read_text(encoding="utf-8"), encoding="utf-8")
+        self.assertEqual(_run_lint("--warn-exit", str(target)).returncode, 0)
+
+    def test_error_document_exits_one_either_way(self):
+        root = _scratch(self)
+        target = root / "BRD-01.md"
+        target.write_text(_BROKEN_BRD.read_text(encoding="utf-8"), encoding="utf-8")
+        self.assertEqual(_run_lint(str(target)).returncode, 1)
+        self.assertEqual(_run_lint("--warn-exit", str(target)).returncode, 1)
+
+
+class TheHookPassesWarnExit(LintGuardHarness):
+    """L5 closes only if the hook actually passes the flag.
+
+    The scratch project is built outside the repo and outside ``$HOME`` for the
+    reason ``test_plugin_hook_safety`` documents: the hook's upward walk would
+    otherwise reach a real adoption marker.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.assertIsNotNone(
+            shutil.which("jq"), "jq is required: without it the hook exits 0 silently"
+        )
+        self.assertTrue(_HOOK.is_file(), f"hook not found: {_HOOK}")
+
+    def adopted_verbose_project(self) -> Path:
+        root = _scratch(self)
+        home = str(Path.home().resolve())
+        self.assertFalse(
+            str(root).startswith(str(_REPO_ROOT) + os.sep) or str(root).startswith(home + os.sep),
+            f"scratch root {root} would make the adoption walk false-pass",
+        )
+        (root / ".aidoc").mkdir()
+        (root / ".claude").mkdir()
+        (root / ".claude" / "aidoc-flow.config.yaml").write_text(
+            'schema: 1\nreview_hook: "verbose"\n', encoding="utf-8"
+        )
+        return root
+
+    def run_hook(self, target: Path, cwd: Path, env: dict | None = None):
+        return subprocess.run(
+            ["bash", str(_HOOK)],
+            input=json.dumps({"tool_input": {"file_path": str(target)}}),
+            capture_output=True,
+            text=True,
+            cwd=str(cwd),
+            env=env,
+            timeout=120,
+        )
+
+    def test_exit_three_leaves_the_hook_silent_but_still_nudging(self):
+        """The hook's own contract for the code this PR introduced.
+
+        Covered only by accident before: the sibling crash test used to provoke
+        exit 3 by shadowing PyYAML, so repairing *that* test (it had stopped
+        exercising the crash path) would have left exit 3 asserted nowhere. A
+        stub interpreter states the contract without depending on how the code
+        is provoked.
+        """
+        root = self.adopted_verbose_project()
+        target = self.warnings_only_doc(root, "docs/01_BRD/BRD-01.md")
+
+        bindir = root / "stubbin"
+        bindir.mkdir()
+        stub = bindir / "python3"
+        stub.write_text(
+            "#!/usr/bin/env bash\n"
+            "printf '%s\\n' 'sdd-doc-lint: PyYAML is required but could not be imported"
+            " (No module named yaml); install it with `python3 -m pip install pyyaml`.' >&2\n"
+            # Finding-SHAPED, and still must not be forwarded: exit 3 means the
+            # linter declined to run, so its output describes nothing. Without
+            # this line the grammar filter alone would carry the assertions and
+            # the rc test could be widened to `-ne 0` unnoticed.
+            "printf '%s\\n' '/tmp/x/BRD-01.md:1: [ERROR STRUCT01] fabricated by a stub' >&2\n"
+            f"exit {_EXIT_PREREQUISITE}\n",
+            encoding="utf-8",
+        )
+        stub.chmod(0o755)
+
+        proc = self.run_hook(
+            target,
+            cwd=root,
+            env=dict(os.environ, PATH=f"{bindir}{os.pathsep}{os.environ.get('PATH', '')}"),
+        )
+
+        self.assertEqual(proc.returncode, 0, f"stderr={proc.stderr!r}")
+        self.assertEqual(proc.stderr, "", f"hook wrote to stderr: {proc.stderr!r}")
+        context = json.loads(proc.stdout)["hookSpecificOutput"]["additionalContext"]
+        self.assertIn("doc-brd-audit", context, "the nudge must survive a missing prerequisite")
+        self.assertNotIn("<untrusted-tool-output", context)
+        self.assertNotIn("PyYAML", context, "a setup diagnostic is not a structural finding")
+        self.assertNotIn("STRUCT01", context, "exit 3 means the linter never looked at the file")
+
+    def test_warning_only_findings_reach_the_model(self):
+        root = self.adopted_verbose_project()
+        target = self.warnings_only_doc(root, "docs/01_BRD/BRD-01.md")
+
+        proc = self.run_hook(target, cwd=root)
+
+        self.assertEqual(proc.returncode, 0, f"stderr={proc.stderr!r}")
+        self.assertEqual(proc.stderr, "", f"hook wrote to stderr: {proc.stderr!r}")
+        context = json.loads(proc.stdout)["hookSpecificOutput"]["additionalContext"]
+        self.assertIn("STY02", context)
+        self.assertIn("WARNING", context)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/conformance/test_plugin_hook_safety.py
+++ b/tests/conformance/test_plugin_hook_safety.py
@@ -3,9 +3,11 @@
 Locks the PLUGIN-PREPROD-001 PR 1 fixes for
 `platforms/claude-code-plugin/hooks/sdd-doc-review.sh`:
 
-* **B1** — a `sdd_doc_lint/` package sitting in the user's working directory must
-  not execute. The hook invokes the linter with `python3 -m`, which puts the CWD
-  ahead of `PYTHONPATH` unless `PYTHONSAFEPATH` suppresses it.
+* **B1** — no module the project can place gets imported by the linter. Two
+  vectors, closed in two stages: a `sdd_doc_lint/` package in the user's working
+  directory (`python3 -m` searches the CWD first — PR 1), and a `yaml/` package
+  on an **inherited `PYTHONPATH`**, which the hook used to append to the plugin
+  root (PR 2). The second one executed, silently, in a real hook run.
 * **B4 (hook half)** — only lines matching the linter's finding grammar reach the
   model; a crash must not be relabelled as structural findings.
 * **H1** — structural findings require a project that actually adopted the
@@ -26,6 +28,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -127,6 +130,27 @@ class HookHarness(unittest.TestCase):
                     handle.write(f"\n## Pad {n}\n\n{words}\n")
         return target
 
+    def stub_python3(self, root: Path, *, rc: int, stdout: str = "", stderr: str = ""):
+        """A `python3` on `PATH` that emits fixed output and exits `rc`.
+
+        The hook's contract is written in terms of the linter's exit code, and
+        every way of provoking a real non-zero from the vendored linter runs
+        through a path the hardening has since closed. Stubbing the interpreter
+        states the contract directly: this code, this output, this behaviour.
+        """
+        bindir = root / "stubbin"
+        bindir.mkdir(exist_ok=True)
+        stub = bindir / "python3"
+        stub.write_text(
+            "#!/usr/bin/env bash\n"
+            f"printf '%s' {shlex.quote(stdout)}\n"
+            f"printf '%s' {shlex.quote(stderr)} >&2\n"
+            f"exit {int(rc)}\n",
+            encoding="utf-8",
+        )
+        stub.chmod(0o755)
+        return dict(os.environ, PATH=f"{bindir}{os.pathsep}{os.environ.get('PATH', '')}")
+
     def run_hook(self, target: Path, cwd: Path, env: dict | None = None):
         payload = json.dumps({"tool_input": {"file_path": str(target)}})
         return subprocess.run(
@@ -221,30 +245,80 @@ class OnlyFindingsReachTheModel(HookHarness):
         self.assertIn("[ERROR STRUCT01]", context)
 
     def test_a_crashing_linter_yields_no_findings_block(self):
-        """A traceback exits 1 — the same code as findings — and must be dropped."""
+        """A traceback exits 1 — the same code as findings — and must be dropped.
+
+        Driven by a stub `python3` on `PATH` rather than by shadowing PyYAML.
+        The shadow used to work because the hook appended the inherited
+        `PYTHONPATH`; it no longer does (that was a code-execution hole — see
+        `PlantedModulesOnPythonpathDoNotExecute`), so the shadow can no longer
+        reach the linter. It had also stopped testing this at all in the
+        meantime: PLUGIN-PREPROD-001 PR 2 made an absent PyYAML exit **3**, so
+        the `rc == 1` branch was never entered and all three assertions below
+        passed because nothing was produced rather than because it was filtered.
+
+        The stub is strictly better than either: it names the exit code and the
+        output independently, so the test states the contract instead of
+        arranging for a real crash and hoping it still lands on 1.
+        """
         root = self.make_project(review_hook="verbose", adopted=True)
         target = self.place_broken_brd(root, "docs/01_BRD/BRD-01.md")
 
-        # Shadow PyYAML so the vendored linter dies on import, exiting non-zero
-        # with a traceback on stderr and nothing matching the finding grammar.
-        (root / "yaml.py").write_text('raise ImportError("no yaml here")\n', encoding="utf-8")
-        env = dict(os.environ, PYTHONPATH=str(root))
-        payload = json.dumps({"tool_input": {"file_path": str(target)}})
-        proc = subprocess.run(
-            ["bash", str(_HOOK)],
-            input=payload,
-            capture_output=True,
-            text=True,
-            cwd=str(root),
-            env=env,
-            timeout=120,
+        env = self.stub_python3(
+            root,
+            rc=1,
+            stderr=(
+                "Traceback (most recent call last):\n"
+                '  File "<frozen runpy>", line 189, in _run_module_as_main\n'
+                "ImportError: cannot import name 'safe_load' from 'yaml'\n"
+            ),
         )
+        proc = self.run_hook(target, cwd=root, env=env)
 
         context = self.context_of(proc)
         self.assertIn("doc-brd-audit", context, "the nudge must survive a linter crash")
         self.assertNotIn("Traceback", context)
         self.assertNotIn("ImportError", context)
         self.assertNotIn("<untrusted-tool-output", context)
+
+
+class PlantedModulesOnPythonpathDoNotExecute(HookHarness):
+    """B1, second vector: an inherited `PYTHONPATH` must not reach the linter.
+
+    PR 1 closed the working-directory vector (`python3 -m` searching the CWD).
+    The hook still *appended* the inherited `PYTHONPATH` to the plugin root,
+    so a `yaml/` package on any inherited entry was imported by the linter and
+    ran — silently, with the hook exiting 0 and emitting a normal nudge.
+    `.envrc` is repository content and direnv exports it, so this was reachable
+    from a cloned repo on a developer machine with a common tool installed.
+    """
+
+    def test_planted_yaml_package_does_not_execute(self):
+        root = self.make_project(review_hook="verbose", adopted=True)
+        target = self.place_broken_brd(root, "docs/01_BRD/BRD-01.md")
+
+        planted = root / "envdir"
+        (planted / "yaml").mkdir(parents=True)
+        marker = root / "PLANTED_RAN"
+        (planted / "yaml" / "__init__.py").write_text(
+            "import pathlib\n"
+            f'pathlib.Path({str(marker)!r}).write_text("executed\\n")\n'
+            "def safe_load(*a, **k):\n"
+            "    return {}\n"
+            "def safe_load_all(*a, **k):\n"
+            "    return iter(())\n",
+            encoding="utf-8",
+        )
+
+        context = self.context_of(
+            self.run_hook(target, cwd=root, env=dict(os.environ, PYTHONPATH=str(planted)))
+        )
+
+        self.assertFalse(
+            marker.exists(),
+            "a yaml/ package on the inherited PYTHONPATH executed inside the hook",
+        )
+        # The real linter ran instead — the fix must not have silenced it.
+        self.assertIn("STRUCT01", context)
 
 
 class AdoptionIsRequiredForFindings(HookHarness):

--- a/tools/sdd_doc_lint/__init__.py
+++ b/tools/sdd_doc_lint/__init__.py
@@ -15,9 +15,60 @@ LLM `-audit` skill; this is the fast, repeatable gate beneath it.
 
 Text-based on purpose: the checks work on an instance document whether it is
 authored as Markdown or YAML.
+
+Importing this package **exits the process** (``SystemExit``,
+``EXIT_MISSING_PREREQUISITE``) when the interpreter is below ``MIN_PYTHON`` or
+PyYAML cannot be imported, after printing one line naming the cause. Deliberate:
+the package cannot function without either, every consumer is a short-lived CLI,
+and the alternative — an ``ImportError`` traceback exiting 1 — is
+indistinguishable from "this document has error findings" to the callers that
+only read the exit code.
 """
 
 from __future__ import annotations
+
+import sys
+
+#: The interpreter floor, and the exit code every unmet prerequisite reports.
+#: ``StrEnum`` (imported below) and ``datetime.UTC`` in the sibling tools both
+#: landed in Python 3.11; stock macOS still ships 3.9 as ``/usr/bin/python3``,
+#: so this is a real user, not a hypothetical one.
+#:
+#: Exit **3**, deliberately not 2: 2 already means both "argparse usage error"
+#: and "registry unavailable" (see ``__main__``), and overloading it a third
+#: time would defeat the point of telling failure modes apart. Callers that
+#: only distinguish 0/1 — the plugin's review hook is the live example — treat
+#: 3 as "the linter declined to run" and stay silent.
+MIN_PYTHON = (3, 11)
+EXIT_MISSING_PREREQUISITE = 3
+
+
+def python_floor_error(version_info: tuple[int, ...] | None = None) -> str | None:
+    """Return a one-line diagnostic if the interpreter is too old, else ``None``.
+
+    Split out as a plain function taking the version so it is testable: the
+    branch it guards can never be exercised on an interpreter new enough to run
+    the test suite.
+    """
+    found = tuple(version_info if version_info is not None else sys.version_info)[:2]
+    if found >= MIN_PYTHON:
+        return None
+    return (
+        "sdd-doc-lint: needs Python {}.{} or newer (running {}.{}); the linter uses "
+        "enum.StrEnum. Stock macOS ships 3.9 as /usr/bin/python3 — run it with a "
+        "newer interpreter.".format(*MIN_PYTHON, *found)
+    )
+
+
+# Checked BEFORE `from enum import StrEnum`, which is the import that would
+# otherwise fail: on 3.9 the user would get an ImportError naming a symbol they
+# have never heard of instead of the version they need. Everything above this
+# line must stay parseable on the floor it names, or the diagnostic is
+# unreachable — `tests/conformance/test_lint_runtime_guards.py` locks both.
+_floor_error = python_floor_error()
+if _floor_error is not None:
+    print(_floor_error, file=sys.stderr)
+    raise SystemExit(EXIT_MISSING_PREREQUISITE)
 
 import hashlib
 import os
@@ -27,7 +78,25 @@ from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
 
-import yaml
+# PyYAML is the linter's one third-party dependency and the plugin bundles no
+# installer, so "not installed" is the expected state on a fresh machine rather
+# than a broken one. Unguarded it died with a traceback at exit 1 — the same
+# code as "this document has error findings" — which is what B4 was about.
+# Catch ImportError, not just ModuleNotFoundError: a present-but-broken install
+# fails the same way for the user and needs the same one-line answer.
+try:
+    import yaml
+except ImportError as exc:
+    # First line, bounded: a broken install's message can be multi-line and can
+    # carry the absolute path of the site-packages that failed, which would both
+    # break the one-line contract and publish host layout into a CI log.
+    _why = str(exc).splitlines()[0][:200] if str(exc) else exc.__class__.__name__
+    print(
+        f"sdd-doc-lint: PyYAML is required but could not be imported ({_why}); "
+        "install it with `python3 -m pip install pyyaml`.",
+        file=sys.stderr,
+    )
+    raise SystemExit(EXIT_MISSING_PREREQUISITE) from exc
 
 # Shared @-tag trace primitives (CFB-PR-2 DD-1). The forward coverage engine
 # reuses the SAME token→doc reduction, layer order, and `@`-tag regex as the

--- a/tools/sdd_doc_lint/__main__.py
+++ b/tools/sdd_doc_lint/__main__.py
@@ -1,7 +1,16 @@
 """CLI: python -m sdd_doc_lint [--registry PATH] [--mode build|gate-code]
-       [--skip-coverage-gate] <path> [<path> ...]
+       [--skip-coverage-gate] [--warn-exit] <path> [<path> ...]
 
-Exit 0 = no error-level findings; 1 = error findings; 2 = usage error.
+Exit codes:
+
+* **0** — no error-level findings (and, under ``--warn-exit``, no findings at all)
+* **1** — error findings; with ``--warn-exit``, warning findings too
+* **2** — usage error, *or* the registry could not be read
+* **3** — a runtime prerequisite is missing: Python is below the floor, or PyYAML
+  cannot be imported. Raised at package import, before any linting. Kept distinct
+  from 2 so a caller can tell "the linter declined to run" from "your document is
+  wrong" — see ``sdd_doc_lint.EXIT_MISSING_PREREQUISITE``.
+
 The framework registry is located automatically (upward search for
 ``framework/registry/LAYER_REGISTRY.yaml``, or ``$SDD_REGISTRY`` / ``--registry``),
 so the same code runs from the canonical repo or a vendored platform copy.
@@ -50,6 +59,13 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="suppress the forward-coverage gate entirely (CFB-PR-2 DD-9 — the "
         "transient-migration escape hatch)",
+    )
+    parser.add_argument(
+        "--warn-exit",
+        action="store_true",
+        help="exit 1 when any finding is emitted, not only error-severity ones; the "
+        "default contract (0 unless an error) is what CI gates on, so callers that "
+        "want to see warnings — the plugin's review hook — opt in here",
     )
     parser.add_argument(
         "--active-layers",
@@ -115,7 +131,11 @@ def main(argv: list[str] | None = None) -> int:
         elif not findings:
             print("sdd-doc-lint: no structural findings.")
 
-    return 1 if any(f.severity == "error" for f in findings) else 0
+    if any(f.severity == "error" for f in findings):
+        return 1
+    # Without this, a warning is emitted and then reported as success, so a
+    # caller that speaks only on a non-zero exit can never surface one.
+    return 1 if (args.warn_exit and findings) else 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What this is

**PLUGIN-PREPROD-001 PR 2 of 5** — the linter half of `B4`, the interpreter
floor, and `L5`. Plan: [`plans/PLUGIN-PREPROD-001-PLAN.md`](../blob/main/plans/PLUGIN-PREPROD-001-PLAN.md)
§ "PR 2". Depends on PR 1 (#410), which is merged.

## The problem

`tools/sdd_doc_lint/` has two runtime prerequisites and declared neither in code.
Absent, both died the same way: a traceback, exiting **1** — the identical exit
code the plugin's review hook reads as *"this document has structural findings"*.
So a fresh machine without PyYAML got a Python traceback injected into model
context labelled as a lint finding. Stock macOS ships 3.9 as `/usr/bin/python3`
and the linter needs 3.11 (`enum.StrEnum`), so this is a real population, not a
hypothetical one.

Separately (`L5`): `__main__` returned 0 unless a finding was `error`, so the
hook — which speaks only on exit 1 — could never surface a warning, while
`verbose` mode's documentation said it would.

## What changed

- **Both prerequisites are diagnosed and exit 3.** One line on stderr naming the
  cause; no traceback. **3, not 2**: 2 already carries *both* "argparse usage
  error" and "registry unavailable", and overloading it a third time inside a PR
  whose purpose is to stop conflating failure modes would be self-defeating. The
  hook treats any code but 0/1 as "the linter declined to run" and stays silent.
- **The floor check runs *before* `from enum import StrEnum`** — the import it
  protects. After it, the user gets an `ImportError` about a symbol they have
  never heard of instead of the version they need.
- **`--warn-exit`** makes warning-severity findings reachable. Off by default:
  the existing contract (0 unless an error) is what CI gates on and is unchanged.
- **The hook passes `--warn-exit`.** The flag closes `L5` only if it does; that
  invocation line is a PR 1 file, which is why PR 2 depends on PR 1.
- **Both mirrors re-vendored** via `tools/sdd_doc_lint/sync-vendored.sh`
  (byte-identical; the drift guard covers it).

## Verification

| Suite | Result |
| --- | --- |
| `tests/conformance` | 299 passed, 692 subtests (281 on `main`) |
| `tests/acceptance/deterministic` | 64 passed, 56 subtests |
| `tools/sdd_doc_lint/tests` | 5 passed |
| Hermes `pytest` | 570 passed *(local; `main` is red in CI for the unrelated floating-`mcp` reason — not a required context)* |
| `pre-commit run --all-files` | clean, twice consecutively |
| `test-acceptance.sh --phase=hook` | `sdd-doc-review` **PASS** *(with `--skip-lint-smoke`; Phase 0 is the known corpus debt)* |

**Every guard is individually mutation-killed** — 12 mutants, each caught by
exactly one test: hook drops `--warn-exit`; `--warn-exit` accepted but inert;
the yaml guard catches the wrong exception; the floor check moved after the
`StrEnum` import; the floor lowered to 3.9; 3.10-only syntax added to the file;
the floor guard deleted; `from __future__ import annotations` removed; the yaml
guard narrowed to `ModuleNotFoundError`; the diagnostic's version arguments
reversed; the hook treating exit 3 like exit 1; and the interpolated import
error left unbounded.

The last two **survived a first pass**, and the tests that now kill them say so
in place: exit 3 must be ignored even when the output is finding-*shaped*
(otherwise the grammar filter alone carries the assertion and the `rc` test can
be widened unnoticed), and the broken-install fixture has to raise a long
multi-line message or the bound is never exercised.

The `from __future__` one is the most interesting: the guard's own
annotations (`tuple[int, ...] | None`) are inert *only* because of the future
import. Remove that line — a plausible cleanup, since ruff targets py311 — and
on 3.9 the `def` evaluates its annotations and dies with a `TypeError` traceback
at exit 1: precisely the failure the guard exists to replace, in precisely the
population it serves. The mutant still parses under 3.9 grammar, so the
parse-only assertion did not catch it. There is now a source-order assertion for
the future import, plus a test that fakes `sys.version_info` in a subprocess and
exercises the guard's real path end-to-end.

## Two fixes review surfaced, both reproduced before folding

**The hook appended the inherited `PYTHONPATH`** to the plugin root, so a
`yaml/` package on any inherited entry was imported by the linter and **ran** —
measured during a real hook invocation, with the hook still exiting 0 and
writing nothing, so nothing observable said so. `.envrc` is repository content
and direnv exports it. `PYTHONPATH` is replaced now, not extended. This is
**B1's second vector**: PR 1 closed the working-directory one and the plan
recorded B1 as closed, so leaving this would have been a bounded sweep declared
complete — the failure mode this repo has hit three times.

**The new guard silently disarmed a PR 1 test.**
`test_a_crashing_linter_yields_no_findings_block` provoked a crash by shadowing
PyYAML with an `ImportError` — exactly what this PR's guard now catches, so the
linter exits 3, the `rc == 1` branch is never entered, and its three assertions
passed because *nothing was produced* rather than because it was filtered. A
mutant that weakens the finding-grammar filter to `grep -Ev '^sdd-doc-lint:'`
passed the whole suite while forwarding a full traceback into
`<untrusted-tool-output>` — the exact B4 defect PR 1 fixed. It runs against a
stub interpreter now, which states the contract instead of arranging for a crash
and hoping it still lands on 1.

Also: `.github/workflows/doc-review.yml`'s negative step counted *any* non-zero
as "gate works". Harmless until this PR made a second non-zero code reachable;
it requires 1 now.

## Two out-of-scope defects, captured not fixed

Review surfaced [#412](https://github.com/vladm3105/aidoc-flow-framework/issues/412):
linting a **single file** reports every cross-document trace tag as a
`TRACE-RES-001` ERROR, because `doc_index` is built from the paths passed on
that invocation. `SPEC-01.md` alone yields **66** of them; the whole corpus
yields **0**. The review hook lints exactly one file, so it forwards ~4000 bytes
of false ERRORs into model context on every edit in `verbose` mode.

**Pre-existing and not caused by this PR** — they are ERROR-severity, so the exit
code was already 1 and they already reached the model. Fixing it is a
linter-semantics change with its own design (the fix shape is the single-file
gate `_check_forward_coverage` already has), deliberately not folded into a
dependency-guard PR. Captured as `LINT-TRACE-RES-SINGLE-FILE` in
`plans/FRAMEWORK-TODO.md` and filed per `GOV-TODO-ISSUE-SPLIT`.

**`LINT-FINDING-MESSAGES-UNBOUNDED`** — `STY02` interpolates the raw section
heading and `PROV01` the raw `id_state`, both bounded only by the hook's 1 MiB
file gate, so a ~7 KB hostile heading fills the entire 4000-byte findings budget
with attacker-chosen prose. **Envelope integrity holds** — `tr -d '<>'` plus the
line-anchored grammar filter were verified against a multi-line breakout attempt
and only the first line survived; what is unbounded is plain prose inside a
correctly-formed envelope. Pre-existing, but `--warn-exit` widens it from
"documents that also carry an ERROR" to warnings-only documents. Deferred
deliberately: the fix truncates at the source, which moves linter output and
needs a blast-radius pass over `tests/acceptance/expected_warnings/` and the
golden fixtures first.

## What is NOT broken

- **`doc-review.yml` could not actually have false-greened**, even before the
  fix above: the *valid*-fixtures smoke step runs first and would exit 3, and
  `tests/conformance/requirements.txt` installs PyYAML before either. The step
  was tightened because ordering is a weak reason for a gate to be correct.
- **No consumer degrades on a caught `ImportError`.** Nothing in the repo wraps
  `import sdd_doc_lint` in a `try`, so the import-time `SystemExit` cannot
  swallow a fallback path. Every consumer is a short-lived CLI or test process;
  Hermes' runtime never imports it.
- **No `platforms/hermes/VERSION` bump** (founder decision O2), so
  `sync-version-refs.sh`'s five-file fanout never fires. The change is logged
  under Hermes' `[Unreleased]`.
- **Doc surfaces: 2** (`platforms/hermes/CHANGELOG.md`,
  `plans/FRAMEWORK-TODO.md`), under the ≤3 governance cap.
- **Pinning `PYTHONPATH` costs nothing legitimate.** The linter needs only the
  plugin root; an installed PyYAML resolves from site-packages either way, and
  one supplied *solely* via `PYTHONPATH` now gets the exit-3 diagnostic rather
  than silent substitution.

The Hermes CHANGELOG diff carries a few markdownlint `_x_` → `*x*` rewrites of
historical entries. That is the repo's own pre-commit hook normalizing MD049 on
a file the PR touches; byte-level, no semantic change.
