### PR TITLE
fix(plugin): saga driver correctness and disclosure — PLUGIN-PREPROD-001 PR 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,102 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — the saga driver stops wedging, stops clobbering its subprocess, and stops reporting success on runs that never converged (2026-08-01)
+
+**PLUGIN-PREPROD-001 PR 3 of 5.** No version bump on any stream; the plugin's
+`0.24.0 → 0.25.0` cut is PR 5. Closes B2, B3a–c, M3, M4, M5, L2 and L3 of the
+2026-07-31 pre-production review.
+
+- **The permission bypass is opt-in and stated where it is requested.** The
+  driver hardcoded `--dangerously-skip-permissions` on every subprocess it
+  spawned, disclosed in no shipped file. It is now behind
+  `--allow-skip-permissions`, off by default; the 9 `doc-*-autopilot` skills
+  and the acceptance harness pass it explicitly, so the bypass is visible at
+  the invocation site rather than buried in the driver. Documented in the
+  plugin README and the `plugin.json` description.
+- **A saga could wedge permanently.** Four call sites transitioned to
+  `PARTIAL_TIMEOUT` from whatever state the saga was in, but three
+  non-terminal states cannot legally reach it — so the recovery path itself
+  raised, and the run died holding a journal it never finished writing. All
+  four now use an explicit forced transition, recorded as `forced: true` so a
+  reader can tell a reconciled edge from a legal one. `can_transition` is
+  unchanged: the preemptive validation was right, its recovery paths were not.
+  **A forced edge may only target `PARTIAL_TIMEOUT`** — forcing toward a
+  failure terminal is safe in the worst case, while forcing toward `CLOSED`
+  would report a pass the transition table says was unreachable.
+- **A `PASS` verdict arriving on an inconsistent journal no longer closes the
+  run.** If the audit reports `PASS` while leaving the saga in a state from
+  which fan-in was never reached, that is evidence the audit is broken, not
+  that the document is good; the run is reported as not converged with a
+  compensation action naming the state. The `ESCALATED` case is the one that
+  matters: an audit that escalates *and* writes a `PASS` verdict would
+  otherwise have had its escalation rewritten as success at exit 0.
+- **The driver overwrote its own subprocess's journal.** `dispatch_phase`
+  wrote a pre-dispatch snapshot back after the child returned, discarding the
+  per-branch transitions, branch records and status the child had written; the
+  caller's later reload then read the driver's overwrite and could not tell.
+  The completion event is now appended to the file as the child left it. An
+  unreadable `saga.json` is treated as a failed phase and copied aside to
+  `saga.corrupt.json` — swallowing it and writing the stale snapshot back
+  would have been the same clobber, destroying the evidence with it.
+- **Resume walked branch-scoped transitions.** A saga resuming from
+  `PARTIAL_TIMEOUT` could adopt one lens's `BRANCH_FAILED` as the whole run's
+  status. The walk is now run-scoped, defaulting a missing `scope` to `"run"`
+  — scope-less entries are real, and a stricter test would have restarted
+  every such journal at `PREPARED`.
+- **GNU `timeout` is probed for, not assumed.** Stock macOS ships no
+  `timeout`; the driver now falls back to `gtimeout`, then to
+  `subprocess.run(timeout=…)`, and maps an expiry to 124 either way. A
+  subprocess that cannot be spawned at all now journals its failure instead of
+  leaving a `dispatch:` event with no completion.
+- **A run that never passed review no longer exits 0.** `main` returned 0 for
+  every terminal status. It now exits **4** for `PARTIAL_TIMEOUT`, **5** for
+  `ESCALATED` and **127** when the phase subprocess could not be spawned —
+  never 2 (argparse) or 124 (`timeout`), so failure attribution stays
+  unambiguous — at both return sites and on the already-`ESCALATED` early
+  exit. 127 is deliberately not folded into 4: a missing `claude` binary is an
+  environment defect that fails identically on every retry, and reporting it
+  as "resumable" would send the operator round that loop. The acceptance
+  harness reports each cause by name.
+- **`verdict.json` is rotated to `verdict.iterN.json` before each audit
+  dispatch**, so an audit that crashes cannot have the previous iteration's
+  `PASS` read as its own. Rotated rather than deleted: the file holds the
+  `blocking_findings` that motivated the fixer pass, and the runs that most
+  need them are exactly the ones where no replacement verdict is ever written.
+- **`--threshold` was accepted and ignored.** It now gates a `PASS` verdict
+  that reports a `content_score`, reading `int`, `float` and numeric strings —
+  an int-only reader would have been silently defeated by `92.5`, which is an
+  entirely ordinary thing for an LLM-written verdict to contain, and that was
+  the most likely way this gate would have failed in practice. Three outcomes
+  are kept distinct: a number is gated; **no** score is not gated (CHG has no
+  numeric readiness score by design and says so in its own verdict, so
+  coercing that absence to 0 would drive the layer to the iteration cap); a
+  score that is present but unreadable **fails** the gate, because an
+  unreadable score means a broken audit. The flag string survives either way —
+  the acceptance harness passes `--threshold 90` on every cascade layer, so
+  removing it would have exited 2 on a usage error before any saga work.
+- **`playbook_loader` confined to its own root.** `layer` and `lens` were
+  interpolated into a path with no traversal guard. The guard resolves both
+  sides, so symlink escapes are caught too, and it returns the path it
+  validated rather than re-building an unvalidated one.
+
+Test-first throughout: `tests/conformance/test_saga_driver_recovery.py`,
+`tests/conformance/test_playbook_loader_safety.py` and
+`tests/conformance/platforms/test_tools_vendoring.py` were written failing,
+then made to pass — conformance goes 299 → 357. Both new guards are
+deliberately conformance-resident rather than joining `playbook_loader`'s
+existing tests under `tests/unit/`, which no hook and no workflow executes.
+
+Then mutation-checked: **34 mutants, each backing out exactly one fix, all 34
+detected.** Two were initially missed and the *tests* were at fault, not the
+fixes — `content_score: true` compares as 1 and so fails a threshold of 90 for
+the wrong reason, and a resolved-vs-unresolved return path is indistinguishable
+unless a symlink makes the two differ. Both now assert the classification
+rather than the downstream outcome. The harness also restores from a saved
+copy on every iteration rather than in a `finally`: one mutant leaves the
+driver's loop non-terminating, and killing the run skipped the cleanup and left
+a mutant in the working tree.
+
 ### Fixed — the linter diagnoses its own prerequisites, and the review hook stops importing project-supplied code (2026-07-31)
 
 **PLUGIN-PREPROD-001 PR 2 of 5.** No version bump on any stream; the plugin's

--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -56,6 +56,57 @@
 
 ## Open
 
+### `[plugin]` `SAGA-ALL-BRANCHES-FAILED-CLOSES` — a review where every lens failed still closes at exit 0
+
+- *Context:* found 2026-08-01 by review during PLUGIN-PREPROD-001 PR 3, and
+  **pre-existing** — not introduced by that PR, though B3b makes it more
+  reachable by preserving the subprocess's real state.
+  `tools/saga_driver.py` `reconcile_post_audit` counts `BRANCH_FAILED` as
+  terminal-and-fine (`terminal_branch_states = {"BRANCH_COMPLETED",
+  "BRANCH_FAILED"}`), so a run whose crew all failed walks `FANOUT_STARTED →
+  BRANCH_RUNNING → BRANCH_COMPLETED` **legally**. A `PASS` verdict then closes
+  it via the ordinary chain — PR 3's forced-edge guard does not catch this,
+  because no edge is forced. Reachable in practice: `validate_and_repair_branches`
+  fabricates `BRANCH_FAILED` for every persona with no slot file, which is what
+  an audit that writes `verdict.json` but dies before stamping branches leaves.
+- *Fix shape:* gate the run-level walk on `BRANCH_COMPLETED` only, or escalate
+  when any branch is `BRANCH_FAILED`. Needs a decision on what a partially-failed
+  crew means for quorum (`REVIEW_TEAM.md` §Resilience already defines
+  `coverage.quorum_met`, which the driver never reads) — so it is a design
+  question, not a one-liner, and deliberately out of PR 3's scope.
+
+### `[plugin]` `SAGA-DRAFT-HARDCODED-FROM-STATE` — the draft branch journals a `from` state it never checked
+
+- *Context:* found 2026-08-01 during PLUGIN-PREPROD-001 PR 3.
+  `tools/saga_driver.py` `_advance_after_phase` stamps
+  `append_transition(from_state="PREPARED", to_state="FANOUT_STARTED")` for the
+  draft phase regardless of the saga's actual status, then overwrites
+  `saga["status"]`. Latent while the draft subprocess leaves `saga.json` alone
+  (it does today — journal writes belong to the audit skill), but B3b now
+  preserves whatever the child wrote, so a draft skill that ever touches the
+  journal would have its state silently replaced and the transition recorded
+  with a `from` that was never true.
+- *Fix shape:* read `saga["status"]` like the other branches do, and treat an
+  unexpected state as the inconsistency it is rather than overwriting it.
+
+### `[plugin]` `PREPROD-B2-GATE-SCOPE` — the no-bypass release gate matches a literal string, and skips `commands/` + `agents/`
+
+- *Context:* found 2026-08-01 by security review of PLUGIN-PREPROD-001 PR 3.
+  `tests/release/test_marketplace_gate.py:39` asserts the absence of the literal
+  `--dangerously-skip-permissions` in `SKILL.md` files. PR 3 moved the bypass
+  behind `--allow-skip-permissions`, which the gate does not match — the
+  semantic invariant is still covered (conformance
+  `test_bypass_absent_by_default` + `test_flag_defaults_off` assert the driver
+  ships it off, `test_driver_invocation_passes_the_permission_flag` asserts which
+  skills opt in), but the gate itself no longer measures it. Separately
+  `skill_dirs()` (`tests/conformance/_spec.py:90`) scans `skills/` only, so a
+  `commands/` or `agents/` surface that enabled a bypass would be outside both.
+- *Fix shape:* have the gate assert the property rather than the spelling —
+  any surface naming a bypass flag must be on a declared allowlist and carry an
+  in-file disclosure — and extend the scan to `commands/` and `agents/`.
+  **Not done in PR 3:** the plan forbids amending that gate, and PR 5 cuts the
+  release off it.
+
 ### `[plugin]` `PLUGIN-PREPROD-001` — the pre-prod review queue (23 findings, one entry each below)
 
 - *Context:* a five-lens pre-production review of `platforms/claude-code-plugin`

--- a/platforms/claude-code-plugin/.claude-plugin/plugin.json
+++ b/platforms/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "aidoc-flow",
-  "description": "Pre-1.0 preview. AI-Driven Specification-Driven Development (SDD) workflow — skills, agents, and commands for the 8-layer doc flow (BRD → IPLAN). Consumes the aidoc-flow framework spec. APIs and surfaces may change before 1.0.",
+  "description": "Pre-1.0 preview. AI-Driven Specification-Driven Development (SDD) workflow — skills, agents, and commands for the 8-layer doc flow (BRD → IPLAN). Consumes the aidoc-flow framework spec. The doc-*-autopilot skills opt in to running their dispatched subprocesses without permission prompts; see README \"What the autopilot skills do to your permissions\". APIs and surfaces may change before 1.0.",
   "version": "0.24.0",
   "author": {
     "name": "AI Doc Flow",

--- a/platforms/claude-code-plugin/CHANGELOG.md
+++ b/platforms/claude-code-plugin/CHANGELOG.md
@@ -14,6 +14,59 @@ this platform adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed — the autopilot's saga driver: no permanent wedge, no clobbered journal, no false success (2026-08-01)
+
+PLUGIN-PREPROD-001 PR 3 of 5. Closes B2, B3a–c, M3, M4, M5, L2 and L3 from the
+2026-07-31 pre-production review; PRs 4 and 5 carry the rest.
+
+- **`--allow-skip-permissions` (new, off by default).** `tools/saga_driver.py`
+  ran every dispatched phase with `--dangerously-skip-permissions`
+  unconditionally. The bypass is now opt-in. The 9 `doc-*-autopilot` skills
+  pass it, so autopilot behaviour is unchanged for anyone invoking a skill;
+  running the driver directly without the flag now prompts normally. See the
+  README section "What the autopilot skills do to your permissions".
+- **Recovery paths no longer raise.** Transitions to `PARTIAL_TIMEOUT` from
+  `BRANCH_FAILED`, `BRANCH_COMPENSATING` or `SYNTHESIZED` are recorded as
+  forced edges instead of raising `ValueError` and abandoning the run. A
+  forced edge may only ever target `PARTIAL_TIMEOUT`: forcing toward a failure
+  terminal is safe, forcing toward `CLOSED` would report a pass the state
+  machine says was unreachable.
+- **A `PASS` verdict on an inconsistent journal no longer closes the saga.**
+  If the audit subprocess reports `PASS` while leaving the saga in a state
+  from which fan-in was never reached — including `ESCALATED` — the run is
+  reported as not converged rather than walked to `CLOSED`. Previously an
+  audit that escalated *and* wrote a `PASS` verdict had its escalation
+  silently rewritten as success at exit 0.
+- **`dispatch_phase` preserves what the phase subprocess wrote to
+  `saga.json`** instead of overwriting it with a pre-dispatch snapshot. If
+  that file comes back unreadable the phase is treated as failed and the
+  corrupt journal is copied to `saga.corrupt.json` rather than being
+  overwritten with the driver's stale snapshot.
+- **Resume from `PARTIAL_TIMEOUT` considers run-scoped transitions only**, so
+  a single lens's branch failure can no longer become the run's status.
+- **macOS: `timeout` is probed, with `gtimeout` and a Python-level timeout as
+  fallbacks.** A failed spawn is journalled rather than leaving a dispatch
+  event with no completion.
+- **Exit codes: 4 = `PARTIAL_TIMEOUT`, 5 = `ESCALATED`, 127 = the phase
+  subprocess could not be spawned, 0 only for `CLOSED`.** Previously every
+  terminal status exited 0, so a caller chaining on success proceeded on
+  artifacts that never passed review. 127 is reported directly rather than as
+  a `PARTIAL_TIMEOUT`, because a missing `claude` binary is an environment
+  defect that will fail identically on every retry, not a resumable deadline.
+- **`verdict.json` is rotated to `verdict.iterN.json` before each audit
+  dispatch**, so a stale `PASS` cannot be read as the current verdict while
+  the findings that motivated the fixer pass survive for whoever inspects the
+  run.
+- **`--threshold` now gates a `PASS` that reports a `content_score`** (it was
+  accepted and ignored). `int`, `float` and numeric strings are all read —
+  `92.5` is an ordinary thing for an LLM-written verdict to contain, and an
+  int-only reader would have silently disabled the gate on it. Verdicts that
+  report no score — CHG, by design — are not gated; a score that is present
+  but unreadable fails the gate rather than skipping it.
+- **`tools/playbook_loader.py` rejects `layer`/`lens` values that resolve
+  outside `framework/playbooks/`**, including via symlink, and returns the
+  path it validated rather than a re-built one.
+
 ### Fixed — the review hook no longer runs the user's code, and `review_hook` finally does something (2026-07-31)
 
 PLUGIN-PREPROD-001 PR 1 of 5. Closes B1, B4's hook half, H1, H2, H3, M1, L4 and

--- a/platforms/claude-code-plugin/README.md
+++ b/platforms/claude-code-plugin/README.md
@@ -28,6 +28,31 @@ Everything else — the other 41 skills, all commands, the agents — works with
 none of these installed. The review hook in particular is advisory and degrades
 quietly: it never blocks an edit, whatever is missing.
 
+## What the autopilot skills do to your permissions
+
+The 9 `doc-*-autopilot` skills run a create-review-revise loop by spawning
+`claude` subprocesses through `tools/saga_driver.py`. An unattended loop
+cannot answer permission prompts, so the skills pass
+**`--allow-skip-permissions`** to the driver, and the driver in turn runs each
+subprocess with Claude Code's `--dangerously-skip-permissions`.
+
+Inside those subprocesses **every** permission prompt is suppressed — not only
+file writes. The dispatched skills declare no `allowed-tools`, so each
+subprocess holds the full tool set (`Bash`, `Write`, `Edit`, `WebFetch`) and
+can run shell commands and reach the network without asking. Nothing scopes
+the writes to your project directory. One autopilot invocation dispatches up
+to four phases per iteration and up to three iterations — ten if
+`.aidoc/profile.yaml` raises `quality_loop_max_iterations` — each bounded at
+30 minutes.
+
+Run the autopilot only on a repository whose contents you trust.
+
+It is **opt-in and visible at the invocation site**, not a default buried in
+the driver: run `saga_driver.py` yourself without the flag and every dispatched
+phase prompts normally. If you would rather approve each write, invoke the
+per-layer skills (`/aidoc-flow:doc-brd`, `-audit`, `-fixer`) directly instead of
+the autopilot — same work, one prompt at a time, no subprocesses.
+
 ## Install
 
 Published through the repo-root marketplace manifest

--- a/platforms/claude-code-plugin/skills/doc-adr-autopilot/SKILL.md
+++ b/platforms/claude-code-plugin/skills/doc-adr-autopilot/SKILL.md
@@ -88,8 +88,13 @@ Your first **orchestration** action MUST be the `Bash` tool (the Model precheck 
 
 ```sh
 python3 "${CLAUDE_PLUGIN_ROOT}/tools/saga_driver.py" \
-  --layer 05_ADR
+  --layer 05_ADR \
+  --allow-skip-permissions
 ```
+
+`--allow-skip-permissions` lets the phases the driver dispatches write
+files without a permission prompt — unattended autopilot requires it.
+Drop the flag to run the same loop with Claude Code's normal prompts on.
 
 Use a generous timeout (≥1800s). Do not pre-analyze the input. Do not
 read the upstream. Do not classify type/scope. The driver and its

--- a/platforms/claude-code-plugin/skills/doc-bdd-autopilot/SKILL.md
+++ b/platforms/claude-code-plugin/skills/doc-bdd-autopilot/SKILL.md
@@ -84,8 +84,13 @@ Your first **orchestration** action MUST be the `Bash` tool (the Model precheck 
 
 ```sh
 python3 "${CLAUDE_PLUGIN_ROOT}/tools/saga_driver.py" \
-  --layer 04_BDD
+  --layer 04_BDD \
+  --allow-skip-permissions
 ```
+
+`--allow-skip-permissions` lets the phases the driver dispatches write
+files without a permission prompt — unattended autopilot requires it.
+Drop the flag to run the same loop with Claude Code's normal prompts on.
 
 Use a generous timeout (≥1800s). Do not pre-analyze the input. Do not
 read the upstream. Do not classify type/scope. The driver and its

--- a/platforms/claude-code-plugin/skills/doc-brd-autopilot/SKILL.md
+++ b/platforms/claude-code-plugin/skills/doc-brd-autopilot/SKILL.md
@@ -100,8 +100,13 @@ Your first **orchestration** action MUST be the `Bash` tool (the Model precheck 
 
 ```sh
 python3 "${CLAUDE_PLUGIN_ROOT}/tools/saga_driver.py" \
-  --layer 01_BRD
+  --layer 01_BRD \
+  --allow-skip-permissions
 ```
+
+`--allow-skip-permissions` lets the phases the driver dispatches write
+files without a permission prompt — unattended autopilot requires it.
+Drop the flag to run the same loop with Claude Code's normal prompts on.
 
 Use a generous timeout (≥1800s). Do not pre-analyze the input. Do not
 read the seed. Do not classify type/scope. The driver and its

--- a/platforms/claude-code-plugin/skills/doc-chg-autopilot/SKILL.md
+++ b/platforms/claude-code-plugin/skills/doc-chg-autopilot/SKILL.md
@@ -86,8 +86,13 @@ Your VERY FIRST tool call MUST be the `Bash` tool, running exactly:
 ```sh
 python3 "${CLAUDE_PLUGIN_ROOT}/tools/saga_driver.py" \
   --layer 09_CHG \
-  --artifact-path "${ARTIFACT_PATH}"
+  --artifact-path "${ARTIFACT_PATH}" \
+  --allow-skip-permissions
 ```
+
+`--allow-skip-permissions` lets the phases the driver dispatches write
+files without a permission prompt — unattended autopilot requires it.
+Drop the flag to run the same loop with Claude Code's normal prompts on.
 
 Use a generous timeout (≥1800s). Do not pre-analyze the input. Do not
 read the seed. Do not classify level/source. The driver and its

--- a/platforms/claude-code-plugin/skills/doc-ears-autopilot/SKILL.md
+++ b/platforms/claude-code-plugin/skills/doc-ears-autopilot/SKILL.md
@@ -84,8 +84,13 @@ Your first **orchestration** action MUST be the `Bash` tool (the Model precheck 
 
 ```sh
 python3 "${CLAUDE_PLUGIN_ROOT}/tools/saga_driver.py" \
-  --layer 03_EARS
+  --layer 03_EARS \
+  --allow-skip-permissions
 ```
+
+`--allow-skip-permissions` lets the phases the driver dispatches write
+files without a permission prompt — unattended autopilot requires it.
+Drop the flag to run the same loop with Claude Code's normal prompts on.
 
 Use a generous timeout (≥1800s). Do not pre-analyze the input. Do not
 read the upstream. Do not classify type/scope. The driver and its

--- a/platforms/claude-code-plugin/skills/doc-iplan-autopilot/SKILL.md
+++ b/platforms/claude-code-plugin/skills/doc-iplan-autopilot/SKILL.md
@@ -90,8 +90,13 @@ Your first **orchestration** action MUST be the `Bash` tool (the Model precheck 
 
 ```sh
 python3 "${CLAUDE_PLUGIN_ROOT}/tools/saga_driver.py" \
-  --layer 08_IPLAN
+  --layer 08_IPLAN \
+  --allow-skip-permissions
 ```
+
+`--allow-skip-permissions` lets the phases the driver dispatches write
+files without a permission prompt — unattended autopilot requires it.
+Drop the flag to run the same loop with Claude Code's normal prompts on.
 
 Use a generous timeout (≥1800s). Do not pre-analyze the input. Do not
 read the upstream. Do not classify type/scope. The driver and its

--- a/platforms/claude-code-plugin/skills/doc-prd-autopilot/SKILL.md
+++ b/platforms/claude-code-plugin/skills/doc-prd-autopilot/SKILL.md
@@ -88,8 +88,13 @@ Your first **orchestration** action MUST be the `Bash` tool (the Model precheck 
 
 ```sh
 python3 "${CLAUDE_PLUGIN_ROOT}/tools/saga_driver.py" \
-  --layer 02_PRD
+  --layer 02_PRD \
+  --allow-skip-permissions
 ```
+
+`--allow-skip-permissions` lets the phases the driver dispatches write
+files without a permission prompt — unattended autopilot requires it.
+Drop the flag to run the same loop with Claude Code's normal prompts on.
 
 Use a generous timeout (≥1800s). Do not pre-analyze the input. Do not
 read the BRD. Do not classify type/scope. The driver and its

--- a/platforms/claude-code-plugin/skills/doc-spec-autopilot/SKILL.md
+++ b/platforms/claude-code-plugin/skills/doc-spec-autopilot/SKILL.md
@@ -84,8 +84,13 @@ Your first **orchestration** action MUST be the `Bash` tool (the Model precheck 
 
 ```sh
 python3 "${CLAUDE_PLUGIN_ROOT}/tools/saga_driver.py" \
-  --layer 06_SPEC
+  --layer 06_SPEC \
+  --allow-skip-permissions
 ```
+
+`--allow-skip-permissions` lets the phases the driver dispatches write
+files without a permission prompt — unattended autopilot requires it.
+Drop the flag to run the same loop with Claude Code's normal prompts on.
 
 Use a generous timeout (≥1800s). Do not pre-analyze the input. Do not
 read the upstream. Do not classify type/scope. The driver and its

--- a/platforms/claude-code-plugin/skills/doc-tdd-autopilot/SKILL.md
+++ b/platforms/claude-code-plugin/skills/doc-tdd-autopilot/SKILL.md
@@ -87,8 +87,13 @@ Your first **orchestration** action MUST be the `Bash` tool (the Model precheck 
 
 ```sh
 python3 "${CLAUDE_PLUGIN_ROOT}/tools/saga_driver.py" \
-  --layer 07_TDD
+  --layer 07_TDD \
+  --allow-skip-permissions
 ```
+
+`--allow-skip-permissions` lets the phases the driver dispatches write
+files without a permission prompt — unattended autopilot requires it.
+Drop the flag to run the same loop with Claude Code's normal prompts on.
 
 Use a generous timeout (≥1800s). Do not pre-analyze the input. Do not
 read the upstream. Do not classify type/scope. The driver and its

--- a/platforms/claude-code-plugin/tools/playbook_loader.py
+++ b/platforms/claude-code-plugin/tools/playbook_loader.py
@@ -15,12 +15,43 @@ class PlaybookMissingError(FileNotFoundError):
     """Raised when a (layer, lens) pair has no playbook on disk."""
 
 
+class PlaybookPathError(ValueError):
+    """Raised when a (layer, lens) pair resolves outside the playbook root."""
+
+
 def resolve_playbook_path(repo_root: Path | str, layer: str, lens: str) -> Path:
     """Return the absolute path where the (layer, lens) playbook should live.
 
-    No I/O. Pure path resolution. Use load_playbook() to actually read.
+    `layer` and `lens` are interpolated straight into the path, so a value
+    containing `..` or a leading `/` would otherwise resolve anywhere on the
+    filesystem and `load_playbook` would read it. Both are rejected: the
+    resolved path must stay under `<repo_root>/framework/playbooks/`
+    (PLUGIN-PREPROD-001 L3).
+
+    Raises PlaybookPathError on escape. Does not require the file to exist —
+    use load_playbook() to actually read.
+
+    Returns the **resolved** path, which is the one that was validated.
+    Returning a freshly-built unresolved path instead would leave the checked
+    path and the opened path as two different objects, so a symlinked
+    component swapped between the check and the read would escape a check that
+    passed.
     """
-    return Path(repo_root) / "framework" / "playbooks" / layer / f"{lens}.md"
+    if not str(layer).strip() or not str(lens).strip():
+        raise PlaybookPathError(f"layer and lens must be non-empty: layer={layer!r} lens={lens!r}")
+    root = (Path(repo_root) / "framework" / "playbooks").resolve()
+    try:
+        candidate = (root / layer / f"{lens}.md").resolve()
+    except ValueError as exc:
+        # An embedded null byte makes realpath raise a bare ValueError. Since
+        # PlaybookPathError subclasses ValueError, letting that through would
+        # escape a caller written to catch PlaybookPathError.
+        raise PlaybookPathError(
+            f"playbook path is not a usable path: layer={layer!r} lens={lens!r} ({exc})"
+        ) from exc
+    if not candidate.is_relative_to(root):
+        raise PlaybookPathError(f"playbook path escapes {root}: layer={layer!r} lens={lens!r}")
+    return candidate
 
 
 def load_playbook(repo_root: Path | str, layer: str, lens: str) -> str:
@@ -31,6 +62,9 @@ def load_playbook(repo_root: Path | str, layer: str, lens: str) -> str:
     """
     path = resolve_playbook_path(repo_root, layer, lens)
     if not path.is_file():
-        rel = path.relative_to(repo_root) if path.is_absolute() else path
+        # resolve_playbook_path returns a resolved path, so compare against a
+        # resolved root or relative_to() raises on an unresolved repo_root.
+        root = Path(repo_root).resolve()
+        rel = path.relative_to(root) if path.is_relative_to(root) else path
         raise PlaybookMissingError(f"playbook missing: {rel}")
     return path.read_text()

--- a/platforms/claude-code-plugin/tools/saga_driver.py
+++ b/platforms/claude-code-plugin/tools/saga_driver.py
@@ -29,6 +29,7 @@ import argparse
 import hashlib
 import json
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -146,6 +147,59 @@ SUBPROCESS_TIMEOUT_SECONDS = 1800
 # missing, malformed, or the field is absent / out of range [1, 10].
 MAX_ITERATIONS = 3
 
+# Process exit codes. A caller that chains on success must not proceed on an
+# artifact that never passed review, so a saga ending in a non-CLOSED terminal
+# state exits non-zero.
+#
+# Deliberately neither 2 nor 124: argparse spends 2 on a usage error, and 124
+# is what `timeout` returns, which `tests/scripts/test-acceptance.sh`
+# special-cases as "driver timeout". Reusing either would make failure
+# attribution in that harness ambiguous.
+EXIT_OK = 0
+EXIT_PARTIAL_TIMEOUT = 4
+EXIT_ESCALATED = 5
+# Returned when the phase subprocess could not be spawned at all (the shell
+# convention for command-not-found). Returned by `main` directly, not mapped
+# through `_exit_code_for_status`: the saga does end PARTIAL_TIMEOUT, but
+# reporting a missing `claude` binary as a resumable deadline would tell the
+# operator to retry a run that will fail identically every time.
+EXIT_SPAWN_FAILED = 127
+
+
+# Sentinel: `verdict.json` reported a `content_score` that cannot be read as a
+# number. Distinct from `None`, which means it reported none at all — the two
+# must not share a gate outcome (see `read_verdict_score`).
+SCORE_UNUSABLE = object()
+
+# Terminal states that already represent a run which did not pass review. A
+# saga sitting in one of these has nothing left to force.
+_FAILURE_TERMINALS = frozenset({"PARTIAL_TIMEOUT", "ESCALATED"})
+
+
+def _force_partial_timeout(saga: dict, *, scope: str = "run") -> None:
+    """Drive the saga to PARTIAL_TIMEOUT from wherever it is.
+
+    No-ops when the saga already sits in a failure terminal: re-forcing
+    `PARTIAL_TIMEOUT -> PARTIAL_TIMEOUT` writes a meaningless self-edge, and
+    rewriting an `ESCALATED` run as merely timed-out would downgrade a state
+    that asks for a human.
+    """
+    if saga["status"] in _FAILURE_TERMINALS:
+        return
+    append_transition(
+        saga, from_state=saga["status"], to_state="PARTIAL_TIMEOUT", scope=scope, forced=True
+    )
+    saga["status"] = "PARTIAL_TIMEOUT"
+
+
+def _exit_code_for_status(status: str) -> int:
+    """Map a terminal saga status to the driver's process exit code."""
+    if status == "PARTIAL_TIMEOUT":
+        return EXIT_PARTIAL_TIMEOUT
+    if status == "ESCALATED":
+        return EXIT_ESCALATED
+    return EXIT_OK
+
 
 def _resolve_max_iterations(profile_path: str | Path | None = None) -> int:
     """Resolve the quality-loop iteration cap.
@@ -199,6 +253,12 @@ class SagaContext:
     start_epoch: float = field(default_factory=time.time)
     threshold: int = 90
     plugin_dir: Path | None = None
+    # Opt-in only (PLUGIN-PREPROD-001 B2). When false — the default — the
+    # dispatched phase subprocess runs under Claude Code's normal permission
+    # prompts. The 9 `doc-*-autopilot` SKILLs and the acceptance harness pass
+    # `--allow-skip-permissions` explicitly, so the bypass is visible where it
+    # is requested rather than hidden in this driver.
+    allow_skip_permissions: bool = False
 
 
 def load_or_init_saga(ctx: SagaContext, seed_path: Path) -> dict:
@@ -207,7 +267,8 @@ def load_or_init_saga(ctx: SagaContext, seed_path: Path) -> dict:
     Entry conditions handled here:
     - saga.json missing -> fresh init (pre-Phase-2 blackboard migration
       if slot files are present).
-    - status CLOSED or ESCALATED -> log + sys.exit(0).
+    - status CLOSED -> log + sys.exit(0); ESCALATED -> log +
+      sys.exit(EXIT_ESCALATED), since that artifact never passed review.
     - status PARTIAL_TIMEOUT or any other in-flight state -> resume.
     """
     if ctx.saga_file.exists():
@@ -220,8 +281,11 @@ def load_or_init_saga(ctx: SagaContext, seed_path: Path) -> dict:
             )
             sys.exit(0)
         if status == "ESCALATED":
+            # Non-zero for the same reason main's return is (M4): the artifact
+            # never passed review, so a caller chaining on success must not
+            # proceed just because this invocation had nothing left to do.
             print(f"saga ESCALATED for {ctx.artifact_id}; human review required")
-            sys.exit(0)
+            sys.exit(EXIT_ESCALATED)
         return saga
 
     ctx.saga_dir.mkdir(parents=True, exist_ok=True)
@@ -297,15 +361,51 @@ def can_transition(*, current: str, target: str) -> bool:
 
 
 def append_transition(
-    saga: dict, *, from_state: str | None, to_state: str, scope: str = "run"
+    saga: dict, *, from_state: str | None, to_state: str, scope: str = "run", forced: bool = False
 ) -> None:
     """Append a transition. Raises ValueError on invalid transitions
-    (preemptive enforcement)."""
-    if from_state is not None and not can_transition(current=from_state, target=to_state):
+    (preemptive enforcement).
+
+    `forced=True` records an edge the transition table does not allow instead
+    of raising, stamping it `forced: true` so a journal reader can tell a
+    reconciled edge from a legal one. It exists for the recovery paths that
+    must reach `PARTIAL_TIMEOUT` from *any* non-terminal state — three of
+    which (`BRANCH_FAILED`, `BRANCH_COMPENSATING`, `SYNTHESIZED`) cannot reach
+    it legally, so an unforced call there raises and wedges the saga
+    permanently (PLUGIN-PREPROD-001 B3a). Use it only where the alternative is
+    an uncaught raise; `can_transition` itself stays strict.
+
+    **A forced edge may only target `PARTIAL_TIMEOUT`.** Forcing toward a
+    failure terminal is safe in the worst case — it fails a run that might
+    have passed. Forcing toward `CLOSED` (or along the chain that reaches it)
+    inverts that: it would report success for a saga the transition table says
+    could not have got there, which is precisely the "reports PASS on reviews
+    that never ran" defect this driver's fixes exist to remove. Anything
+    wanting a forced success has a journal inconsistency to surface, not to
+    paper over.
+    """
+    if forced and to_state != "PARTIAL_TIMEOUT":
         raise ValueError(
-            f"Invalid transition: {from_state} -> {to_state} "
-            f"(allowed: {sorted(_ALLOWED_TRANSITIONS.get(from_state, set()))})"
+            f"forced transitions may only target PARTIAL_TIMEOUT, not {to_state}: "
+            "forcing toward a success state would report a pass the state "
+            "machine says was unreachable"
         )
+    if from_state is not None and not can_transition(current=from_state, target=to_state):
+        if not forced:
+            raise ValueError(
+                f"Invalid transition: {from_state} -> {to_state} "
+                f"(allowed: {sorted(_ALLOWED_TRANSITIONS.get(from_state, set()))})"
+            )
+        entry = {
+            "ts": _utc_now_iso(),
+            "from": from_state,
+            "to": to_state,
+            "scope": scope,
+            "forced": True,
+        }
+        saga["transitions"].append(entry)
+        saga["updated_at"] = _utc_now_iso()
+        return
     saga["transitions"].append(
         {
             "ts": _utc_now_iso(),
@@ -348,8 +448,7 @@ def check_break_circuit(ctx: SagaContext, saga: dict) -> bool:
     PARTIAL_TIMEOUT and caller should exit."""
     elapsed = time.time() - ctx.start_epoch
     if elapsed > SOFT_DEADLINE_SECONDS:
-        append_transition(saga, from_state=saga["status"], to_state="PARTIAL_TIMEOUT", scope="run")
-        saga["status"] = "PARTIAL_TIMEOUT"
+        _force_partial_timeout(saga)
         write_saga(ctx, saga)
         print(
             f"break-circuit fired at {elapsed:.0f}s elapsed; "
@@ -363,14 +462,81 @@ def resume_from_partial_timeout(saga: dict) -> None:
     """Per Phase 2 Pass 4 G-R1: walk transitions[] backward to find the
     pre-PARTIAL_TIMEOUT state. Set saga.status to that state so the loop
     continues from there. Do NOT append a transition with from: PARTIAL_TIMEOUT.
+
+    Only **run-scoped** transitions are candidates: `transitions[]` interleaves
+    run-scope and `branch:<lens>`-scope entries, so an unscoped walk can adopt
+    a branch terminal (e.g. `BRANCH_FAILED` for one lens) as the whole run's
+    status (PLUGIN-PREPROD-001 B3c).
+
+    The `"run"` default is load-bearing, not stylistic. Scope-less entries are
+    real — the audit SKILL's LLM writes transitions straight into `saga.json`,
+    and `reconcile_post_audit` already reads `scope` defensively for that
+    reason. Under a bare `t.get("scope") == "run"` any such journal would find
+    no candidate and restart the saga at `PREPARED`.
     """
     if saga["status"] != "PARTIAL_TIMEOUT":
         return
     for t in reversed(saga["transitions"]):
-        if t["to"] != "PARTIAL_TIMEOUT":
+        if t.get("scope", "run") == "run" and t["to"] != "PARTIAL_TIMEOUT":
             saga["status"] = t["to"]
             return
     saga["status"] = "PREPARED"
+
+
+def _timeout_wrapper() -> list[str]:
+    """Return the argv prefix that bounds a phase subprocess, if one exists.
+
+    `timeout` is GNU coreutils: present on Linux, absent from a stock macOS,
+    where Homebrew's coreutils installs it as `gtimeout`. Probe rather than
+    assume — an unconditional `timeout` prefix makes every dispatch fail with
+    a spawn error on macOS. Callers fall back to `subprocess.run(timeout=…)`
+    when this returns empty (PLUGIN-PREPROD-001 M3).
+    """
+    for name in ("timeout", "gtimeout"):
+        found = shutil.which(name)
+        if found:
+            return [found, str(SUBPROCESS_TIMEOUT_SECONDS)]
+    return []
+
+
+def _reload_saga_in_place(ctx: SagaContext, saga: dict) -> bool:
+    """Refresh `saga` from disk, preserving the caller's dict identity.
+
+    The dispatched subprocess writes its own per-branch transitions and status
+    directly to `saga.json`. Mutating in place (rather than rebinding) means
+    every holder of the dict — including the caller that passed it in — sees
+    the child's work instead of a stale pre-dispatch snapshot.
+
+    Returns False when the journal is unreadable, having first copied it aside
+    as `saga.corrupt.json`. Swallowing that case silently would be the B3b
+    clobber all over again: the caller would go on to write its stale
+    pre-dispatch snapshot over the child's work *and* over the evidence of why
+    the child failed, and nothing downstream could tell. The caller must treat
+    False as a failed phase.
+    """
+    if not ctx.saga_file.exists():
+        return True
+    try:
+        on_disk = json.loads(ctx.saga_file.read_text())
+        if not isinstance(on_disk, dict):
+            raise ValueError(f"saga.json is not a JSON object: {ctx.saga_file}")
+    except (OSError, ValueError) as exc:
+        quarantine = ctx.saga_file.with_name("saga.corrupt.json")
+        try:
+            shutil.copy2(ctx.saga_file, quarantine)
+            preserved = f" preserved at {quarantine}"
+        except OSError:
+            preserved = " (could not be preserved)"
+        print(
+            f"saga.json is unreadable after the subprocess returned ({exc}); "
+            f"the subprocess's work cannot be recovered and must not be "
+            f"overwritten. Corrupt file{preserved}.",
+            file=sys.stderr,
+        )
+        return False
+    saga.clear()
+    saga.update(on_disk)
+    return True
 
 
 def dispatch_phase(ctx: SagaContext, phase: str, brief: str, saga: dict | None = None) -> int:
@@ -382,6 +548,12 @@ def dispatch_phase(ctx: SagaContext, phase: str, brief: str, saga: dict | None =
     events to saga.events[] for orchestration observability (SPEC-RT-001
     2026-06-09 gap — fixer dispatch + completion previously left no
     journal trace).
+
+    The completion event is appended to the saga **as the subprocess left it on
+    disk**, not to the pre-dispatch in-memory copy. Writing the stale copy back
+    clobbered every transition, branch update and status change the child made
+    (PLUGIN-PREPROD-001 B3b) — the caller's later reload then read the driver's
+    own overwrite and could not tell.
     """
     slash = {
         "draft": f"/aidoc-flow:doc-{ctx.layer_type.lower()}",
@@ -389,44 +561,138 @@ def dispatch_phase(ctx: SagaContext, phase: str, brief: str, saga: dict | None =
         "fixer": f"/aidoc-flow:doc-{ctx.layer_type.lower()}-fixer",
         "re-review": f"/aidoc-flow:doc-{ctx.layer_type.lower()}-audit",
     }[phase]
-    cmd = [
-        "timeout",
-        str(SUBPROCESS_TIMEOUT_SECONDS),
+    claude_argv = [
         "claude",
         "--plugin-dir",
         str(ctx.plugin_dir),
-        "--dangerously-skip-permissions",
-        "-p",
-        f"{slash} {brief}",
     ]
+    if ctx.allow_skip_permissions:
+        claude_argv.append("--dangerously-skip-permissions")
+    claude_argv += ["-p", f"{slash} {brief}"]
+
+    wrapper = _timeout_wrapper()
+    cmd = wrapper + claude_argv
+    run_kwargs: dict = {"capture_output": False, "check": False}
+    if not wrapper:
+        run_kwargs["timeout"] = SUBPROCESS_TIMEOUT_SECONDS
+
     print(f"dispatch: {phase} ({slash}) ...")
     if saga is not None:
         append_event(saga, f"dispatch:{phase}", iteration=saga.get("iteration"), slash=slash)
         write_saga(ctx, saga)
-    result = subprocess.run(cmd, capture_output=False, check=False)
+
+    error: str | None = None
+    try:
+        returncode = subprocess.run(cmd, **run_kwargs).returncode
+    except subprocess.TimeoutExpired:
+        # Match GNU `timeout`'s exit code so both wrapper paths report a
+        # deadline the same way to every caller.
+        returncode = 124
+        error = f"phase {phase} exceeded {SUBPROCESS_TIMEOUT_SECONDS}s"
+    except (FileNotFoundError, PermissionError) as exc:
+        # The dispatch event is already journalled. Returning without a
+        # completion event would leave a journal claiming work that never
+        # started, so record the failed spawn explicitly.
+        #
+        # Name `claude` rather than cmd[0]: when a wrapper is in use, cmd[0]
+        # is the resolved timeout path that `shutil.which` just proved exists,
+        # so blaming it points at the one binary that is definitely present.
+        returncode = EXIT_SPAWN_FAILED
+        error = f"could not spawn {claude_argv[0]!r}: {exc}"
+        print(f"dispatch failed: {error}", file=sys.stderr)
+
     if saga is not None:
+        if not _reload_saga_in_place(ctx, saga) and returncode == 0:
+            # An unreadable journal is a failed phase even when the child
+            # exited 0 — main must not advance the state machine on it.
+            returncode = 1
+            error = "saga.json unreadable after the subprocess returned"
+        extra = {"error": error} if error else {}
         append_event(
             saga,
             f"complete:{phase}",
             iteration=saga.get("iteration"),
-            exit_code=result.returncode,
+            exit_code=returncode,
+            **extra,
         )
         write_saga(ctx, saga)
-    return result.returncode
+    return returncode
 
 
-def read_verdict_score(ctx: SagaContext) -> tuple[int, str]:
+def read_verdict_score(ctx: SagaContext) -> tuple[int | float | None | object, str]:
     """Read .aidoc/review/<layer>/<id>/verdict.json. Returns (score, status).
 
-    Returns (0, "MISSING") if verdict.json absent - caller treats this as
+    Returns (None, "MISSING") if verdict.json absent - caller treats this as
     an AUDIT FAILURE (per Pass-4 A9), distinct from a low content score
     (FAIL with score). Driver escalates rather than dispatching fixer.
+
+    Three score outcomes, and conflating any two of them breaks the
+    `--threshold` gate in one direction or the other:
+
+    * a number (`int` or `float`) — gate on it.
+    * `None`, when the verdict reports **no** `content_score`. Some layers
+      have no numeric readiness score *by design*: CHG says so in its own
+      `content_score_note` and gates on `combined_status` plus
+      `blocking_findings_count`. Coercing that absence to 0 would fail every
+      threshold and drive such a layer to the iteration cap.
+    * `SCORE_UNUSABLE`, when the key **is** present but cannot be read as a
+      number. `verdict.json` is written by an LLM-driven audit skill, so
+      `92.5` and `"88"` are ordinary — but `true`, `null` or `"n/a"` are not
+      scores. Treating those as "no score supplied" would silently disable
+      the gate, which is the most likely way this gate fails in practice.
     """
     verdict_path = ctx.saga_dir / "verdict.json"
     if not verdict_path.exists():
-        return 0, "MISSING"
+        return None, "MISSING"
     v = json.loads(verdict_path.read_text())
-    return v.get("content_score", 0), v.get("combined_status", "UNKNOWN")
+    if not isinstance(v, dict):
+        raise ValueError(f"verdict.json is not a JSON object: {verdict_path}")
+    if "content_score" not in v or v["content_score"] is None:
+        return None, v.get("combined_status", "UNKNOWN")
+    raw = v["content_score"]
+    score: int | float | object
+    if isinstance(raw, bool):
+        score = SCORE_UNUSABLE
+    elif isinstance(raw, (int, float)):
+        score = raw
+    elif isinstance(raw, str):
+        try:
+            score = float(raw)
+        except ValueError:
+            score = SCORE_UNUSABLE
+        else:
+            print(
+                f"verdict content_score was the string {raw!r}; read as {score}",
+                file=sys.stderr,
+            )
+    else:
+        score = SCORE_UNUSABLE
+    if score is SCORE_UNUSABLE:
+        print(
+            f"verdict content_score is present but unusable ({raw!r}); "
+            f"treating the run as not converged",
+            file=sys.stderr,
+        )
+    return score, v.get("combined_status", "UNKNOWN")
+
+
+def _invalidate_verdict(ctx: SagaContext, iteration: int) -> None:
+    """Move verdict.json aside so a stale PASS cannot be read as current.
+
+    The audit subprocess is not guaranteed to rewrite it — a crashed or
+    non-team-mode audit leaves the previous iteration's file in place, which
+    `read_verdict_score` would then read as the current verdict
+    (PLUGIN-PREPROD-001 M5).
+
+    Rotated rather than deleted. The file holds the `blocking_findings` that
+    motivated this fixer pass, and the runs that most need it are exactly the
+    ones where the next audit never writes a replacement: a human arriving at
+    the resulting PARTIAL_TIMEOUT would otherwise find an empty review
+    directory — neither the failing verdict nor a new one.
+    """
+    verdict = ctx.saga_dir / "verdict.json"
+    if verdict.exists():
+        verdict.replace(ctx.saga_dir / f"verdict.iter{iteration}.json")
 
 
 def validate_and_repair_branches(ctx: SagaContext, saga: dict) -> None:
@@ -545,6 +811,21 @@ def reconcile_post_audit(ctx: SagaContext, saga: dict) -> None:
     saga["updated_at"] = _utc_now_iso()
 
 
+def _meets_threshold(ctx: SagaContext, score: int | float | None | object) -> bool:
+    """Whether a PASS verdict clears the caller's `--threshold` gate.
+
+    `None` (no score reported) is **not** gated — see `read_verdict_score` for
+    why CHG depends on that. `SCORE_UNUSABLE` (a score reported but
+    unreadable) **fails** the gate: an unreadable score is a broken audit, and
+    failing closed is the only safe reading of one.
+    """
+    if score is None:
+        return True
+    if score is SCORE_UNUSABLE:
+        return False
+    return score >= ctx.threshold
+
+
 def _advance_after_phase(ctx: SagaContext, saga: dict, phase: str) -> None:
     """Apply the state-machine transition for a completed phase + decide
     next phase based on verdict.json (for review/re-review phases)."""
@@ -565,10 +846,16 @@ def _advance_after_phase(ctx: SagaContext, saga: dict, phase: str) -> None:
             # not fan out / write verdict.json — e.g., legacy single-pass
             # audit subprocess that hasn't been team-mode-wired yet). From
             # FANOUT_STARTED, ESCALATED is illegal; PARTIAL_TIMEOUT is the
-            # universally-reachable non-CLOSED terminal. Use PARTIAL_TIMEOUT
-            # so the harness B2 assertion reports FAIL with the right
-            # semantics ("resumable; needs human review / team-mode wiring
-            # for this layer") instead of the driver crashing.
+            # non-CLOSED terminal that carries the right semantics
+            # ("resumable; needs human review / team-mode wiring for this
+            # layer") for the harness B2 assertion.
+            #
+            # PARTIAL_TIMEOUT is NOT reachable from every non-terminal state —
+            # BRANCH_FAILED, BRANCH_COMPENSATING and SYNTHESIZED cannot reach
+            # it, and this branch runs after reconcile_post_audit, which can
+            # leave the saga in any of them. Hence forced=True: without it the
+            # recovery path itself raises and wedges the saga permanently
+            # (PLUGIN-PREPROD-001 B3a).
             saga["compensation_actions"].append(
                 {
                     "ts": _utc_now_iso(),
@@ -581,8 +868,26 @@ def _advance_after_phase(ctx: SagaContext, saga: dict, phase: str) -> None:
                     "action": "partial_timeout",
                 }
             )
-            append_transition(saga, from_state=saga["status"], to_state="PARTIAL_TIMEOUT")
-            saga["status"] = "PARTIAL_TIMEOUT"
+            _force_partial_timeout(saga)
+            return
+
+        if status == "PASS" and not _meets_threshold(ctx, score):
+            # L2: --threshold was accepted and ignored. A PASS whose reported
+            # content_score is below the caller's gate is not a pass; fall
+            # through to the fixer/cap branch below.
+            print(
+                f"verdict PASS but content_score {score} < threshold "
+                f"{ctx.threshold}; treating as not converged"
+            )
+            status = "FAIL"
+
+        if status != "PASS" and saga["status"] in {"CLOSED"} | _FAILURE_TERMINALS:
+            # The audit subprocess left the saga terminal, but the verdict
+            # says this run did not converge. Without this, the fixer branch
+            # below would set current_phase on a CLOSED saga, main's loop
+            # guard would see a terminal status, and the run would exit 0 —
+            # the gate firing and the run reporting success in one breath.
+            _force_partial_timeout(saga)
             return
 
         if status == "PASS":
@@ -593,8 +898,36 @@ def _advance_after_phase(ctx: SagaContext, saga: dict, phase: str) -> None:
             # along the chain. Append only the transitions still needed
             # to reach CLOSED — appending a no-op (e.g. FANIN_REDUCED ->
             # FANIN_REDUCED) would raise ValueError.
+            #
+            # The entry state is whatever the audit subprocess left on disk
+            # (B3b stopped the driver clobbering it), so it need not be one
+            # from which FANIN_REDUCED is legal. That inconsistency is NOT
+            # absorbed: a PASS arriving on a journal that records no completed
+            # fan-in is evidence the audit is broken, not evidence the
+            # document is good. Forcing the edge here would walk the saga to
+            # CLOSED and exit 0 — e.g. an audit that wrote `status: ESCALATED`
+            # and a PASS verdict would have its escalation silently rewritten
+            # as success. Surface it as unconverged instead.
             terminal_chain = ("FANIN_REDUCED", "SYNTHESIZED", "CLOSED")
             if saga["status"] not in terminal_chain:
+                if not can_transition(current=saga["status"], target="FANIN_REDUCED"):
+                    print(
+                        f"verdict PASS but saga is at {saga['status']}, from which "
+                        f"FANIN_REDUCED is unreachable — the audit reported a pass on a "
+                        f"journal recording no completed fan-in. Treating as not "
+                        f"converged; inspect {ctx.saga_file}.",
+                        file=sys.stderr,
+                    )
+                    saga["compensation_actions"].append(
+                        {
+                            "ts": _utc_now_iso(),
+                            "branch": "*",
+                            "reason": (f"PASS verdict from non-fan-in state {saga['status']}"),
+                            "action": "partial_timeout",
+                        }
+                    )
+                    _force_partial_timeout(saga)
+                    return
                 append_transition(saga, from_state=saga["status"], to_state="FANIN_REDUCED")
                 saga["status"] = "FANIN_REDUCED"
             if saga["status"] == "FANIN_REDUCED":
@@ -613,17 +946,19 @@ def _advance_after_phase(ctx: SagaContext, saga: dict, phase: str) -> None:
                 # BRANCH_FAILED or BRANCH_COMPENSATING. At max iterations
                 # we're typically at BRANCH_COMPLETED or FANIN_REDUCED
                 # (audit completed but verdict FAIL), neither of which
-                # allows direct -> ESCALATED. Use PARTIAL_TIMEOUT
-                # (universally reachable from non-terminal states) as
-                # the non-CLOSED terminal. Harness treats both as FAIL.
-                append_transition(saga, from_state=saga["status"], to_state="PARTIAL_TIMEOUT")
-                saga["status"] = "PARTIAL_TIMEOUT"
+                # allows direct -> ESCALATED. Use PARTIAL_TIMEOUT as the
+                # non-CLOSED terminal. Harness treats both as FAIL.
+                # Forced for the same reason as the MISSING branch above:
+                # PARTIAL_TIMEOUT is not reachable from every non-terminal
+                # state, and BRANCH_FAILED is a live entry state here
+                # (PLUGIN-PREPROD-001 B3a).
+                _force_partial_timeout(saga)
     elif phase == "fixer":
         saga["iteration"] += 1
         saga["current_phase"] = "re-review"
 
 
-def main(argv: list[str] | None = None) -> int:
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Saga driver for plugin autopilot")
     parser.add_argument("--layer", required=True, help="e.g. 01_BRD")
     parser.add_argument(
@@ -641,11 +976,35 @@ def main(argv: list[str] | None = None) -> int:
         default=os.environ.get("PREV_OUTPUT"),
         help="upstream seed; falls back to $PREV_OUTPUT",
     )
-    parser.add_argument("--threshold", type=int, default=90)
+    parser.add_argument(
+        "--threshold",
+        type=int,
+        default=90,
+        help=(
+            "minimum content_score a PASS verdict must report to close the "
+            "saga; verdicts that report no score are not gated"
+        ),
+    )
     parser.add_argument(
         "--plugin-dir",
         default=os.environ.get("CLAUDE_PLUGIN_ROOT", os.environ.get("PLUGIN_DIR", "")),
     )
+    parser.add_argument(
+        "--allow-skip-permissions",
+        action="store_true",
+        help=(
+            "run each dispatched phase subprocess with "
+            "--dangerously-skip-permissions, so it can write files without "
+            "prompting. Required for unattended autopilot runs; off by default "
+            "because it disables Claude Code's permission prompts for every "
+            "subprocess this driver spawns."
+        ),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
     args = parser.parse_args(argv)
 
     for name in ("artifact_id", "artifact_path", "seed"):
@@ -668,6 +1027,7 @@ def main(argv: list[str] | None = None) -> int:
         saga_file=saga_dir / "saga.json",
         threshold=args.threshold,
         plugin_dir=Path(args.plugin_dir),
+        allow_skip_permissions=args.allow_skip_permissions,
     )
 
     saga = load_or_init_saga(ctx, Path(args.seed))
@@ -676,9 +1036,11 @@ def main(argv: list[str] | None = None) -> int:
 
     while saga["status"] not in {"CLOSED", "ESCALATED", "PARTIAL_TIMEOUT"}:
         if check_break_circuit(ctx, saga):
-            return 0
+            return _exit_code_for_status(saga["status"])
 
         phase = saga["current_phase"]
+        if phase in ("review", "re-review"):
+            _invalidate_verdict(ctx, saga["iteration"])
         brief = (
             f"Artifact {args.artifact_id} at {args.artifact_path}; "
             f"seed at {args.seed}; saga at {ctx.saga_file}; "
@@ -704,23 +1066,43 @@ def main(argv: list[str] | None = None) -> int:
             # failure (claude API limit, network, timeout, etc.) the
             # saga is usually at PREPARED / FANOUT_STARTED / BRANCH_RUNNING
             # / BRANCH_COMPLETED, none of which allow direct -> ESCALATED.
-            # PARTIAL_TIMEOUT is universally reachable from non-terminal
-            # states and connotes "non-CLOSED terminal, resumable on
+            # PARTIAL_TIMEOUT connotes "non-CLOSED terminal, resumable on
             # next invocation" — the right semantics for a transient
             # external failure. Harness treats both ESCALATED and
-            # PARTIAL_TIMEOUT as FAIL.
+            # PARTIAL_TIMEOUT as FAIL. forced=True because the reloaded
+            # status is whatever the subprocess left behind, which may be
+            # one of the three states PARTIAL_TIMEOUT is not reachable
+            # from (PLUGIN-PREPROD-001 B3a).
+            reason = f"phase {phase} subprocess exit {rc}"
+            if rc == EXIT_SPAWN_FAILED:
+                reason = f"phase {phase} subprocess could not be spawned"
+            elif rc == 124 and not ctx.allow_skip_permissions:
+                # A phase that ran to the full deadline with the permission
+                # bypass off is far more likely to have been sitting on an
+                # unanswerable prompt than to have been slow.
+                reason += " (permission prompts are on; --allow-skip-permissions was not passed)"
             saga["compensation_actions"].append(
                 {
                     "ts": _utc_now_iso(),
                     "branch": "*",
-                    "reason": f"phase {phase} subprocess exit {rc}",
+                    "reason": reason,
                     "action": "partial_timeout",
                 }
             )
-            append_transition(
-                saga, from_state=saga["status"], to_state="PARTIAL_TIMEOUT", scope="run"
-            )
-            saga["status"] = "PARTIAL_TIMEOUT"
+            _force_partial_timeout(saga)
+
+            if rc == EXIT_SPAWN_FAILED:
+                # An environment defect, not a resumable deadline. Reporting
+                # it through EXIT_PARTIAL_TIMEOUT would tell the operator the
+                # run can simply be retried, and every retry would fail
+                # identically.
+                print(
+                    f"phase {phase} could not be spawned — this is an environment "
+                    f"defect, not a resumable timeout. Verify `claude` is on PATH.",
+                    file=sys.stderr,
+                )
+                write_saga(ctx, saga)
+                return EXIT_SPAWN_FAILED
 
         write_saga(ctx, saga)
 
@@ -729,7 +1111,7 @@ def main(argv: list[str] | None = None) -> int:
         f"(iteration {saga['iteration']}, "
         f"{len(saga['transitions'])} transitions)"
     )
-    return 0
+    return _exit_code_for_status(saga["status"])
 
 
 if __name__ == "__main__":

--- a/tests/conformance/platforms/test_autopilot_saga_parity.py
+++ b/tests/conformance/platforms/test_autopilot_saga_parity.py
@@ -32,6 +32,10 @@ LAYER_AUTOPILOTS = {
     "doc-iplan-autopilot": "08_IPLAN",
 }
 
+# Every SKILL that shells the driver, including the CHG autopilot, which is
+# outside the 8-layer flow above but invokes the driver identically.
+DRIVER_INVOKERS = dict(LAYER_AUTOPILOTS, **{"doc-chg-autopilot": "09_CHG"})
+
 
 def split_frontmatter(path):
     text = path.read_text(encoding="utf-8")
@@ -97,6 +101,27 @@ class AutopilotSagaParity(unittest.TestCase):
                     declared_adapts(fm),
                     f"{name}: adapts must declare review_mode (it branches on it)",
                 )
+
+    def test_driver_invocation_passes_the_permission_flag(self):
+        """PLUGIN-PREPROD-001 B2: the permission bypass is opt-in in the
+        driver, so every invoker must *pass* `--allow-skip-permissions`, not
+        merely mention it. A documentation-only change would strip the bypass
+        from the plugin's primary path and from the live cascade.
+
+        Asserted on the invocation block itself — prose elsewhere in the SKILL
+        naming the flag is not a passed argument.
+        """
+        for name in DRIVER_INVOKERS:
+            with self.subTest(skill=name):
+                _, body = split_frontmatter(self._skill(name))
+                blocks = [b for b in body.split("```") if "saga_driver.py" in b and "python3" in b]
+                self.assertTrue(blocks, f"{name}: no saga_driver.py invocation block")
+                for block in blocks:
+                    self.assertIn(
+                        "--allow-skip-permissions",
+                        block,
+                        f"{name}: driver invocation does not pass --allow-skip-permissions",
+                    )
 
     def test_no_dangling_singlepass_crossref(self):
         # Regression guard (Phase 4 review): the team-mode saga block must state

--- a/tests/conformance/platforms/test_tools_vendoring.py
+++ b/tests/conformance/platforms/test_tools_vendoring.py
@@ -1,0 +1,61 @@
+"""Conformance: the plugin's vendored `tools/` modules match the canonical ones.
+
+`tools/sync-plugin-framework.sh` copies three modules into
+`platforms/claude-code-plugin/tools/`, and that vendored copy is what a
+marketplace consumer installs and runs. Re-vendoring is a manual step (CLAUDE.md
+§"Durable traps" records that editing these files requires re-copying by hand,
+and that a formatter can rewrite the file *after* the copy), so drift is silent:
+the canonical copy is what tests import, the vendored copy is what ships.
+
+`test_doc_lint_vendoring.py` covers `sdd_doc_lint/` the same way. These three
+modules had no equivalent guard — so a fix applied only to `tools/` would
+re-ship the plugin with the unfixed code and CI would stay green.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_CANONICAL = _REPO_ROOT / "tools"
+_VENDORED = _REPO_ROOT / "platforms" / "claude-code-plugin" / "tools"
+
+# Keep in sync with TOOLS_FILES in tools/sync-plugin-framework.sh.
+TOOLS_FILES = ("saga_driver.py", "finding_filter.py", "playbook_loader.py")
+
+
+class ToolsVendoring(unittest.TestCase):
+    def test_vendored_tools_are_byte_identical(self):
+        for name in TOOLS_FILES:
+            with self.subTest(module=name):
+                canonical = _CANONICAL / name
+                vendored = _VENDORED / name
+                self.assertTrue(canonical.is_file(), f"missing canonical {canonical}")
+                self.assertTrue(vendored.is_file(), f"missing vendored {vendored}")
+                self.assertEqual(
+                    vendored.read_bytes(),
+                    canonical.read_bytes(),
+                    f"{name} drifted from tools/{name} — re-run tools/sync-plugin-framework.sh",
+                )
+
+    def test_sync_script_list_matches_this_test(self):
+        """If the sync script grows a fourth module, this guard must grow with
+        it — otherwise the new module ships unguarded."""
+        script = (_CANONICAL / "sync-plugin-framework.sh").read_text(encoding="utf-8")
+        for line in script.splitlines():
+            if line.startswith("TOOLS_FILES="):
+                declared = tuple(line.split("(", 1)[1].split(")", 1)[0].split())
+                self.assertEqual(
+                    declared,
+                    TOOLS_FILES,
+                    "TOOLS_FILES in sync-plugin-framework.sh changed; update "
+                    "TOOLS_FILES in this test",
+                )
+                break
+        else:
+            self.fail("TOOLS_FILES not found in tools/sync-plugin-framework.sh")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/conformance/test_playbook_loader_safety.py
+++ b/tests/conformance/test_playbook_loader_safety.py
@@ -1,0 +1,125 @@
+"""Conformance: playbook_loader.py confines reads to the playbook root.
+
+`layer` and `lens` are interpolated into a filesystem path, so an unguarded
+resolver lets a caller read any file the process can (PLUGIN-PREPROD-001 L3).
+
+Lives under tests/conformance/ deliberately: the module's other tests are in
+tests/unit/, which no hook and no workflow executes, so a guard placed there
+would prove itself once and never again.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "tools"))
+import playbook_loader  # noqa: E402  (path injection above is intentional)
+
+
+class TraversalIsRejected(unittest.TestCase):
+    ESCAPES = [
+        ("../../..", "passwd"),
+        ("02_PRD", "../../../../etc/passwd"),
+        ("02_PRD/../../..", "secret"),
+        ("/etc", "passwd"),
+        ("02_PRD", "/etc/passwd"),
+    ]
+
+    def test_resolve_rejects_escape(self):
+        for layer, lens in self.ESCAPES:
+            with self.subTest(layer=layer, lens=lens):
+                with self.assertRaises(playbook_loader.PlaybookPathError):
+                    playbook_loader.resolve_playbook_path(_REPO_ROOT, layer, lens)
+
+    def test_load_rejects_escape_before_reading(self):
+        """The guard must fire even when the traversal target exists — an
+        existing target is exactly the case a traversal is aimed at.
+
+        `layer=".."` climbs from `framework/playbooks` to `framework`, so the
+        decoy has to live there for this to be the "target exists" case rather
+        than a missing-file case that would pass for the wrong reason.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "framework" / "playbooks").mkdir(parents=True)
+            secret = root / "framework" / "secret.md"
+            secret.write_text("classified\n")
+            self.assertTrue(secret.exists())
+            with self.assertRaises(playbook_loader.PlaybookPathError):
+                playbook_loader.load_playbook(root, "..", "secret")
+
+    def test_symlinked_file_inside_root_cannot_escape(self):
+        """The guard's strongest property, and the one a lexical `..` check
+        would not have: it resolves symlinks. Without this, a refactor to a
+        cheaper string-based guard passes every other test here."""
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            pb = root / "framework" / "playbooks" / "02_PRD"
+            pb.mkdir(parents=True)
+            (root / "outside.md").write_text("classified\n")
+            os.symlink(root / "outside.md", pb / "leak.md")
+            with self.assertRaises(playbook_loader.PlaybookPathError):
+                playbook_loader.load_playbook(root, "02_PRD", "leak")
+
+    def test_symlinked_directory_inside_root_cannot_escape(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            pb = root / "framework" / "playbooks"
+            pb.mkdir(parents=True)
+            outside = root / "elsewhere"
+            (outside / "02_PRD").mkdir(parents=True)
+            (outside / "02_PRD" / "architect.md").write_text("classified\n")
+            os.symlink(outside, pb / "evil")
+            with self.assertRaises(playbook_loader.PlaybookPathError):
+                playbook_loader.load_playbook(root, "evil/02_PRD", "architect")
+
+    def test_null_byte_raises_the_modules_own_error(self):
+        """PlaybookPathError subclasses ValueError, so a bare ValueError from
+        realpath would escape a caller that catches PlaybookPathError."""
+        with self.assertRaises(playbook_loader.PlaybookPathError):
+            playbook_loader.resolve_playbook_path(_REPO_ROOT, "02_PRD", "ok\x00")
+
+    def test_empty_segments_rejected(self):
+        for layer, lens in (("", "architect"), ("02_PRD", ""), ("  ", "architect")):
+            with self.subTest(layer=layer, lens=lens):
+                with self.assertRaises(playbook_loader.PlaybookPathError):
+                    playbook_loader.resolve_playbook_path(_REPO_ROOT, layer, lens)
+
+    def test_returns_the_path_it_validated(self):
+        """The checked path and the returned path must be the same object, or
+        a symlinked component swapped between the check and the read escapes a
+        check that passed. A legitimate symlink — one resolving *inside* the
+        root — is what makes the two differ observably."""
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td).resolve()
+            pb = root / "framework" / "playbooks"
+            (pb / "real_layer").mkdir(parents=True)
+            (pb / "real_layer" / "architect.md").write_text("ok\n")
+            os.symlink(pb / "real_layer", pb / "alias_layer")
+
+            path = playbook_loader.resolve_playbook_path(root, "alias_layer", "architect")
+            self.assertEqual(path, path.resolve(), "returned an unvalidated path")
+            self.assertEqual(path, pb / "real_layer" / "architect.md")
+            # and the legitimate symlink is not over-blocked
+            self.assertEqual(
+                playbook_loader.load_playbook(root, "alias_layer", "architect"), "ok\n"
+            )
+
+    def test_legitimate_path_still_resolves(self):
+        path = playbook_loader.resolve_playbook_path(_REPO_ROOT, "02_PRD", "chaos_engineer")
+        self.assertEqual(
+            path, _REPO_ROOT / "framework" / "playbooks" / "02_PRD" / "chaos_engineer.md"
+        )
+
+    def test_missing_playbook_still_raises_its_own_error(self):
+        with self.assertRaises(playbook_loader.PlaybookMissingError):
+            playbook_loader.load_playbook(_REPO_ROOT, "02_PRD", "nonexistent_lens")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/conformance/test_saga_driver_recovery.py
+++ b/tests/conformance/test_saga_driver_recovery.py
@@ -1,0 +1,770 @@
+"""Conformance: saga_driver.py recovery, disclosure and exit-code contract.
+
+Locks the PLUGIN-PREPROD-001 PR 3 findings:
+
+* **B2** — the `--dangerously-skip-permissions` bypass is opt-in
+  (`--allow-skip-permissions`) and absent from the dispatched command by
+  default.
+* **B3a** — the four unconditional `PARTIAL_TIMEOUT` transitions use the
+  forced path, so a saga in a state that cannot reach `PARTIAL_TIMEOUT`
+  terminates and journals instead of raising.
+* **B3b** — `dispatch_phase` does not clobber transitions the dispatched
+  subprocess wrote to `saga.json`.
+* **B3c** — the resume walk considers run-scoped transitions only.
+* **M3** — the GNU `timeout` wrapper is probed for, not assumed, and a
+  failed spawn cannot leave a journalled dispatch that never happened.
+* **M4** — a saga that ends `PARTIAL_TIMEOUT` or `ESCALATED` exits
+  non-zero, with a code that is neither 2 (argparse) nor 124 (`timeout`).
+* **M5** — `verdict.json` is invalidated before every audit dispatch.
+* **L2** — `--threshold` gates the PASS verdict when the audit reported a
+  `content_score`, and is inert when it did not.
+
+No live subprocess is spawned; `subprocess.run` and `dispatch_phase` are
+stubbed. The live cascade exercises the real dispatch separately.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "tools"))
+import saga_driver  # noqa: E402  (path injection above is intentional)
+
+
+def _ctx(root: Path, **kwargs) -> saga_driver.SagaContext:
+    saga_dir = root / ".aidoc" / "review" / "01_BRD" / "BRD-01"
+    saga_dir.mkdir(parents=True, exist_ok=True)
+    defaults = dict(
+        layer="01_BRD",
+        layer_type="BRD",
+        artifact_id="BRD-01",
+        artifact_path=root / "docs" / "01_BRD" / "BRD-01.md",
+        saga_dir=saga_dir,
+        saga_file=saga_dir / "saga.json",
+        plugin_dir=root / "plugin",
+    )
+    defaults.update(kwargs)
+    return saga_driver.SagaContext(**defaults)
+
+
+def _saga(status: str, **kwargs) -> dict:
+    saga = {
+        "review_run_id": "r1",
+        "artifact_id": "BRD-01",
+        "layer": "01_BRD",
+        "status": status,
+        "iteration": 1,
+        "current_phase": "review",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+        "branches": {},
+        "transitions": [
+            {"ts": "2026-01-01T00:00:00+00:00", "from": None, "to": status, "scope": "run"}
+        ],
+        "compensation_actions": [],
+        "events": [],
+    }
+    saga.update(kwargs)
+    return saga
+
+
+class PermissionBypassIsOptIn(unittest.TestCase):
+    """B2: the bypass ships off and is requested at the invocation site."""
+
+    def _dispatched_cmd(self, **ctx_kwargs) -> list[str]:
+        with tempfile.TemporaryDirectory() as td:
+            ctx = _ctx(Path(td), **ctx_kwargs)
+            with mock.patch.object(saga_driver.subprocess, "run") as run:
+                run.return_value = mock.Mock(returncode=0)
+                saga_driver.dispatch_phase(ctx, "draft", "brief")
+            return list(run.call_args.args[0])
+
+    def test_bypass_absent_by_default(self):
+        self.assertNotIn("--dangerously-skip-permissions", self._dispatched_cmd())
+
+    def test_bypass_present_when_opted_in(self):
+        cmd = self._dispatched_cmd(allow_skip_permissions=True)
+        self.assertIn("--dangerously-skip-permissions", cmd)
+
+    def test_flag_is_accepted_by_the_parser(self):
+        parser = saga_driver.build_parser()
+        args = parser.parse_args(
+            [
+                "--layer",
+                "01_BRD",
+                "--artifact-id",
+                "BRD-01",
+                "--artifact-path",
+                "a/b/c/d.md",
+                "--seed",
+                "s.md",
+                "--plugin-dir",
+                "p",
+                "--allow-skip-permissions",
+            ]
+        )
+        self.assertTrue(args.allow_skip_permissions)
+
+    def test_flag_defaults_off(self):
+        parser = saga_driver.build_parser()
+        args = parser.parse_args(
+            [
+                "--layer",
+                "01_BRD",
+                "--artifact-id",
+                "BRD-01",
+                "--artifact-path",
+                "a/b/c/d.md",
+                "--seed",
+                "s.md",
+                "--plugin-dir",
+                "p",
+            ]
+        )
+        self.assertFalse(args.allow_skip_permissions)
+
+
+class ForcedTransitionsDoNotWedge(unittest.TestCase):
+    """B3a: PARTIAL_TIMEOUT is reachable from every non-terminal state via
+    the forced path, and the forced edge is journalled as such."""
+
+    UNREACHABLE = ["BRANCH_FAILED", "BRANCH_COMPENSATING", "SYNTHESIZED"]
+
+    def test_forced_transition_records_instead_of_raising(self):
+        for state in self.UNREACHABLE:
+            with self.subTest(state=state):
+                saga = _saga(state)
+                saga_driver.append_transition(
+                    saga, from_state=state, to_state="PARTIAL_TIMEOUT", forced=True
+                )
+                last = saga["transitions"][-1]
+                self.assertEqual(last["to"], "PARTIAL_TIMEOUT")
+                self.assertTrue(last.get("forced"))
+
+    def test_unforced_transition_still_raises(self):
+        """The preemptive validation is unchanged for ordinary callers."""
+        saga = _saga("BRANCH_FAILED")
+        with self.assertRaises(ValueError):
+            saga_driver.append_transition(
+                saga, from_state="BRANCH_FAILED", to_state="PARTIAL_TIMEOUT"
+            )
+
+    def test_break_circuit_from_unreachable_state(self):
+        for state in self.UNREACHABLE:
+            with self.subTest(state=state), tempfile.TemporaryDirectory() as td:
+                ctx = _ctx(Path(td))
+                saga = _saga(state, current_phase="review")
+                with mock.patch.object(saga_driver, "SOFT_DEADLINE_SECONDS", -1):
+                    self.assertTrue(saga_driver.check_break_circuit(ctx, saga))
+                self.assertEqual(saga["status"], "PARTIAL_TIMEOUT")
+                self.assertEqual(json.loads(ctx.saga_file.read_text())["status"], "PARTIAL_TIMEOUT")
+
+    def test_iteration_cap_from_branch_failed(self):
+        """A saga at BRANCH_FAILED hitting the cap terminates and journals."""
+        with tempfile.TemporaryDirectory() as td:
+            ctx = _ctx(Path(td))
+            (ctx.saga_dir / "verdict.json").write_text(
+                json.dumps({"combined_status": "FAIL", "content_score": 40})
+            )
+            saga = _saga("BRANCH_FAILED", iteration=99)
+            saga_driver._advance_after_phase(ctx, saga, "review")
+            self.assertEqual(saga["status"], "PARTIAL_TIMEOUT")
+            self.assertTrue(saga["transitions"][-1].get("forced"))
+
+    def test_missing_verdict_from_unreachable_state(self):
+        with tempfile.TemporaryDirectory() as td:
+            ctx = _ctx(Path(td))
+            saga = _saga("BRANCH_FAILED")
+            saga_driver._advance_after_phase(ctx, saga, "review")
+            self.assertEqual(saga["status"], "PARTIAL_TIMEOUT")
+
+    def test_subprocess_failure_from_unreachable_state(self):
+        """The fourth call site: main's non-zero subprocess branch."""
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            ctx = _ctx(root)
+            ctx.saga_file.write_text(json.dumps(_saga("BRANCH_FAILED")))
+            rc = _run_main(root, dispatch_rc=1)
+            self.assertEqual(json.loads(ctx.saga_file.read_text())["status"], "PARTIAL_TIMEOUT")
+            self.assertEqual(rc, saga_driver.EXIT_PARTIAL_TIMEOUT)
+
+
+class DispatchPreservesSubprocessJournal(unittest.TestCase):
+    """B3b: the post-subprocess write must not clobber what the child wrote."""
+
+    def test_subprocess_transitions_survive_dispatch(self):
+        """The audit subprocess loads saga.json, stamps its own per-branch
+        transitions and status, and writes it back. None of that may be lost
+        to the driver's post-dispatch write."""
+        with tempfile.TemporaryDirectory() as td:
+            ctx = _ctx(Path(td))
+            saga = _saga("FANOUT_STARTED")
+            ctx.saga_file.write_text(json.dumps(saga))
+
+            def fake_run(cmd, **kwargs):
+                child = json.loads(ctx.saga_file.read_text())
+                child["status"] = "BRANCH_COMPLETED"
+                child["branches"] = {
+                    "architect": {"branch_id": "b1", "status": "BRANCH_COMPLETED", "attempt": 0}
+                }
+                child["transitions"].append(
+                    {
+                        "ts": "2026-01-01T00:01:00+00:00",
+                        "from": "BRANCH_RUNNING",
+                        "to": "BRANCH_COMPLETED",
+                        "scope": "branch:architect",
+                    }
+                )
+                ctx.saga_file.write_text(json.dumps(child))
+                return mock.Mock(returncode=0)
+
+            with mock.patch.object(saga_driver.subprocess, "run", side_effect=fake_run):
+                saga_driver.dispatch_phase(ctx, "review", "brief", saga=saga)
+
+            on_disk = json.loads(ctx.saga_file.read_text())
+            self.assertEqual(on_disk["status"], "BRANCH_COMPLETED")
+            self.assertIn("architect", on_disk["branches"])
+            scopes = [t.get("scope") for t in on_disk["transitions"]]
+            self.assertIn("branch:architect", scopes)
+            kinds = [e["kind"] for e in on_disk["events"]]
+            self.assertIn("dispatch:review", kinds)
+            self.assertIn("complete:review", kinds)
+
+    def test_corrupt_child_journal_is_not_overwritten_silently(self):
+        """A child that dies mid-write leaves unreadable JSON. Swallowing that
+        and writing the stale snapshot back is the B3b clobber again — and it
+        destroys the evidence of why the child failed."""
+        with tempfile.TemporaryDirectory() as td:
+            ctx = _ctx(Path(td))
+            saga = _saga("FANOUT_STARTED")
+            ctx.saga_file.write_text(json.dumps(saga))
+
+            def fake_run(cmd, **kwargs):
+                ctx.saga_file.write_text('{"status": "BRANCH_COMPLETED", "transi')
+                return mock.Mock(returncode=0)
+
+            with mock.patch.object(saga_driver.subprocess, "run", side_effect=fake_run):
+                rc = saga_driver.dispatch_phase(ctx, "review", "brief", saga=saga)
+
+            self.assertNotEqual(rc, 0, "an unreadable journal is a failed phase")
+            quarantine = ctx.saga_dir / "saga.corrupt.json"
+            self.assertTrue(quarantine.exists(), "corrupt journal was destroyed")
+            self.assertEqual(quarantine.read_text(), '{"status": "BRANCH_COMPLETED", "transi')
+
+    def test_child_write_is_authoritative(self):
+        """A child that rewrites saga.json wholesale — rather than loading it
+        first — still wins. Its `events` list replaces the driver's, dropping
+        the `dispatch:` stamp; that is the accepted consequence of treating
+        the child's write as authoritative, not a clobber to undo."""
+        with tempfile.TemporaryDirectory() as td:
+            ctx = _ctx(Path(td))
+            saga = _saga("FANOUT_STARTED")
+            ctx.saga_file.write_text(json.dumps(saga))
+            fabricated = _saga("BRANCH_COMPLETED")
+
+            def fake_run(cmd, **kwargs):
+                ctx.saga_file.write_text(json.dumps(fabricated))
+                return mock.Mock(returncode=0)
+
+            with mock.patch.object(saga_driver.subprocess, "run", side_effect=fake_run):
+                saga_driver.dispatch_phase(ctx, "review", "brief", saga=saga)
+
+            on_disk = json.loads(ctx.saga_file.read_text())
+            self.assertEqual(on_disk["status"], "BRANCH_COMPLETED")
+            self.assertEqual([e["kind"] for e in on_disk["events"]], ["complete:review"])
+
+    def test_caller_dict_reflects_disk_after_dispatch(self):
+        """The in-memory dict the caller holds is reconciled with disk, so a
+        caller that does not reload cannot act on a stale status."""
+        with tempfile.TemporaryDirectory() as td:
+            ctx = _ctx(Path(td))
+            saga = _saga("FANOUT_STARTED")
+            ctx.saga_file.write_text(json.dumps(saga))
+
+            def fake_run(cmd, **kwargs):
+                ctx.saga_file.write_text(json.dumps(_saga("BRANCH_COMPLETED")))
+                return mock.Mock(returncode=0)
+
+            with mock.patch.object(saga_driver.subprocess, "run", side_effect=fake_run):
+                saga_driver.dispatch_phase(ctx, "review", "brief", saga=saga)
+            self.assertEqual(saga["status"], "BRANCH_COMPLETED")
+
+
+class TerminalChainToleratesSubprocessState(unittest.TestCase):
+    """B3b sequencing: preserving the child's status un-masks a latent raise on
+    the PASS terminal chain when that status cannot reach FANIN_REDUCED.
+
+    Not raising is necessary but not sufficient — the run must also not
+    *close*. A PASS arriving on a journal that records no completed fan-in is
+    evidence the audit is broken, and walking it to CLOSED would report
+    success for a review the state machine says cannot have finished.
+    """
+
+    def test_pass_from_unreachable_state_does_not_close(self):
+        for state in ("BRANCH_FAILED", "BRANCH_COMPENSATING", "ESCALATED"):
+            with self.subTest(state=state), tempfile.TemporaryDirectory() as td:
+                ctx = _ctx(Path(td))
+                (ctx.saga_dir / "verdict.json").write_text(
+                    json.dumps({"combined_status": "PASS", "content_score": 95})
+                )
+                saga = _saga(state)
+                saga_driver._advance_after_phase(ctx, saga, "review")
+                self.assertNotEqual(saga["status"], "CLOSED")
+                self.assertNotEqual(saga_driver._exit_code_for_status(saga["status"]), 0)
+
+    def test_escalation_is_never_rewritten_as_success(self):
+        """The concrete regression: an audit that escalates and also writes a
+        PASS verdict must not have its escalation erased."""
+        with tempfile.TemporaryDirectory() as td:
+            ctx = _ctx(Path(td))
+            (ctx.saga_dir / "verdict.json").write_text(
+                json.dumps({"combined_status": "PASS", "content_score": 99})
+            )
+            saga = _saga("ESCALATED")
+            saga_driver._advance_after_phase(ctx, saga, "review")
+            self.assertEqual(saga["status"], "ESCALATED")
+
+    def test_forced_transitions_may_only_target_partial_timeout(self):
+        """The invariant behind the two tests above: forcing toward a success
+        state would report a pass the transition table says was unreachable."""
+        saga = _saga("ESCALATED")
+        for target in ("FANIN_REDUCED", "SYNTHESIZED", "CLOSED", "BRANCH_COMPLETED"):
+            with self.subTest(target=target):
+                with self.assertRaises(ValueError):
+                    saga_driver.append_transition(
+                        saga, from_state="ESCALATED", to_state=target, forced=True
+                    )
+
+    def test_pass_from_legal_state_still_closes(self):
+        for state in ("BRANCH_COMPLETED", "FANIN_REDUCED", "SYNTHESIZED"):
+            with self.subTest(state=state), tempfile.TemporaryDirectory() as td:
+                ctx = _ctx(Path(td))
+                (ctx.saga_dir / "verdict.json").write_text(
+                    json.dumps({"combined_status": "PASS", "content_score": 95})
+                )
+                saga = _saga(state)
+                saga_driver._advance_after_phase(ctx, saga, "review")
+                self.assertEqual(saga["status"], "CLOSED")
+
+    def test_gate_failure_on_a_terminal_saga_does_not_exit_zero(self):
+        """The child left the saga CLOSED but the verdict did not converge:
+        the gate must not fire into a run that then reports success."""
+        with tempfile.TemporaryDirectory() as td:
+            ctx = _ctx(Path(td), threshold=90)
+            (ctx.saga_dir / "verdict.json").write_text(
+                json.dumps({"combined_status": "PASS", "content_score": 40})
+            )
+            saga = _saga("CLOSED")
+            saga_driver._advance_after_phase(ctx, saga, "review")
+            self.assertEqual(saga["status"], "PARTIAL_TIMEOUT")
+            self.assertNotEqual(saga_driver._exit_code_for_status(saga["status"]), 0)
+
+
+class ResumeIsRunScoped(unittest.TestCase):
+    """B3c: a branch-scoped terminal must not become the run status."""
+
+    def test_branch_scoped_transitions_ignored(self):
+        saga = {
+            "status": "PARTIAL_TIMEOUT",
+            "transitions": [
+                {"from": None, "to": "PREPARED", "scope": "run"},
+                {"from": "PREPARED", "to": "FANOUT_STARTED", "scope": "run"},
+                {"from": "FANOUT_STARTED", "to": "BRANCH_RUNNING", "scope": "branch:architect"},
+                {"from": "BRANCH_RUNNING", "to": "BRANCH_FAILED", "scope": "branch:architect"},
+                {"from": "FANOUT_STARTED", "to": "PARTIAL_TIMEOUT", "scope": "run"},
+            ],
+        }
+        saga_driver.resume_from_partial_timeout(saga)
+        self.assertEqual(saga["status"], "FANOUT_STARTED")
+
+    def test_scopeless_transitions_default_to_run(self):
+        """Claim 48: the existing fixture carries no `scope` keys, and the
+        audit SKILL's LLM writes scope-less transitions directly."""
+        saga = {
+            "status": "PARTIAL_TIMEOUT",
+            "transitions": [
+                {"from": None, "to": "PREPARED"},
+                {"from": "PREPARED", "to": "FANOUT_STARTED"},
+                {"from": "FANOUT_STARTED", "to": "BRANCH_RUNNING"},
+                {"from": "BRANCH_RUNNING", "to": "PARTIAL_TIMEOUT"},
+            ],
+        }
+        saga_driver.resume_from_partial_timeout(saga)
+        self.assertEqual(saga["status"], "BRANCH_RUNNING")
+
+    def test_falls_back_to_prepared_when_no_run_scoped_entry(self):
+        saga = {
+            "status": "PARTIAL_TIMEOUT",
+            "transitions": [
+                {"from": "BRANCH_RUNNING", "to": "BRANCH_FAILED", "scope": "branch:auditor"},
+                {"from": None, "to": "PARTIAL_TIMEOUT", "scope": "run"},
+            ],
+        }
+        saga_driver.resume_from_partial_timeout(saga)
+        self.assertEqual(saga["status"], "PREPARED")
+
+
+class TimeoutWrapperIsProbed(unittest.TestCase):
+    """M3: `timeout` is GNU coreutils and absent on a stock macOS."""
+
+    def _cmd_and_kwargs(self, which_map):
+        with tempfile.TemporaryDirectory() as td:
+            ctx = _ctx(Path(td))
+            with mock.patch.object(saga_driver.shutil, "which", side_effect=which_map.get):
+                with mock.patch.object(saga_driver.subprocess, "run") as run:
+                    run.return_value = mock.Mock(returncode=0)
+                    saga_driver.dispatch_phase(ctx, "draft", "brief")
+            return list(run.call_args.args[0]), run.call_args.kwargs
+
+    def test_gnu_timeout_used_when_present(self):
+        cmd, kwargs = self._cmd_and_kwargs({"timeout": "/usr/bin/timeout"})
+        self.assertEqual(cmd[0], "/usr/bin/timeout")
+        self.assertIsNone(kwargs.get("timeout"))
+
+    def test_gtimeout_fallback(self):
+        cmd, kwargs = self._cmd_and_kwargs({"gtimeout": "/opt/homebrew/bin/gtimeout"})
+        self.assertEqual(cmd[0], "/opt/homebrew/bin/gtimeout")
+
+    def test_python_timeout_when_neither_present(self):
+        cmd, kwargs = self._cmd_and_kwargs({})
+        self.assertEqual(cmd[0], "claude")
+        self.assertEqual(kwargs.get("timeout"), saga_driver.SUBPROCESS_TIMEOUT_SECONDS)
+
+    def test_python_timeout_expiry_maps_to_124(self):
+        with tempfile.TemporaryDirectory() as td:
+            ctx = _ctx(Path(td))
+            saga = _saga("PREPARED")
+            ctx.saga_file.write_text(json.dumps(saga))
+            with mock.patch.object(saga_driver.shutil, "which", return_value=None):
+                with mock.patch.object(
+                    saga_driver.subprocess,
+                    "run",
+                    side_effect=saga_driver.subprocess.TimeoutExpired("claude", 1),
+                ):
+                    rc = saga_driver.dispatch_phase(ctx, "draft", "brief", saga=saga)
+            self.assertEqual(rc, 124)
+
+    def test_failed_spawn_journals_completion(self):
+        """A dispatch event with no completion event is a journal that claims
+        work which never happened."""
+        with tempfile.TemporaryDirectory() as td:
+            ctx = _ctx(Path(td))
+            saga = _saga("PREPARED")
+            ctx.saga_file.write_text(json.dumps(saga))
+            with mock.patch.object(
+                saga_driver.subprocess, "run", side_effect=FileNotFoundError("claude")
+            ):
+                rc = saga_driver.dispatch_phase(ctx, "draft", "brief", saga=saga)
+            self.assertNotEqual(rc, 0)
+            kinds = [e["kind"] for e in json.loads(ctx.saga_file.read_text())["events"]]
+            self.assertIn("complete:draft", kinds)
+
+
+class ExitCodesAreMeaningful(unittest.TestCase):
+    """M4: a caller chaining on success must not proceed on an artifact that
+    never passed review."""
+
+    def test_codes_are_distinct_and_unambiguous(self):
+        codes = {saga_driver.EXIT_PARTIAL_TIMEOUT, saga_driver.EXIT_ESCALATED}
+        self.assertNotIn(0, codes)
+        self.assertNotIn(2, codes, "2 is argparse's usage error")
+        self.assertNotIn(124, codes, "124 is `timeout`, which the harness special-cases")
+        self.assertEqual(len(codes), 2)
+
+    def test_status_mapping(self):
+        self.assertEqual(saga_driver._exit_code_for_status("CLOSED"), 0)
+        self.assertEqual(
+            saga_driver._exit_code_for_status("PARTIAL_TIMEOUT"),
+            saga_driver.EXIT_PARTIAL_TIMEOUT,
+        )
+        self.assertEqual(saga_driver._exit_code_for_status("ESCALATED"), saga_driver.EXIT_ESCALATED)
+
+    def test_break_circuit_return_is_non_zero(self):
+        """Claim 49: the `return 0` taken straight after the break circuit is
+        the single most likely way a run ends non-CLOSED."""
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            with mock.patch.object(saga_driver, "SOFT_DEADLINE_SECONDS", -1):
+                rc = _run_main(root, dispatch_rc=0)
+            self.assertEqual(rc, saga_driver.EXIT_PARTIAL_TIMEOUT)
+
+    def test_already_escalated_saga_exits_non_zero(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            ctx = _ctx(root)
+            ctx.saga_file.write_text(json.dumps(_saga("ESCALATED")))
+            with self.assertRaises(SystemExit) as cm:
+                _run_main(root, dispatch_rc=0)
+            self.assertEqual(cm.exception.code, saga_driver.EXIT_ESCALATED)
+
+    def test_unspawnable_subprocess_is_not_reported_as_resumable(self):
+        """A missing `claude` binary is an environment defect. Reporting it as
+        PARTIAL_TIMEOUT tells the operator to retry a run that will fail
+        identically every time."""
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+
+            def stub(ctx_, phase, brief, saga=None):
+                return saga_driver.EXIT_SPAWN_FAILED
+
+            rc = _run_main(root, dispatch_stub=stub)
+            self.assertEqual(rc, saga_driver.EXIT_SPAWN_FAILED)
+            self.assertNotEqual(rc, saga_driver.EXIT_PARTIAL_TIMEOUT)
+            saga = json.loads((root / ".aidoc/review/01_BRD/BRD-01/saga.json").read_text())
+            self.assertEqual(saga["status"], "PARTIAL_TIMEOUT")
+            self.assertIn(
+                "could not be spawned",
+                saga["compensation_actions"][-1]["reason"],
+            )
+
+    def test_already_closed_saga_still_exits_zero(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            ctx = _ctx(root)
+            ctx.saga_file.write_text(json.dumps(_saga("CLOSED")))
+            with self.assertRaises(SystemExit) as cm:
+                _run_main(root, dispatch_rc=0)
+            self.assertEqual(cm.exception.code, 0)
+
+    def test_closed_run_exits_zero(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            ctx = _ctx(root)
+            ctx.saga_file.write_text(json.dumps(_saga("FANOUT_STARTED", current_phase="review")))
+            rc = _run_main(root, dispatch_rc=0)
+            self.assertEqual(rc, 0)
+            self.assertEqual(json.loads(ctx.saga_file.read_text())["status"], "CLOSED")
+
+
+class VerdictIsInvalidatedBetweenIterations(unittest.TestCase):
+    """M5: a stale PASS must not be read as current."""
+
+    def test_verdict_unlinked_before_audit_dispatch(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            ctx = _ctx(root)
+            ctx.saga_file.write_text(json.dumps(_saga("FANOUT_STARTED", current_phase="review")))
+            verdict = ctx.saga_dir / "verdict.json"
+            verdict.write_text(json.dumps({"combined_status": "PASS", "content_score": 99}))
+
+            seen: list[bool] = []
+
+            def stub(ctx_, phase, brief, saga=None):
+                seen.append(verdict.exists())
+                verdict.write_text(json.dumps({"combined_status": "PASS", "content_score": 95}))
+                return 0
+
+            _run_main(root, dispatch_stub=stub)
+            self.assertEqual(seen, [False], "stale verdict.json survived into the audit")
+            self.assertTrue(
+                (ctx.saga_dir / "verdict.iter1.json").exists(),
+                "the superseded verdict was deleted, not rotated — its "
+                "blocking_findings are what a human needs at the resulting "
+                "PARTIAL_TIMEOUT",
+            )
+            self.assertEqual(
+                json.loads((ctx.saga_dir / "verdict.iter1.json").read_text())["content_score"],
+                99,
+            )
+
+    def test_verdict_kept_for_non_audit_phases(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            ctx = _ctx(root)
+            ctx.saga_file.write_text(json.dumps(_saga("PREPARED", current_phase="draft")))
+            verdict = ctx.saga_dir / "verdict.json"
+            verdict.write_text(json.dumps({"combined_status": "PASS", "content_score": 99}))
+
+            seen: list[bool] = []
+
+            def stub(ctx_, phase, brief, saga=None):
+                if phase == "draft":
+                    seen.append(verdict.exists())
+                    saga_ = json.loads(ctx.saga_file.read_text())
+                    saga_["status"] = "PARTIAL_TIMEOUT"
+                    ctx.saga_file.write_text(json.dumps(saga_))
+                    return 1
+                return 0
+
+            _run_main(root, dispatch_stub=stub)
+            self.assertEqual(seen, [True])
+
+
+class ThresholdIsHonored(unittest.TestCase):
+    """L2: the flag string must survive (claim 52) and must not be inert."""
+
+    def test_flag_still_accepted(self):
+        parser = saga_driver.build_parser()
+        args = parser.parse_args(
+            [
+                "--layer",
+                "01_BRD",
+                "--artifact-id",
+                "BRD-01",
+                "--artifact-path",
+                "a/b/c/d.md",
+                "--seed",
+                "s.md",
+                "--plugin-dir",
+                "p",
+                "--threshold",
+                "90",
+            ]
+        )
+        self.assertEqual(args.threshold, 90)
+
+    def test_pass_below_threshold_is_not_a_pass(self):
+        with tempfile.TemporaryDirectory() as td:
+            ctx = _ctx(Path(td), threshold=90)
+            (ctx.saga_dir / "verdict.json").write_text(
+                json.dumps({"combined_status": "PASS", "content_score": 71})
+            )
+            saga = _saga("BRANCH_COMPLETED", iteration=1)
+            saga_driver._advance_after_phase(ctx, saga, "review")
+            self.assertNotEqual(saga["status"], "CLOSED")
+            self.assertEqual(saga["current_phase"], "fixer")
+
+    def test_pass_at_threshold_closes(self):
+        with tempfile.TemporaryDirectory() as td:
+            ctx = _ctx(Path(td), threshold=90)
+            (ctx.saga_dir / "verdict.json").write_text(
+                json.dumps({"combined_status": "PASS", "content_score": 90})
+            )
+            saga = _saga("BRANCH_COMPLETED")
+            saga_driver._advance_after_phase(ctx, saga, "review")
+            self.assertEqual(saga["status"], "CLOSED")
+
+    def test_scoreless_pass_is_not_gated(self):
+        """CHG has no numeric readiness score by design — see the
+        `content_score_note` in the CHG verdict of the example corpus. A
+        verdict that reports no score must not be gated to death."""
+        with tempfile.TemporaryDirectory() as td:
+            ctx = _ctx(Path(td), threshold=90)
+            (ctx.saga_dir / "verdict.json").write_text(
+                json.dumps({"combined_status": "PASS", "content_score_advisory": 95})
+            )
+            saga = _saga("BRANCH_COMPLETED")
+            saga_driver._advance_after_phase(ctx, saga, "review")
+            self.assertEqual(saga["status"], "CLOSED")
+
+    def test_float_score_is_gated(self):
+        """`92.5` is an ordinary thing for an LLM-written verdict to contain.
+        An int-only reader silently disables the gate on it."""
+        for raw, closes in ((95.0, True), (88.5, False), (90.0, True)):
+            with self.subTest(score=raw), tempfile.TemporaryDirectory() as td:
+                ctx = _ctx(Path(td), threshold=90)
+                (ctx.saga_dir / "verdict.json").write_text(
+                    json.dumps({"combined_status": "PASS", "content_score": raw})
+                )
+                saga = _saga("BRANCH_COMPLETED")
+                saga_driver._advance_after_phase(ctx, saga, "review")
+                self.assertEqual(saga["status"] == "CLOSED", closes)
+
+    def test_numeric_string_score_is_gated(self):
+        for raw, closes in (("95", True), ("71", False)):
+            with self.subTest(score=raw), tempfile.TemporaryDirectory() as td:
+                ctx = _ctx(Path(td), threshold=90)
+                (ctx.saga_dir / "verdict.json").write_text(
+                    json.dumps({"combined_status": "PASS", "content_score": raw})
+                )
+                saga = _saga("BRANCH_COMPLETED")
+                saga_driver._advance_after_phase(ctx, saga, "review")
+                self.assertEqual(saga["status"] == "CLOSED", closes)
+
+    def test_unusable_score_fails_closed(self):
+        """A score that is present but unreadable means a broken audit. It
+        must NOT take the same ungated path as a verdict reporting none."""
+        for raw in (True, "n/a", [], {}):
+            with self.subTest(score=raw), tempfile.TemporaryDirectory() as td:
+                ctx = _ctx(Path(td), threshold=90)
+                (ctx.saga_dir / "verdict.json").write_text(
+                    json.dumps({"combined_status": "PASS", "content_score": raw})
+                )
+                saga = _saga("BRANCH_COMPLETED")
+                saga_driver._advance_after_phase(ctx, saga, "review")
+                self.assertNotEqual(saga["status"], "CLOSED")
+
+    def test_unusable_score_is_classified_as_unusable(self):
+        """Assert the classification, not just the outcome. `true` happens to
+        fail a threshold of 90 by comparing as 1, so an outcome-only assertion
+        passes even when bool is wrongly accepted as a score."""
+        for raw in (True, False, "n/a", [], {}):
+            with self.subTest(score=raw), tempfile.TemporaryDirectory() as td:
+                ctx = _ctx(Path(td), threshold=90)
+                (ctx.saga_dir / "verdict.json").write_text(
+                    json.dumps({"combined_status": "PASS", "content_score": raw})
+                )
+                score, _ = saga_driver.read_verdict_score(ctx)
+                self.assertIs(score, saga_driver.SCORE_UNUSABLE)
+                self.assertFalse(saga_driver._meets_threshold(ctx, score))
+
+    def test_a_true_score_cannot_pass_a_low_threshold(self):
+        """The case an outcome-only test cannot see: `true` compares as 1, so
+        with a threshold of 1 an accepted bool would close the saga."""
+        with tempfile.TemporaryDirectory() as td:
+            ctx = _ctx(Path(td), threshold=1)
+            (ctx.saga_dir / "verdict.json").write_text(
+                json.dumps({"combined_status": "PASS", "content_score": True})
+            )
+            saga = _saga("BRANCH_COMPLETED")
+            saga_driver._advance_after_phase(ctx, saga, "review")
+            self.assertNotEqual(saga["status"], "CLOSED")
+
+    def test_explicit_null_score_is_treated_as_absent(self):
+        """`"content_score": null` is how an audit says "no numeric score",
+        so it belongs with the absent case, not the unusable one."""
+        with tempfile.TemporaryDirectory() as td:
+            ctx = _ctx(Path(td), threshold=90)
+            (ctx.saga_dir / "verdict.json").write_text(
+                json.dumps({"combined_status": "PASS", "content_score": None})
+            )
+            saga = _saga("BRANCH_COMPLETED")
+            saga_driver._advance_after_phase(ctx, saga, "review")
+            self.assertEqual(saga["status"], "CLOSED")
+
+
+def _run_main(root: Path, *, dispatch_rc: int = 0, dispatch_stub=None):
+    """Drive `main` against a scratch tree with dispatch stubbed out."""
+    artifact = root / "docs" / "01_BRD" / "BRD-01.md"
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_text("# BRD-01\n")
+    seed = root / "seed.md"
+    seed.write_text("seed\n")
+    saga_file = root / ".aidoc" / "review" / "01_BRD" / "BRD-01" / "saga.json"
+    verdict = saga_file.parent / "verdict.json"
+
+    def default_stub(ctx_, phase, brief, saga=None):
+        current = json.loads(saga_file.read_text())
+        if dispatch_rc == 0:
+            current["status"] = "BRANCH_COMPLETED"
+            saga_file.write_text(json.dumps(current))
+            verdict.write_text(json.dumps({"combined_status": "PASS", "content_score": 95}))
+        return dispatch_rc
+
+    with mock.patch.object(saga_driver, "dispatch_phase", dispatch_stub or default_stub):
+        return saga_driver.main(
+            [
+                "--layer",
+                "01_BRD",
+                "--artifact-id",
+                "BRD-01",
+                "--artifact-path",
+                str(artifact),
+                "--seed",
+                str(seed),
+                "--plugin-dir",
+                str(root / "plugin"),
+                "--threshold",
+                "90",
+            ]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test-acceptance.sh
+++ b/tests/scripts/test-acceptance.sh
@@ -1169,21 +1169,37 @@ phase_1_cascade() {
       write_element_log "doc-$layer-autopilot"
 
       driver_timeout="$ORCHESTRATOR_TIMEOUT"
+      # --allow-skip-permissions: the driver's permission bypass is opt-in
+      # (PLUGIN-PREPROD-001 B2). Without it the phase subprocesses this
+      # cascade spawns would block on permission prompts with no one to
+      # answer them.
       timeout "$driver_timeout" python3 \
         "$PLUGIN_DIR/tools/saga_driver.py" \
         --layer "${layer_num}_${type}" \
         --threshold 90 \
+        --allow-skip-permissions \
         > "$driver_log" 2>&1
       driver_rc=$?
       driver_t1="$(date +%s)"
       driver_dur=$((driver_t1 - driver_t0))
 
       OUTPUT_PATH_BY_NAME["doc-$layer-autopilot"]="$artifact"
+      # The driver's exit code now distinguishes how a run ended (M4): 0 only
+      # when the saga reached CLOSED, 4 PARTIAL_TIMEOUT, 5 ESCALATED, 127 the
+      # phase subprocess could not be spawned at all. 124 is still the outer
+      # `timeout` above, which the driver deliberately does not reuse, so each
+      # code attributes to exactly one cause.
       if (( driver_rc == 0 )); then
         record_outcome "doc-$layer-autopilot" "skill" "cascade" "PASS" "$driver_dur"
       elif (( driver_rc == 124 )); then
         echo "TIMEOUT after ${driver_timeout}s" >> "$driver_log"
         record_outcome "doc-$layer-autopilot" "skill" "cascade" "FAIL" "$driver_dur" "" "" "false" "" "driver timeout"
+      elif (( driver_rc == 4 )); then
+        record_outcome "doc-$layer-autopilot" "skill" "cascade" "FAIL" "$driver_dur" "" "" "false" "" "saga PARTIAL_TIMEOUT (resumable)"
+      elif (( driver_rc == 5 )); then
+        record_outcome "doc-$layer-autopilot" "skill" "cascade" "FAIL" "$driver_dur" "" "" "false" "" "saga ESCALATED (human review required)"
+      elif (( driver_rc == 127 )); then
+        record_outcome "doc-$layer-autopilot" "skill" "cascade" "FAIL" "$driver_dur" "" "" "false" "" "driver could not spawn claude (environment defect, not resumable)"
       else
         record_outcome "doc-$layer-autopilot" "skill" "cascade" "FAIL" "$driver_dur" "" "" "false" "" "driver exit $driver_rc"
       fi

--- a/tools/playbook_loader.py
+++ b/tools/playbook_loader.py
@@ -15,12 +15,43 @@ class PlaybookMissingError(FileNotFoundError):
     """Raised when a (layer, lens) pair has no playbook on disk."""
 
 
+class PlaybookPathError(ValueError):
+    """Raised when a (layer, lens) pair resolves outside the playbook root."""
+
+
 def resolve_playbook_path(repo_root: Path | str, layer: str, lens: str) -> Path:
     """Return the absolute path where the (layer, lens) playbook should live.
 
-    No I/O. Pure path resolution. Use load_playbook() to actually read.
+    `layer` and `lens` are interpolated straight into the path, so a value
+    containing `..` or a leading `/` would otherwise resolve anywhere on the
+    filesystem and `load_playbook` would read it. Both are rejected: the
+    resolved path must stay under `<repo_root>/framework/playbooks/`
+    (PLUGIN-PREPROD-001 L3).
+
+    Raises PlaybookPathError on escape. Does not require the file to exist —
+    use load_playbook() to actually read.
+
+    Returns the **resolved** path, which is the one that was validated.
+    Returning a freshly-built unresolved path instead would leave the checked
+    path and the opened path as two different objects, so a symlinked
+    component swapped between the check and the read would escape a check that
+    passed.
     """
-    return Path(repo_root) / "framework" / "playbooks" / layer / f"{lens}.md"
+    if not str(layer).strip() or not str(lens).strip():
+        raise PlaybookPathError(f"layer and lens must be non-empty: layer={layer!r} lens={lens!r}")
+    root = (Path(repo_root) / "framework" / "playbooks").resolve()
+    try:
+        candidate = (root / layer / f"{lens}.md").resolve()
+    except ValueError as exc:
+        # An embedded null byte makes realpath raise a bare ValueError. Since
+        # PlaybookPathError subclasses ValueError, letting that through would
+        # escape a caller written to catch PlaybookPathError.
+        raise PlaybookPathError(
+            f"playbook path is not a usable path: layer={layer!r} lens={lens!r} ({exc})"
+        ) from exc
+    if not candidate.is_relative_to(root):
+        raise PlaybookPathError(f"playbook path escapes {root}: layer={layer!r} lens={lens!r}")
+    return candidate
 
 
 def load_playbook(repo_root: Path | str, layer: str, lens: str) -> str:
@@ -31,6 +62,9 @@ def load_playbook(repo_root: Path | str, layer: str, lens: str) -> str:
     """
     path = resolve_playbook_path(repo_root, layer, lens)
     if not path.is_file():
-        rel = path.relative_to(repo_root) if path.is_absolute() else path
+        # resolve_playbook_path returns a resolved path, so compare against a
+        # resolved root or relative_to() raises on an unresolved repo_root.
+        root = Path(repo_root).resolve()
+        rel = path.relative_to(root) if path.is_relative_to(root) else path
         raise PlaybookMissingError(f"playbook missing: {rel}")
     return path.read_text()

--- a/tools/saga_driver.py
+++ b/tools/saga_driver.py
@@ -29,6 +29,7 @@ import argparse
 import hashlib
 import json
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -146,6 +147,59 @@ SUBPROCESS_TIMEOUT_SECONDS = 1800
 # missing, malformed, or the field is absent / out of range [1, 10].
 MAX_ITERATIONS = 3
 
+# Process exit codes. A caller that chains on success must not proceed on an
+# artifact that never passed review, so a saga ending in a non-CLOSED terminal
+# state exits non-zero.
+#
+# Deliberately neither 2 nor 124: argparse spends 2 on a usage error, and 124
+# is what `timeout` returns, which `tests/scripts/test-acceptance.sh`
+# special-cases as "driver timeout". Reusing either would make failure
+# attribution in that harness ambiguous.
+EXIT_OK = 0
+EXIT_PARTIAL_TIMEOUT = 4
+EXIT_ESCALATED = 5
+# Returned when the phase subprocess could not be spawned at all (the shell
+# convention for command-not-found). Returned by `main` directly, not mapped
+# through `_exit_code_for_status`: the saga does end PARTIAL_TIMEOUT, but
+# reporting a missing `claude` binary as a resumable deadline would tell the
+# operator to retry a run that will fail identically every time.
+EXIT_SPAWN_FAILED = 127
+
+
+# Sentinel: `verdict.json` reported a `content_score` that cannot be read as a
+# number. Distinct from `None`, which means it reported none at all — the two
+# must not share a gate outcome (see `read_verdict_score`).
+SCORE_UNUSABLE = object()
+
+# Terminal states that already represent a run which did not pass review. A
+# saga sitting in one of these has nothing left to force.
+_FAILURE_TERMINALS = frozenset({"PARTIAL_TIMEOUT", "ESCALATED"})
+
+
+def _force_partial_timeout(saga: dict, *, scope: str = "run") -> None:
+    """Drive the saga to PARTIAL_TIMEOUT from wherever it is.
+
+    No-ops when the saga already sits in a failure terminal: re-forcing
+    `PARTIAL_TIMEOUT -> PARTIAL_TIMEOUT` writes a meaningless self-edge, and
+    rewriting an `ESCALATED` run as merely timed-out would downgrade a state
+    that asks for a human.
+    """
+    if saga["status"] in _FAILURE_TERMINALS:
+        return
+    append_transition(
+        saga, from_state=saga["status"], to_state="PARTIAL_TIMEOUT", scope=scope, forced=True
+    )
+    saga["status"] = "PARTIAL_TIMEOUT"
+
+
+def _exit_code_for_status(status: str) -> int:
+    """Map a terminal saga status to the driver's process exit code."""
+    if status == "PARTIAL_TIMEOUT":
+        return EXIT_PARTIAL_TIMEOUT
+    if status == "ESCALATED":
+        return EXIT_ESCALATED
+    return EXIT_OK
+
 
 def _resolve_max_iterations(profile_path: str | Path | None = None) -> int:
     """Resolve the quality-loop iteration cap.
@@ -199,6 +253,12 @@ class SagaContext:
     start_epoch: float = field(default_factory=time.time)
     threshold: int = 90
     plugin_dir: Path | None = None
+    # Opt-in only (PLUGIN-PREPROD-001 B2). When false — the default — the
+    # dispatched phase subprocess runs under Claude Code's normal permission
+    # prompts. The 9 `doc-*-autopilot` SKILLs and the acceptance harness pass
+    # `--allow-skip-permissions` explicitly, so the bypass is visible where it
+    # is requested rather than hidden in this driver.
+    allow_skip_permissions: bool = False
 
 
 def load_or_init_saga(ctx: SagaContext, seed_path: Path) -> dict:
@@ -207,7 +267,8 @@ def load_or_init_saga(ctx: SagaContext, seed_path: Path) -> dict:
     Entry conditions handled here:
     - saga.json missing -> fresh init (pre-Phase-2 blackboard migration
       if slot files are present).
-    - status CLOSED or ESCALATED -> log + sys.exit(0).
+    - status CLOSED -> log + sys.exit(0); ESCALATED -> log +
+      sys.exit(EXIT_ESCALATED), since that artifact never passed review.
     - status PARTIAL_TIMEOUT or any other in-flight state -> resume.
     """
     if ctx.saga_file.exists():
@@ -220,8 +281,11 @@ def load_or_init_saga(ctx: SagaContext, seed_path: Path) -> dict:
             )
             sys.exit(0)
         if status == "ESCALATED":
+            # Non-zero for the same reason main's return is (M4): the artifact
+            # never passed review, so a caller chaining on success must not
+            # proceed just because this invocation had nothing left to do.
             print(f"saga ESCALATED for {ctx.artifact_id}; human review required")
-            sys.exit(0)
+            sys.exit(EXIT_ESCALATED)
         return saga
 
     ctx.saga_dir.mkdir(parents=True, exist_ok=True)
@@ -297,15 +361,51 @@ def can_transition(*, current: str, target: str) -> bool:
 
 
 def append_transition(
-    saga: dict, *, from_state: str | None, to_state: str, scope: str = "run"
+    saga: dict, *, from_state: str | None, to_state: str, scope: str = "run", forced: bool = False
 ) -> None:
     """Append a transition. Raises ValueError on invalid transitions
-    (preemptive enforcement)."""
-    if from_state is not None and not can_transition(current=from_state, target=to_state):
+    (preemptive enforcement).
+
+    `forced=True` records an edge the transition table does not allow instead
+    of raising, stamping it `forced: true` so a journal reader can tell a
+    reconciled edge from a legal one. It exists for the recovery paths that
+    must reach `PARTIAL_TIMEOUT` from *any* non-terminal state — three of
+    which (`BRANCH_FAILED`, `BRANCH_COMPENSATING`, `SYNTHESIZED`) cannot reach
+    it legally, so an unforced call there raises and wedges the saga
+    permanently (PLUGIN-PREPROD-001 B3a). Use it only where the alternative is
+    an uncaught raise; `can_transition` itself stays strict.
+
+    **A forced edge may only target `PARTIAL_TIMEOUT`.** Forcing toward a
+    failure terminal is safe in the worst case — it fails a run that might
+    have passed. Forcing toward `CLOSED` (or along the chain that reaches it)
+    inverts that: it would report success for a saga the transition table says
+    could not have got there, which is precisely the "reports PASS on reviews
+    that never ran" defect this driver's fixes exist to remove. Anything
+    wanting a forced success has a journal inconsistency to surface, not to
+    paper over.
+    """
+    if forced and to_state != "PARTIAL_TIMEOUT":
         raise ValueError(
-            f"Invalid transition: {from_state} -> {to_state} "
-            f"(allowed: {sorted(_ALLOWED_TRANSITIONS.get(from_state, set()))})"
+            f"forced transitions may only target PARTIAL_TIMEOUT, not {to_state}: "
+            "forcing toward a success state would report a pass the state "
+            "machine says was unreachable"
         )
+    if from_state is not None and not can_transition(current=from_state, target=to_state):
+        if not forced:
+            raise ValueError(
+                f"Invalid transition: {from_state} -> {to_state} "
+                f"(allowed: {sorted(_ALLOWED_TRANSITIONS.get(from_state, set()))})"
+            )
+        entry = {
+            "ts": _utc_now_iso(),
+            "from": from_state,
+            "to": to_state,
+            "scope": scope,
+            "forced": True,
+        }
+        saga["transitions"].append(entry)
+        saga["updated_at"] = _utc_now_iso()
+        return
     saga["transitions"].append(
         {
             "ts": _utc_now_iso(),
@@ -348,8 +448,7 @@ def check_break_circuit(ctx: SagaContext, saga: dict) -> bool:
     PARTIAL_TIMEOUT and caller should exit."""
     elapsed = time.time() - ctx.start_epoch
     if elapsed > SOFT_DEADLINE_SECONDS:
-        append_transition(saga, from_state=saga["status"], to_state="PARTIAL_TIMEOUT", scope="run")
-        saga["status"] = "PARTIAL_TIMEOUT"
+        _force_partial_timeout(saga)
         write_saga(ctx, saga)
         print(
             f"break-circuit fired at {elapsed:.0f}s elapsed; "
@@ -363,14 +462,81 @@ def resume_from_partial_timeout(saga: dict) -> None:
     """Per Phase 2 Pass 4 G-R1: walk transitions[] backward to find the
     pre-PARTIAL_TIMEOUT state. Set saga.status to that state so the loop
     continues from there. Do NOT append a transition with from: PARTIAL_TIMEOUT.
+
+    Only **run-scoped** transitions are candidates: `transitions[]` interleaves
+    run-scope and `branch:<lens>`-scope entries, so an unscoped walk can adopt
+    a branch terminal (e.g. `BRANCH_FAILED` for one lens) as the whole run's
+    status (PLUGIN-PREPROD-001 B3c).
+
+    The `"run"` default is load-bearing, not stylistic. Scope-less entries are
+    real — the audit SKILL's LLM writes transitions straight into `saga.json`,
+    and `reconcile_post_audit` already reads `scope` defensively for that
+    reason. Under a bare `t.get("scope") == "run"` any such journal would find
+    no candidate and restart the saga at `PREPARED`.
     """
     if saga["status"] != "PARTIAL_TIMEOUT":
         return
     for t in reversed(saga["transitions"]):
-        if t["to"] != "PARTIAL_TIMEOUT":
+        if t.get("scope", "run") == "run" and t["to"] != "PARTIAL_TIMEOUT":
             saga["status"] = t["to"]
             return
     saga["status"] = "PREPARED"
+
+
+def _timeout_wrapper() -> list[str]:
+    """Return the argv prefix that bounds a phase subprocess, if one exists.
+
+    `timeout` is GNU coreutils: present on Linux, absent from a stock macOS,
+    where Homebrew's coreutils installs it as `gtimeout`. Probe rather than
+    assume — an unconditional `timeout` prefix makes every dispatch fail with
+    a spawn error on macOS. Callers fall back to `subprocess.run(timeout=…)`
+    when this returns empty (PLUGIN-PREPROD-001 M3).
+    """
+    for name in ("timeout", "gtimeout"):
+        found = shutil.which(name)
+        if found:
+            return [found, str(SUBPROCESS_TIMEOUT_SECONDS)]
+    return []
+
+
+def _reload_saga_in_place(ctx: SagaContext, saga: dict) -> bool:
+    """Refresh `saga` from disk, preserving the caller's dict identity.
+
+    The dispatched subprocess writes its own per-branch transitions and status
+    directly to `saga.json`. Mutating in place (rather than rebinding) means
+    every holder of the dict — including the caller that passed it in — sees
+    the child's work instead of a stale pre-dispatch snapshot.
+
+    Returns False when the journal is unreadable, having first copied it aside
+    as `saga.corrupt.json`. Swallowing that case silently would be the B3b
+    clobber all over again: the caller would go on to write its stale
+    pre-dispatch snapshot over the child's work *and* over the evidence of why
+    the child failed, and nothing downstream could tell. The caller must treat
+    False as a failed phase.
+    """
+    if not ctx.saga_file.exists():
+        return True
+    try:
+        on_disk = json.loads(ctx.saga_file.read_text())
+        if not isinstance(on_disk, dict):
+            raise ValueError(f"saga.json is not a JSON object: {ctx.saga_file}")
+    except (OSError, ValueError) as exc:
+        quarantine = ctx.saga_file.with_name("saga.corrupt.json")
+        try:
+            shutil.copy2(ctx.saga_file, quarantine)
+            preserved = f" preserved at {quarantine}"
+        except OSError:
+            preserved = " (could not be preserved)"
+        print(
+            f"saga.json is unreadable after the subprocess returned ({exc}); "
+            f"the subprocess's work cannot be recovered and must not be "
+            f"overwritten. Corrupt file{preserved}.",
+            file=sys.stderr,
+        )
+        return False
+    saga.clear()
+    saga.update(on_disk)
+    return True
 
 
 def dispatch_phase(ctx: SagaContext, phase: str, brief: str, saga: dict | None = None) -> int:
@@ -382,6 +548,12 @@ def dispatch_phase(ctx: SagaContext, phase: str, brief: str, saga: dict | None =
     events to saga.events[] for orchestration observability (SPEC-RT-001
     2026-06-09 gap — fixer dispatch + completion previously left no
     journal trace).
+
+    The completion event is appended to the saga **as the subprocess left it on
+    disk**, not to the pre-dispatch in-memory copy. Writing the stale copy back
+    clobbered every transition, branch update and status change the child made
+    (PLUGIN-PREPROD-001 B3b) — the caller's later reload then read the driver's
+    own overwrite and could not tell.
     """
     slash = {
         "draft": f"/aidoc-flow:doc-{ctx.layer_type.lower()}",
@@ -389,44 +561,138 @@ def dispatch_phase(ctx: SagaContext, phase: str, brief: str, saga: dict | None =
         "fixer": f"/aidoc-flow:doc-{ctx.layer_type.lower()}-fixer",
         "re-review": f"/aidoc-flow:doc-{ctx.layer_type.lower()}-audit",
     }[phase]
-    cmd = [
-        "timeout",
-        str(SUBPROCESS_TIMEOUT_SECONDS),
+    claude_argv = [
         "claude",
         "--plugin-dir",
         str(ctx.plugin_dir),
-        "--dangerously-skip-permissions",
-        "-p",
-        f"{slash} {brief}",
     ]
+    if ctx.allow_skip_permissions:
+        claude_argv.append("--dangerously-skip-permissions")
+    claude_argv += ["-p", f"{slash} {brief}"]
+
+    wrapper = _timeout_wrapper()
+    cmd = wrapper + claude_argv
+    run_kwargs: dict = {"capture_output": False, "check": False}
+    if not wrapper:
+        run_kwargs["timeout"] = SUBPROCESS_TIMEOUT_SECONDS
+
     print(f"dispatch: {phase} ({slash}) ...")
     if saga is not None:
         append_event(saga, f"dispatch:{phase}", iteration=saga.get("iteration"), slash=slash)
         write_saga(ctx, saga)
-    result = subprocess.run(cmd, capture_output=False, check=False)
+
+    error: str | None = None
+    try:
+        returncode = subprocess.run(cmd, **run_kwargs).returncode
+    except subprocess.TimeoutExpired:
+        # Match GNU `timeout`'s exit code so both wrapper paths report a
+        # deadline the same way to every caller.
+        returncode = 124
+        error = f"phase {phase} exceeded {SUBPROCESS_TIMEOUT_SECONDS}s"
+    except (FileNotFoundError, PermissionError) as exc:
+        # The dispatch event is already journalled. Returning without a
+        # completion event would leave a journal claiming work that never
+        # started, so record the failed spawn explicitly.
+        #
+        # Name `claude` rather than cmd[0]: when a wrapper is in use, cmd[0]
+        # is the resolved timeout path that `shutil.which` just proved exists,
+        # so blaming it points at the one binary that is definitely present.
+        returncode = EXIT_SPAWN_FAILED
+        error = f"could not spawn {claude_argv[0]!r}: {exc}"
+        print(f"dispatch failed: {error}", file=sys.stderr)
+
     if saga is not None:
+        if not _reload_saga_in_place(ctx, saga) and returncode == 0:
+            # An unreadable journal is a failed phase even when the child
+            # exited 0 — main must not advance the state machine on it.
+            returncode = 1
+            error = "saga.json unreadable after the subprocess returned"
+        extra = {"error": error} if error else {}
         append_event(
             saga,
             f"complete:{phase}",
             iteration=saga.get("iteration"),
-            exit_code=result.returncode,
+            exit_code=returncode,
+            **extra,
         )
         write_saga(ctx, saga)
-    return result.returncode
+    return returncode
 
 
-def read_verdict_score(ctx: SagaContext) -> tuple[int, str]:
+def read_verdict_score(ctx: SagaContext) -> tuple[int | float | None | object, str]:
     """Read .aidoc/review/<layer>/<id>/verdict.json. Returns (score, status).
 
-    Returns (0, "MISSING") if verdict.json absent - caller treats this as
+    Returns (None, "MISSING") if verdict.json absent - caller treats this as
     an AUDIT FAILURE (per Pass-4 A9), distinct from a low content score
     (FAIL with score). Driver escalates rather than dispatching fixer.
+
+    Three score outcomes, and conflating any two of them breaks the
+    `--threshold` gate in one direction or the other:
+
+    * a number (`int` or `float`) — gate on it.
+    * `None`, when the verdict reports **no** `content_score`. Some layers
+      have no numeric readiness score *by design*: CHG says so in its own
+      `content_score_note` and gates on `combined_status` plus
+      `blocking_findings_count`. Coercing that absence to 0 would fail every
+      threshold and drive such a layer to the iteration cap.
+    * `SCORE_UNUSABLE`, when the key **is** present but cannot be read as a
+      number. `verdict.json` is written by an LLM-driven audit skill, so
+      `92.5` and `"88"` are ordinary — but `true`, `null` or `"n/a"` are not
+      scores. Treating those as "no score supplied" would silently disable
+      the gate, which is the most likely way this gate fails in practice.
     """
     verdict_path = ctx.saga_dir / "verdict.json"
     if not verdict_path.exists():
-        return 0, "MISSING"
+        return None, "MISSING"
     v = json.loads(verdict_path.read_text())
-    return v.get("content_score", 0), v.get("combined_status", "UNKNOWN")
+    if not isinstance(v, dict):
+        raise ValueError(f"verdict.json is not a JSON object: {verdict_path}")
+    if "content_score" not in v or v["content_score"] is None:
+        return None, v.get("combined_status", "UNKNOWN")
+    raw = v["content_score"]
+    score: int | float | object
+    if isinstance(raw, bool):
+        score = SCORE_UNUSABLE
+    elif isinstance(raw, (int, float)):
+        score = raw
+    elif isinstance(raw, str):
+        try:
+            score = float(raw)
+        except ValueError:
+            score = SCORE_UNUSABLE
+        else:
+            print(
+                f"verdict content_score was the string {raw!r}; read as {score}",
+                file=sys.stderr,
+            )
+    else:
+        score = SCORE_UNUSABLE
+    if score is SCORE_UNUSABLE:
+        print(
+            f"verdict content_score is present but unusable ({raw!r}); "
+            f"treating the run as not converged",
+            file=sys.stderr,
+        )
+    return score, v.get("combined_status", "UNKNOWN")
+
+
+def _invalidate_verdict(ctx: SagaContext, iteration: int) -> None:
+    """Move verdict.json aside so a stale PASS cannot be read as current.
+
+    The audit subprocess is not guaranteed to rewrite it — a crashed or
+    non-team-mode audit leaves the previous iteration's file in place, which
+    `read_verdict_score` would then read as the current verdict
+    (PLUGIN-PREPROD-001 M5).
+
+    Rotated rather than deleted. The file holds the `blocking_findings` that
+    motivated this fixer pass, and the runs that most need it are exactly the
+    ones where the next audit never writes a replacement: a human arriving at
+    the resulting PARTIAL_TIMEOUT would otherwise find an empty review
+    directory — neither the failing verdict nor a new one.
+    """
+    verdict = ctx.saga_dir / "verdict.json"
+    if verdict.exists():
+        verdict.replace(ctx.saga_dir / f"verdict.iter{iteration}.json")
 
 
 def validate_and_repair_branches(ctx: SagaContext, saga: dict) -> None:
@@ -545,6 +811,21 @@ def reconcile_post_audit(ctx: SagaContext, saga: dict) -> None:
     saga["updated_at"] = _utc_now_iso()
 
 
+def _meets_threshold(ctx: SagaContext, score: int | float | None | object) -> bool:
+    """Whether a PASS verdict clears the caller's `--threshold` gate.
+
+    `None` (no score reported) is **not** gated — see `read_verdict_score` for
+    why CHG depends on that. `SCORE_UNUSABLE` (a score reported but
+    unreadable) **fails** the gate: an unreadable score is a broken audit, and
+    failing closed is the only safe reading of one.
+    """
+    if score is None:
+        return True
+    if score is SCORE_UNUSABLE:
+        return False
+    return score >= ctx.threshold
+
+
 def _advance_after_phase(ctx: SagaContext, saga: dict, phase: str) -> None:
     """Apply the state-machine transition for a completed phase + decide
     next phase based on verdict.json (for review/re-review phases)."""
@@ -565,10 +846,16 @@ def _advance_after_phase(ctx: SagaContext, saga: dict, phase: str) -> None:
             # not fan out / write verdict.json — e.g., legacy single-pass
             # audit subprocess that hasn't been team-mode-wired yet). From
             # FANOUT_STARTED, ESCALATED is illegal; PARTIAL_TIMEOUT is the
-            # universally-reachable non-CLOSED terminal. Use PARTIAL_TIMEOUT
-            # so the harness B2 assertion reports FAIL with the right
-            # semantics ("resumable; needs human review / team-mode wiring
-            # for this layer") instead of the driver crashing.
+            # non-CLOSED terminal that carries the right semantics
+            # ("resumable; needs human review / team-mode wiring for this
+            # layer") for the harness B2 assertion.
+            #
+            # PARTIAL_TIMEOUT is NOT reachable from every non-terminal state —
+            # BRANCH_FAILED, BRANCH_COMPENSATING and SYNTHESIZED cannot reach
+            # it, and this branch runs after reconcile_post_audit, which can
+            # leave the saga in any of them. Hence forced=True: without it the
+            # recovery path itself raises and wedges the saga permanently
+            # (PLUGIN-PREPROD-001 B3a).
             saga["compensation_actions"].append(
                 {
                     "ts": _utc_now_iso(),
@@ -581,8 +868,26 @@ def _advance_after_phase(ctx: SagaContext, saga: dict, phase: str) -> None:
                     "action": "partial_timeout",
                 }
             )
-            append_transition(saga, from_state=saga["status"], to_state="PARTIAL_TIMEOUT")
-            saga["status"] = "PARTIAL_TIMEOUT"
+            _force_partial_timeout(saga)
+            return
+
+        if status == "PASS" and not _meets_threshold(ctx, score):
+            # L2: --threshold was accepted and ignored. A PASS whose reported
+            # content_score is below the caller's gate is not a pass; fall
+            # through to the fixer/cap branch below.
+            print(
+                f"verdict PASS but content_score {score} < threshold "
+                f"{ctx.threshold}; treating as not converged"
+            )
+            status = "FAIL"
+
+        if status != "PASS" and saga["status"] in {"CLOSED"} | _FAILURE_TERMINALS:
+            # The audit subprocess left the saga terminal, but the verdict
+            # says this run did not converge. Without this, the fixer branch
+            # below would set current_phase on a CLOSED saga, main's loop
+            # guard would see a terminal status, and the run would exit 0 —
+            # the gate firing and the run reporting success in one breath.
+            _force_partial_timeout(saga)
             return
 
         if status == "PASS":
@@ -593,8 +898,36 @@ def _advance_after_phase(ctx: SagaContext, saga: dict, phase: str) -> None:
             # along the chain. Append only the transitions still needed
             # to reach CLOSED — appending a no-op (e.g. FANIN_REDUCED ->
             # FANIN_REDUCED) would raise ValueError.
+            #
+            # The entry state is whatever the audit subprocess left on disk
+            # (B3b stopped the driver clobbering it), so it need not be one
+            # from which FANIN_REDUCED is legal. That inconsistency is NOT
+            # absorbed: a PASS arriving on a journal that records no completed
+            # fan-in is evidence the audit is broken, not evidence the
+            # document is good. Forcing the edge here would walk the saga to
+            # CLOSED and exit 0 — e.g. an audit that wrote `status: ESCALATED`
+            # and a PASS verdict would have its escalation silently rewritten
+            # as success. Surface it as unconverged instead.
             terminal_chain = ("FANIN_REDUCED", "SYNTHESIZED", "CLOSED")
             if saga["status"] not in terminal_chain:
+                if not can_transition(current=saga["status"], target="FANIN_REDUCED"):
+                    print(
+                        f"verdict PASS but saga is at {saga['status']}, from which "
+                        f"FANIN_REDUCED is unreachable — the audit reported a pass on a "
+                        f"journal recording no completed fan-in. Treating as not "
+                        f"converged; inspect {ctx.saga_file}.",
+                        file=sys.stderr,
+                    )
+                    saga["compensation_actions"].append(
+                        {
+                            "ts": _utc_now_iso(),
+                            "branch": "*",
+                            "reason": (f"PASS verdict from non-fan-in state {saga['status']}"),
+                            "action": "partial_timeout",
+                        }
+                    )
+                    _force_partial_timeout(saga)
+                    return
                 append_transition(saga, from_state=saga["status"], to_state="FANIN_REDUCED")
                 saga["status"] = "FANIN_REDUCED"
             if saga["status"] == "FANIN_REDUCED":
@@ -613,17 +946,19 @@ def _advance_after_phase(ctx: SagaContext, saga: dict, phase: str) -> None:
                 # BRANCH_FAILED or BRANCH_COMPENSATING. At max iterations
                 # we're typically at BRANCH_COMPLETED or FANIN_REDUCED
                 # (audit completed but verdict FAIL), neither of which
-                # allows direct -> ESCALATED. Use PARTIAL_TIMEOUT
-                # (universally reachable from non-terminal states) as
-                # the non-CLOSED terminal. Harness treats both as FAIL.
-                append_transition(saga, from_state=saga["status"], to_state="PARTIAL_TIMEOUT")
-                saga["status"] = "PARTIAL_TIMEOUT"
+                # allows direct -> ESCALATED. Use PARTIAL_TIMEOUT as the
+                # non-CLOSED terminal. Harness treats both as FAIL.
+                # Forced for the same reason as the MISSING branch above:
+                # PARTIAL_TIMEOUT is not reachable from every non-terminal
+                # state, and BRANCH_FAILED is a live entry state here
+                # (PLUGIN-PREPROD-001 B3a).
+                _force_partial_timeout(saga)
     elif phase == "fixer":
         saga["iteration"] += 1
         saga["current_phase"] = "re-review"
 
 
-def main(argv: list[str] | None = None) -> int:
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Saga driver for plugin autopilot")
     parser.add_argument("--layer", required=True, help="e.g. 01_BRD")
     parser.add_argument(
@@ -641,11 +976,35 @@ def main(argv: list[str] | None = None) -> int:
         default=os.environ.get("PREV_OUTPUT"),
         help="upstream seed; falls back to $PREV_OUTPUT",
     )
-    parser.add_argument("--threshold", type=int, default=90)
+    parser.add_argument(
+        "--threshold",
+        type=int,
+        default=90,
+        help=(
+            "minimum content_score a PASS verdict must report to close the "
+            "saga; verdicts that report no score are not gated"
+        ),
+    )
     parser.add_argument(
         "--plugin-dir",
         default=os.environ.get("CLAUDE_PLUGIN_ROOT", os.environ.get("PLUGIN_DIR", "")),
     )
+    parser.add_argument(
+        "--allow-skip-permissions",
+        action="store_true",
+        help=(
+            "run each dispatched phase subprocess with "
+            "--dangerously-skip-permissions, so it can write files without "
+            "prompting. Required for unattended autopilot runs; off by default "
+            "because it disables Claude Code's permission prompts for every "
+            "subprocess this driver spawns."
+        ),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
     args = parser.parse_args(argv)
 
     for name in ("artifact_id", "artifact_path", "seed"):
@@ -668,6 +1027,7 @@ def main(argv: list[str] | None = None) -> int:
         saga_file=saga_dir / "saga.json",
         threshold=args.threshold,
         plugin_dir=Path(args.plugin_dir),
+        allow_skip_permissions=args.allow_skip_permissions,
     )
 
     saga = load_or_init_saga(ctx, Path(args.seed))
@@ -676,9 +1036,11 @@ def main(argv: list[str] | None = None) -> int:
 
     while saga["status"] not in {"CLOSED", "ESCALATED", "PARTIAL_TIMEOUT"}:
         if check_break_circuit(ctx, saga):
-            return 0
+            return _exit_code_for_status(saga["status"])
 
         phase = saga["current_phase"]
+        if phase in ("review", "re-review"):
+            _invalidate_verdict(ctx, saga["iteration"])
         brief = (
             f"Artifact {args.artifact_id} at {args.artifact_path}; "
             f"seed at {args.seed}; saga at {ctx.saga_file}; "
@@ -704,23 +1066,43 @@ def main(argv: list[str] | None = None) -> int:
             # failure (claude API limit, network, timeout, etc.) the
             # saga is usually at PREPARED / FANOUT_STARTED / BRANCH_RUNNING
             # / BRANCH_COMPLETED, none of which allow direct -> ESCALATED.
-            # PARTIAL_TIMEOUT is universally reachable from non-terminal
-            # states and connotes "non-CLOSED terminal, resumable on
+            # PARTIAL_TIMEOUT connotes "non-CLOSED terminal, resumable on
             # next invocation" — the right semantics for a transient
             # external failure. Harness treats both ESCALATED and
-            # PARTIAL_TIMEOUT as FAIL.
+            # PARTIAL_TIMEOUT as FAIL. forced=True because the reloaded
+            # status is whatever the subprocess left behind, which may be
+            # one of the three states PARTIAL_TIMEOUT is not reachable
+            # from (PLUGIN-PREPROD-001 B3a).
+            reason = f"phase {phase} subprocess exit {rc}"
+            if rc == EXIT_SPAWN_FAILED:
+                reason = f"phase {phase} subprocess could not be spawned"
+            elif rc == 124 and not ctx.allow_skip_permissions:
+                # A phase that ran to the full deadline with the permission
+                # bypass off is far more likely to have been sitting on an
+                # unanswerable prompt than to have been slow.
+                reason += " (permission prompts are on; --allow-skip-permissions was not passed)"
             saga["compensation_actions"].append(
                 {
                     "ts": _utc_now_iso(),
                     "branch": "*",
-                    "reason": f"phase {phase} subprocess exit {rc}",
+                    "reason": reason,
                     "action": "partial_timeout",
                 }
             )
-            append_transition(
-                saga, from_state=saga["status"], to_state="PARTIAL_TIMEOUT", scope="run"
-            )
-            saga["status"] = "PARTIAL_TIMEOUT"
+            _force_partial_timeout(saga)
+
+            if rc == EXIT_SPAWN_FAILED:
+                # An environment defect, not a resumable deadline. Reporting
+                # it through EXIT_PARTIAL_TIMEOUT would tell the operator the
+                # run can simply be retried, and every retry would fail
+                # identically.
+                print(
+                    f"phase {phase} could not be spawned — this is an environment "
+                    f"defect, not a resumable timeout. Verify `claude` is on PATH.",
+                    file=sys.stderr,
+                )
+                write_saga(ctx, saga)
+                return EXIT_SPAWN_FAILED
 
         write_saga(ctx, saga)
 
@@ -729,7 +1111,7 @@ def main(argv: list[str] | None = None) -> int:
         f"(iteration {saga['iteration']}, "
         f"{len(saga['transitions'])} transitions)"
     )
-    return 0
+    return _exit_code_for_status(saga["status"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**PLUGIN-PREPROD-001 PR 3 of 5.** Closes B2, B3a–c, M3, M4, M5, L2 and L3 of the 2026-07-31 pre-production review. No version bump on any stream; the plugin's `0.24.0 → 0.25.0` cut is PR 5.

Plan: `plans/PLUGIN-PREPROD-001-PLAN.md` § "PR 3 — saga driver correctness and disclosure".

## What changed

| Finding | Fix |
| --- | --- |
| **B2** | The `--dangerously-skip-permissions` bypass is opt-in behind `--allow-skip-permissions`, off by default. The 9 autopilot skills and the acceptance harness **pass** it, so the bypass is visible where it is requested. No `SKILL.md` contains the literal, so the release gate stands unamended. |
| **B3a** | All four `PARTIAL_TIMEOUT` sites use a forced transition instead of raising and wedging the saga. A forced edge may only ever target `PARTIAL_TIMEOUT`. |
| **B3b** | `dispatch_phase` no longer overwrites what the phase subprocess wrote to `saga.json`. An unreadable journal is a failed phase, quarantined to `saga.corrupt.json`. |
| **B3c** | The resume walk is run-scoped, defaulting a missing `scope` to `"run"`. |
| **M3** | `timeout` → `gtimeout` → Python-level timeout, probed not assumed; a failed spawn is journalled. |
| **M4** | Exit **4** `PARTIAL_TIMEOUT`, **5** `ESCALATED`, **127** unspawnable, **0** only for `CLOSED` — never 2 or 124. |
| **M5** | `verdict.json` is rotated to `verdict.iterN.json` before each audit. |
| **L2** | `--threshold` gates a `PASS` reporting a `content_score`, reading `int`, `float` and numeric strings. |
| **L3** | `playbook_loader` confines reads to `framework/playbooks/`, symlinks included. |

Plus the byte-identity guard on the three vendored `tools/` modules, which had none — the vendored copy is what ships.

## Two design calls worth flagging

**L2 is narrower than the plan assumed, on measurement.** Gating unconditionally would have regressed CHG: its verdict carries no `content_score` **by design** and says so in its own `content_score_note`, so `v.get("content_score", 0)` → 0 would fail every threshold and drive that layer to the iteration cap. Three outcomes are kept distinct — a number is gated, *absent* is ungated, *present but unreadable* fails closed.

**Forced transitions are directional.** Forcing toward a failure terminal is safe in the worst case; forcing toward `CLOSED` reports a pass the transition table says was unreachable. `append_transition` now enforces that.

## Verification

- conformance **299 → 357**, acceptance/deterministic 64, `sdd_doc_lint` 5, unit 184, smoke skipped (live-gated)
- two consecutive clean `pre-commit run --all-files`; mirrors byte-identical
- tests written **failing first**, then mutation-checked: **34 mutants, each backing out exactly one fix, all 34 detected**
- `tests/release` is red **only** on the pre-existing `TBD` false positive at `CHANGELOG.md:1233` (a historical entry describing a past fix), tracked as `RELEASE-GATE-TBD-FALSE-POSITIVE` and verified identical on `main`

## Review

Three agents dispatched pre-push per OPS-0065. They found **two blockers, both mine**, each reproduced before fixing:

1. My `forced=` on the PASS chain took a saga the child left at `ESCALATED`, forced it to `FANIN_REDUCED`, walked it to `CLOSED` and exited **0** — an escalation silently rewritten as success. My own test asserted that behaviour, so the correct fix would have read as a regression.
2. My `isinstance(score, int)` filter mapped every `float`, numeric string and `null` to "no score reported", taking the ungated path. `content_score: 88.5` defeated the gate I had just added.

Also folded: the corrupt-journal path re-introduced the B3b clobber and destroyed the evidence; `EXIT_SPAWN_FAILED` never reached the process exit; the README understated the blast radius (verified: **0 of 52 skills declare `allowed-tools`**, so subprocesses hold the full tool set including `Bash` and `WebFetch`).

Two mutants initially survived. Both were **weak tests, not weak fixes** — `content_score: true` compares as 1 and fails a threshold of 90 for the wrong reason; a resolved-vs-unresolved return path is indistinguishable without a symlink. Both now assert the classification rather than the outcome.

## Deliberately not fixed here

Captured in `plans/FRAMEWORK-TODO.md`:

- `SAGA-ALL-BRANCHES-FAILED-CLOSES` — **pre-existing**: `reconcile_post_audit` counts `BRANCH_FAILED` as terminal-and-fine, so a run whose crew all failed walks to `BRANCH_COMPLETED` *legally* and a `PASS` closes it. No edge is forced, so this PR's guard does not catch it. Needs a quorum decision.
- `SAGA-DRAFT-HARDCODED-FROM-STATE` — the draft branch journals `from_state="PREPARED"` unconditionally.
- `PREPROD-B2-GATE-SCOPE` — the release gate matches a literal string and skips `commands/` + `agents/`. The plan forbids amending that gate, and PR 5 cuts the release off it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
