### PR TITLE
fix(release): scope the changelog placeholder gate to the entry being published

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,73 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — the release changelog gate stopped failing on its own history (2026-08-02)
+
+**PLUGIN-PREPROD-001 PR 5 of 5.** PR 5's eight documents of record exceed the
+≤3-surface governance cap, so it lands as a short sequence of PRs; this is the
+first, and carries no version bump on any stream. The plugin's
+`0.24.0 → 0.25.0` cut follows. Closes `RELEASE-GATE-TBD-FALSE-POSITIVE`.
+
+- **`tests/release/test_changelog_entry.py` had been permanently red for 25
+  days.** Its placeholder check asserted the literal `TBD` was absent from the
+  whole of `CHANGELOG.md`. The check landed in `982b06cb` (2026-05-31) and
+  passed until `e73a8c91` (2026-07-08) added a quoted historical commit message
+  recording a past review that fixed such a placeholder. That text is correct
+  and, this file being append-only, must not be edited — so from that commit on
+  the gate could not pass. A placeholder check that scans an append-only record
+  accrues strictly more false positives over time.
+- **Two things were wrong, and fixing only the scope re-broke the gate
+  immediately.** The first draft narrowed *what* is scanned and left the matcher
+  a bare substring test — so this very entry, which has to name the tokens it
+  describes, failed the gate it was documenting. The matcher now ignores
+  occurrences inside backticks or fenced blocks, which is markdown's own way of
+  marking a mention rather than a use, and treats everything else as a
+  placeholder. The word boundary is alphanumeric-only on purpose: punctuation
+  and hyphens do not exempt a token, so a dated heading left unfilled as
+  `2026-08-TBD` still fails — the likeliest such placeholder in a changelog, and
+  the shape the next release heading takes — as do `_TBD_` and `**TBD**`. That leaves
+  exactly one way to name a token without tripping the gate, and the assertion
+  message says so.
+- **The scan is scoped to the entry being published.** A `newest_entry` helper
+  returns the first level-2 section that has a body, truncated at its second
+  level-3 heading, with headings located in the code-stripped text so a `##`
+  inside a fenced example cannot truncate the entry early. Scoping to
+  `## [Unreleased]` — the shape the backlog entry proposed — would not have
+  worked: this repo keeps every unreleased entry under that one heading, roughly
+  2,700 lines of them, so the quoted text is *inside* it. Nor would excluding
+  blockquotes; the line carries no `>` prefix. An emptied section is skipped
+  rather than returned, because a release cut promotes the entry to its own
+  level-2 heading and leaves `## [Unreleased]` bare — the shape
+  `platforms/claude-code-plugin/CHANGELOG.md` takes at its cuts — and returning
+  it would scan nothing and pass vacuously.
+- **Accepted limitations, recorded rather than hidden.** Only the newest entry
+  is scanned, so a single PR adding *two* level-3 entries has only the first
+  checked; that matches this repo's one-entry-per-PR convention but nothing
+  enforces it. And in the window after a cut empties `## [Unreleased]` and
+  before the next entry is written, the newest body-bearing section is a
+  released one. The gate covers the entry being published, not the changelog.
+- **41 new cases, and every mutation in two author sets killed against a
+  baseline asserted green first.** Two earlier mutation runs in this session
+  reported a perfect score and both were worthless — the first because the
+  harness never imported the module, the second because the baseline itself was
+  red — so every mutant "died" of the harness, not the tests. An independent
+  review then ran a wider set and found further survivors; the six consequential
+  ones are now covered too (whitespace-only section bodies, the leading word
+  boundary, case sensitivity, slicing from stripped rather than original text,
+  the body-detection offset, and the fence-indent allowance). The surviving-mutant list that survived
+  a *valid* run drove real changes: the vocabulary assertion no longer iterates
+  the tuple it claims to pin, `strip_code` is a line scanner rather than a
+  regex (a non-greedy fence pattern pairs an unterminated fence with the next
+  one and blanks the prose between them, hiding placeholders), and headings are
+  found in stripped text. `test_changelog_has_entry_for_current_version` still
+  scans the whole file on purpose: it is a presence check, and the heading it
+  looks for may be a released section far below the newest entry.
+- **What this does not fix.** The tier is executed on every PR and every tag by
+  the *umbrella* repo, not by this one — so the red gate was invisible here
+  because the umbrella pins this repo at a submodule commit three weeks older
+  than the offending line, not because nothing runs it. Recorded as
+  `RELEASE-TIER-STALE-SUBMODULE-PIN` in `plans/FRAMEWORK-TODO.md`.
+
 ### Fixed — one agent no longer inherits every tool; the plugin ships its license (2026-08-01)
 
 **PLUGIN-PREPROD-001 PR 4 of 5.** No version bump on any stream; the plugin's

--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -391,19 +391,55 @@
   findings block remove the mechanism.
 - *Stage:* PR 1.
 
-### `[harness]` `RELEASE-GATE-TBD-FALSE-POSITIVE` — the release changelog gate is red on `main` and will block the PLUGIN-PREPROD release cut
+### `[harness]` `RELEASE-TIER-STALE-SUBMODULE-PIN` — the release tier runs on every umbrella PR, against a framework checkout seven weeks stale
 
-- *Context:* found 2026-07-31 running `tests/release/` for PLUGIN-PREPROD-001
-  PR 1. `tests/release/test_changelog_entry.py:45` asserts the literal `TBD` is
-  absent from the whole of `CHANGELOG.md`. It appears at `CHANGELOG.md:1192` —
-  inside a *quoted historical commit message* that records a past review fixing a
-  TBD placeholder. Confirmed pre-existing: red on `main` with this branch stashed.
-- *Why it matters:* the tier is run by no workflow and no hook, so nothing
-  surfaced it; PLUGIN-PREPROD-001 PR 5 cuts a release and is the first thing that
-  will hit it. A placeholder check that scans an append-only historical record
-  gets strictly more false positives over time.
-- *Fix shape:* scope the assertion to the `[Unreleased]` section, or to lines
-  that are not inside a quotation — not by deleting the historical text.
+- *Context:* found 2026-08-02 while closing `RELEASE-GATE-TBD-FALSE-POSITIVE`.
+  ⚠️ **The obvious diagnosis is wrong, and a first draft of this entry shipped
+  it.** The tier is *not* unrun. The umbrella executes it twice, unguarded:
+  `aidoc-flow/.github/workflows/pr-checks.yml:42`
+  (`cd framework && python3 -m unittest discover tests/release -v`) on every PR,
+  and `aidoc-flow/.github/workflows/release.yml:37` on `v*` tags. What it runs
+  is a **submodule pointer**: umbrella `origin/main` pins this repo at
+  `0ffa153c` (2026-06-15). The offending `TBD` line landed here in `e73a8c91`
+  (2026-07-08), three weeks *after* that pin — so the umbrella has been running
+  a green tier against a framework that predates the defect, while `main` here
+  was red. That, not an absent runner, is why nothing surfaced it.
+- *⚠️ Two claims a session will reach for here, both false.* (1) "`tests/release/`
+  is run by nothing" — true of *this* repo only; always check the umbrella
+  before writing an absence down. (2) "`test-plugin.sh` ends in `|| true`, so
+  even the manual path cannot fail" — the script sets `set -uo pipefail` with
+  **no** `-e` (`tests/scripts/test-plugin.sh:52`), and `run()` increments
+  `FAILED` *before* returning (`:114` declares it `-i`, so `+=1` at `:135` is
+  arithmetic; `run()` spans `:123-137`), which `:369-376` turns into `exit 1`.
+  The `|| true` discards an already-recorded status and suppresses nothing.
+  `CLAUDE.md:830-831` § "Durable traps → Local hooks and tooling" carries **two**
+  wrong claims in one sentence — this one about `:257`/`:302`, *and* "nothing
+  calls that script", refuted by umbrella `release.yml:32`. Correcting them
+  needs a governance PR; fix both, not the one that is easier to see.
+- *Why it matters:* the tier is the marketplace pre-publish gate — changelog
+  entry presence, no unfilled placeholders, bundle-size and skill-count caps,
+  a network-egress scan over the vendored linter, no
+  `--dangerously-skip-permissions` default in any `SKILL.md`, plugin manifest
+  present. Every one is a claim about what ships to consumers, and all of them
+  are currently being verified against a seven-week-old snapshot. (The egress
+  scan is narrower than its name — `tests/release/test_marketplace_gate.py:26`
+  walks only the vendored `sdd_doc_lint` tree and `continue`s if it is absent,
+  so do not cite the tier as a marketplace egress guarantee.) A green umbrella run is not evidence about this
+  repo's `main`.
+- *Fix shape:* the gap is *currency*, not existence. Either bump the umbrella's
+  submodule pointer as part of merging here, or run the tier from this repo at
+  the point a release is cut. Do **not** add it to this repo's conformance
+  workflow: it is release-only by design, and
+  `test_changelog_has_entry_for_current_version` would fail every PR that has
+  not yet written its version heading — the tier is release-only by design
+  (`tests/README.md:29`).
+- *Target:* `vladm3105/aidoc-flow` (the umbrella) if fixed by bumping the pointer;
+  this repo if fixed by running the tier at the cut. **Tier 🟡, not filed** — the
+  umbrella is outside the ten-repo OPS-0076 cross-repo carve-out (it holds no dev
+  and has no capture surface), so a human files it if the pointer half is chosen.
+  Queue-only here is the specified behaviour, not an omission.
+- *Stage:* not a PLUGIN-PREPROD-001 blocker — the `0.25.0` cut runs the tier by
+  hand. Genuinely open work after that.
 
 ### `[lint]` `LINT-TRACE-RES-SINGLE-FILE` — linting one file reports every cross-document trace tag as an ERROR → [#412](https://github.com/vladm3105/aidoc-flow-framework/issues/412)
 
@@ -1224,6 +1260,68 @@
 - *Status:* OPEN — P3.
 
 ## Closed
+
+### `[harness]` `RELEASE-GATE-TBD-FALSE-POSITIVE` — ✅ CLOSED (2026-08-02, PR #420) — the release changelog gate was red on `main` and would have blocked the PLUGIN-PREPROD release cut
+
+- *Context:* found 2026-07-31 running `tests/release/` for PLUGIN-PREPROD-001
+  PR 1. `test_no_placeholder_orphans` asserted the literal `TBD` was absent from
+  the whole of `CHANGELOG.md`. One appears — inside a *quoted historical commit
+  message* recording a past review that fixed such a placeholder. Confirmed
+  pre-existing: red on `main` with that branch stashed. **Not "could never
+  pass"**: the check landed in `982b06cb` (2026-05-31) and passed until
+  `e73a8c91` (2026-07-08) added the quoted line, then could not pass again.
+  PLUGIN-PREPROD-001 PR 5 cuts a release and was the first thing to hit it.
+- *Resolution:* **two defects, not one — and fixing only the scope re-broke the
+  gate on the spot.** (a) The *matcher* was a bare substring test, so any entry
+  describing this gate failed it; it now ignores tokens inside backticks or
+  fenced blocks, markdown's own mention-vs-use marker. (b) The *scope* is now
+  the entry being published: a `newest_entry` helper returns the first level-2
+  section that has a body, truncated at its second level-3 heading, with
+  headings located in code-stripped text so a `##` inside a fenced example
+  cannot truncate the entry and leave a placeholder below it unscanned.
+- *⚠️ The word boundary is alphanumeric-only, deliberately — do not "fix" it to
+  `\w` or `[\w-]`.* Either of those exempts `2026-08-TBD` in a dated heading,
+  which is the likeliest real unfilled placeholder in a changelog, and `_TBD_`
+  as well. The cost is that prose must **backtick** this entry's own ID; the
+  benefit is one rule with no exceptions.
+- *⚠️ Both fix shapes this entry originally proposed are wrong, and a future
+  session will reach for them again.* Scoping to `## [Unreleased]` does nothing:
+  this repo keeps every unreleased entry under that one heading — some 2,600
+  lines — so the quoted text is *inside* it. Excluding quotations does nothing
+  either: the line carries no `>` blockquote prefix, it is ordinary prose
+  recording a commit message. And **neither is sufficient alone** — the scope
+  fix alone turned the gate red against this very changelog entry, because an
+  entry documenting a placeholder check has to name the tokens it checks for.
+- *⚠️ An emptied `## [Unreleased]` is skipped, not returned.* A release cut
+  promotes the entry to its own level-2 heading and leaves `## [Unreleased]`
+  bare — the shape `platforms/claude-code-plugin/CHANGELOG.md` takes at every
+  cut. Returning that section would scan nothing and pass vacuously, which is
+  the failure mode this entry exists to prevent, one level up.
+- *Accepted limitation:* only the newest entry is scanned, so a PR adding **two**
+  level-3 entries has only the first checked. That matches the one-entry-per-PR
+  convention; nothing enforces it. **The gate covers the entry being published,
+  not the changelog** — do not cite it as changelog-wide coverage.
+- *Guard:* 44 cases in the module (41 added here); every mutation in two author
+  sets killed, plus the six consequential survivors an independent review found
+  in a wider set.
+  `test_changelog_has_entry_for_current_version` still scans the whole file by
+  design; it is a presence check, and the heading may be a released section far
+  below the newest entry.
+- *⚠️ Two mutation runs in this session scored 17/17 and 11/11 and both were
+  worthless.* The first harness copied the module to a scratch directory where
+  its `sys.path` sibling did not resolve, so every mutant died of
+  `ModuleNotFoundError`. The second ran while two of the new tests were failing,
+  so every mutant died of the red baseline. **A perfect first-try kill rate is
+  the symptom, not the result** — assert the unmutated baseline is green inside
+  the harness before trusting a single row. The valid run's survivors were all
+  real and all drove changes: a vocabulary assertion that iterated the tuple it
+  claimed to pin (so any truncation agreed with it), a non-greedy fence regex
+  that paired an *unterminated* fence with the next one and blanked the prose
+  between them, and the boundary class above.
+- *Not closed by this:* the tier is executed on every umbrella PR and tag, but
+  against a stale submodule pointer, which is why a red gate here was invisible.
+  Tracked as `RELEASE-TIER-STALE-SUBMODULE-PIN` under `## Open` — and read that
+  entry before asserting anything about what runs this tier.
 
 ### `[harness]` `IDHASH-GUARD-GLOB-NARROW` — ✅ CLOSED (2026-07-31, `371f6261` PR #406) — the guard was green partly because it did not look where a violation survived → [#385](https://github.com/vladm3105/aidoc-flow-framework/issues/385)
 

--- a/tests/release/test_changelog_entry.py
+++ b/tests/release/test_changelog_entry.py
@@ -11,6 +11,345 @@ from _spec import FRAMEWORK
 # CHANGELOG.md lives at the repo root, not inside framework/
 CHANGELOG = FRAMEWORK.parent / "CHANGELOG.md"
 
+PLACEHOLDER_TOKENS = ("TBD", "TODO:", "FILL IN")
+
+_HEADING = re.compile(r"^(#{2,3})\s")
+_FENCE_LINE = re.compile(r"^\s{0,3}(```|~~~)")
+_INLINE_CODE = re.compile(r"`+[^`\n]+`+")
+
+
+def strip_code(text: str) -> str:
+    """Blank out fenced blocks and inline code spans, preserving line count.
+
+    A token inside backticks is a *mention* of the literal, not an unfilled
+    placeholder. Markdown already draws that distinction; the gate honours it
+    rather than inventing an allow-marker.
+
+    Scanned line-by-line rather than by a multi-line regex, because a regex
+    pairs an *unterminated* fence with the next opening fence and blanks the
+    prose between them — over-stripping hides real placeholders, which is the
+    dangerous direction for a gate. A line scanner instead blanks an
+    unterminated fence to end-of-file, which is how markdown renders it.
+
+    Line count is preserved exactly — callers align indices against the
+    original, so ``split("\\n")`` is used rather than ``splitlines()``, which
+    would drop a trailing empty line and shift the tail.
+    """
+    out: list[str] = []
+    fence: str | None = None
+    for line in text.split("\n"):
+        marker = _FENCE_LINE.match(line)
+        if fence is None:
+            if marker:
+                fence = marker.group(1)
+                out.append("")
+            else:
+                out.append(_INLINE_CODE.sub(" ", line))
+            continue
+        if marker and marker.group(1) == fence:
+            fence = None
+        out.append("")
+    return "\n".join(out)
+
+
+def placeholders_in(text: str) -> list[str]:
+    """Return the placeholder tokens appearing in ``text`` as unfilled placeholders.
+
+    A token counts when it is outside any code span and not embedded in a
+    longer *word*. The boundary is alphanumeric-only on purpose: punctuation
+    and hyphens do **not** exempt a token, so ``2026-08-TBD`` in a dated
+    heading — the likeliest unfilled placeholder in a changelog — still fails,
+    as do ``_TBD_`` and ``**TBD**``.
+
+    That leaves exactly one way to name a token without tripping the gate:
+    put it in backticks. Prose citing this gate's own backlog ID must write
+    ``RELEASE-GATE-TBD-FALSE-POSITIVE`` in code formatting, which is the
+    correct markdown treatment for an identifier regardless.
+    """
+    body = strip_code(text)
+    found = []
+    for token in PLACEHOLDER_TOKENS:
+        # A token ending in punctuation (``TODO:``) needs no trailing boundary;
+        # requiring one would miss ``TODO:write this``.
+        trailing = r"(?![A-Za-z0-9])" if token[-1].isalnum() else ""
+        if re.search(rf"(?<![A-Za-z0-9]){re.escape(token)}{trailing}", body):
+            found.append(token)
+    return found
+
+
+def newest_entry(changelog: str) -> str:
+    """Return the slice of ``changelog`` a release is publishing *now*.
+
+    ``CHANGELOG.md`` is append-only: past entries are never rewritten, so a
+    placeholder token in one is *history*, not an orphan. The literal ``TBD``
+    at the time of writing sits inside a quoted historical commit message
+    recording a past review that fixed such a placeholder — text that is
+    correct and must not be edited.
+
+    Scoping to ``## [Unreleased]`` does not help: this repo keeps every
+    unreleased entry under that one heading (~2,700 lines of them), so the
+    quoted text is inside it. The boundary that works is the *entry*::
+
+        ## [Unreleased]                 <- start (first level-2 heading …
+                                        …  with a body; an emptied one is
+                                           skipped, see below)
+        ### Fixed — … (2026-08-02)      <- the entry being published
+        …body…
+        ### Fixed — … (2026-08-01)      <- stop (second level-3 heading)
+
+    Two shapes this has to survive, both of which occur in this workspace:
+
+    * **A release cut empties ``## [Unreleased]``** and promotes the entry to
+      its own level-2 section — ``platforms/claude-code-plugin/CHANGELOG.md``
+      does this at its cuts. A section with no body is therefore skipped
+      rather than returned, because returning it would scan nothing and pass
+      vacuously.
+    * **A section may carry no level-3 heading at all**, in which case the
+      whole section is the entry.
+
+    Headings are located in the *code-stripped* text so that a ``##`` line
+    inside a fenced example cannot truncate the entry early and leave a real
+    placeholder below it unscanned. Slicing then uses the original lines,
+    which is sound because ``strip_code`` preserves line count.
+
+    **Accepted limitations, stated rather than hidden.** Only the newest entry
+    is scanned, so a single PR adding *two* level-3 entries has only the first
+    checked; that matches this repo's one-entry-per-PR convention but nothing
+    enforces it. And in the window after a release cut empties
+    ``## [Unreleased]`` and before the next entry is written, the newest
+    body-bearing section is a *released* one — append-only text that cannot be
+    edited if it were ever to trip the gate.
+
+    Raises ``ValueError`` when no level-2 section with a body exists — a
+    placeholder gate that scanned nothing must fail, not silently pass.
+    """
+    lines = changelog.split("\n")
+    scanned = strip_code(changelog).split("\n")
+    headings = [(i, len(m[1])) for i, line in enumerate(scanned) if (m := _HEADING.match(line))]
+
+    for start in [i for i, level in headings if level == 2]:
+        section_end = next((i for i, level in headings if i > start and level == 2), len(lines))
+        entries = [i for i, level in headings if start < i < section_end and level == 3]
+        stop = entries[1] if len(entries) > 1 else section_end
+        block = lines[start:stop]
+        if any(line.strip() for line in block[1:]):
+            return "\n".join(block)
+
+    raise ValueError(
+        "CHANGELOG.md has no level-2 section with a body; cannot locate the newest entry"
+    )
+
+
+class StripCodeTests(unittest.TestCase):
+    def test_removes_inline_code_spans(self):
+        self.assertNotIn("TBD", strip_code("the literal `TBD` is checked"))
+
+    def test_removes_backtick_fenced_blocks(self):
+        self.assertNotIn("TBD", strip_code("before\n```\nTBD\n```\nafter"))
+
+    def test_removes_tilde_fenced_blocks(self):
+        self.assertNotIn("TBD", strip_code("before\n~~~\nTBD\n~~~\nafter"))
+
+    def test_a_tilde_line_does_not_close_a_backtick_fence(self):
+        # The mismatched marker must stay inside the fence, so the TBD between
+        # them is blanked and the prose after the real close survives.
+        stripped = strip_code("```\n~~~\nTBD\n```\nafter")
+        self.assertNotIn("TBD", stripped)
+        self.assertIn("after", stripped)
+
+    def test_a_fence_indented_up_to_three_spaces_is_still_a_fence(self):
+        # CommonMark allows 0-3 spaces before a fence marker; the `\s{0,3}`
+        # allowance in _FENCE_LINE is what honours that.
+        self.assertNotIn("TBD", strip_code("intro\n   ```\n   TBD\n   ```\nafter"))
+
+    def test_an_unterminated_fence_blanks_to_end_of_file(self):
+        self.assertNotIn("TBD", strip_code("intro\n```\nTBD\nstill inside"))
+
+    def test_preserves_line_count_exactly(self):
+        # newest_entry aligns heading indices from the stripped text against
+        # the original lines; a dropped trailing line would shift the tail.
+        for src in ("a\n```\nTBD\n```\nb", "one `x` two", "```\nunterminated\n", "trailing\n"):
+            with self.subTest(src=src):
+                self.assertEqual(len(strip_code(src).split("\n")), len(src.split("\n")))
+
+    def test_keeps_prose_outside_code(self):
+        self.assertIn("TBD", strip_code("a bare TBD and a `quoted` one"))
+
+    def test_does_not_over_strip_between_two_code_spans(self):
+        # Guards the greedy-regex failure mode: `a` … TBD … `b` must not be
+        # collapsed into one span, which would hide the placeholder between them.
+        self.assertIn("TBD", strip_code("see `one` then TBD then `two`"))
+
+
+class PlaceholdersInTests(unittest.TestCase):
+    def test_the_vocabulary_is_exactly_these_three(self):
+        # Asserted against literals, NOT by iterating PLACEHOLDER_TOKENS —
+        # a test that loops the tuple it claims to pin agrees with any
+        # truncation of it and pins nothing.
+        self.assertEqual(PLACEHOLDER_TOKENS, ("TBD", "TODO:", "FILL IN"))
+
+    def test_a_bare_tbd_is_a_placeholder(self):
+        self.assertEqual(placeholders_in("- Version: TBD here"), ["TBD"])
+
+    def test_a_bare_todo_is_a_placeholder(self):
+        self.assertEqual(placeholders_in("- TODO: write the entry"), ["TODO:"])
+
+    def test_a_todo_needs_no_trailing_boundary(self):
+        self.assertEqual(placeholders_in("- TODO:write the entry"), ["TODO:"])
+
+    def test_a_bare_fill_in_is_a_placeholder(self):
+        self.assertEqual(placeholders_in("- Release date: FILL IN"), ["FILL IN"])
+
+    def test_backticked_mentions_are_not_placeholders(self):
+        self.assertEqual(placeholders_in("checks `TBD`, `TODO:` and `FILL IN`"), [])
+
+    def test_a_fenced_mention_is_not_a_placeholder(self):
+        self.assertEqual(placeholders_in("example:\n```\nTBD\n```\n"), [])
+
+    def test_a_hyphenated_date_placeholder_still_fails(self):
+        # The likeliest real placeholder in a changelog, and the reason the
+        # boundary is alphanumeric-only rather than \w or [\w-].
+        self.assertEqual(placeholders_in("## [0.25.0] — 2026-08-TBD"), ["TBD"])
+
+    def test_emphasis_wrapping_does_not_exempt_a_token(self):
+        for wrapped in ("_TBD_", "__TBD__", "*TBD*", "**TBD**", "(TBD)", '"TBD"', "TBD."):
+            with self.subTest(wrapped=wrapped):
+                self.assertEqual(placeholders_in(f"- Version: {wrapped}"), ["TBD"])
+
+    def test_a_token_inside_a_longer_word_is_not_a_placeholder(self):
+        self.assertEqual(placeholders_in("the TBDish approach and FILL INSIDE"), [])
+
+    def test_a_token_preceded_by_a_letter_is_not_a_placeholder(self):
+        # The LEADING boundary, which suffix-only cases above do not exercise.
+        self.assertEqual(placeholders_in("the aTBD marker and xFILL IN"), [])
+
+    def test_matching_is_case_sensitive(self):
+        # Lowercasing the match would fire on ordinary prose: "fill in the form".
+        self.assertEqual(placeholders_in("please fill in the form; tbd later"), [])
+
+    def test_an_unbackticked_identifier_is_reported(self):
+        # Consequence of the alphanumeric-only boundary, pinned so it is a
+        # decision rather than a surprise: prose must backtick the ID.
+        self.assertEqual(placeholders_in("closes RELEASE-GATE-TBD-FALSE-POSITIVE"), ["TBD"])
+        self.assertEqual(placeholders_in("closes `RELEASE-GATE-TBD-FALSE-POSITIVE`"), [])
+
+    def test_clean_text_yields_nothing(self):
+        self.assertEqual(placeholders_in("nothing to declare"), [])
+
+
+class NewestEntryTests(unittest.TestCase):
+    """The slicing helper — the gate is only as good as its boundary."""
+
+    CHANGELOG = "\n".join(
+        [
+            "# Changelog",
+            "preamble PREAMBLE-MARK",  # above the first level-2 heading: out of scope
+            "",
+            "## [Unreleased]",
+            "",
+            "### Added — the entry being published (2026-08-02)",
+            "",
+            "- current body",
+            "",
+            "### Added — a previous entry STOP-MARK (2026-08-01)",
+            "",
+            "- historical body",
+            "",
+            "## [1.0.0] — 2026-05-21",
+            "",
+            "- released body",
+        ]
+    )
+
+    def test_starts_at_the_first_level_2_heading(self):
+        self.assertTrue(newest_entry(self.CHANGELOG).startswith("## [Unreleased]"))
+
+    def test_includes_the_entry_being_published(self):
+        self.assertIn("current body", newest_entry(self.CHANGELOG))
+
+    def test_excludes_the_preceding_entry(self):
+        self.assertNotIn("historical body", newest_entry(self.CHANGELOG))
+
+    def test_excludes_the_stop_heading_line_itself(self):
+        # Off-by-one guard: real entry headings quote their subject, so
+        # including the boundary line would fail on the PREVIOUS entry's title.
+        self.assertNotIn("STOP-MARK", newest_entry(self.CHANGELOG))
+
+    def test_excludes_released_sections(self):
+        self.assertNotIn("released body", newest_entry(self.CHANGELOG))
+
+    def test_excludes_the_preamble(self):
+        self.assertNotIn("PREAMBLE-MARK", newest_entry(self.CHANGELOG))
+
+    def test_a_level_3_heading_above_the_first_level_2_does_not_become_the_start(self):
+        stray = "### stray STRAY-MARK\n\n- stray body\n\n## [Unreleased]\n\n- real body\n"
+        entry = newest_entry(stray)
+        self.assertTrue(entry.startswith("## [Unreleased]"))
+        self.assertNotIn("STRAY-MARK", entry)
+
+    def test_a_level_1_heading_does_not_become_the_start(self):
+        doc = "# Changelog TITLE-MARK\n\n## [Unreleased]\n\n- real body\n"
+        self.assertNotIn("TITLE-MARK", newest_entry(doc))
+
+    def test_a_level_4_heading_does_not_end_the_entry(self):
+        doc = "## [Unreleased]\n\n### Added — entry\n\n#### detail\n\n- deep body\n"
+        self.assertIn("deep body", newest_entry(doc))
+
+    def test_a_heading_marker_needs_a_space(self):
+        doc = "## [Unreleased]\n\n### Added — entry\n\n###NotAHeading\n\n- still mine\n"
+        self.assertIn("still mine", newest_entry(doc))
+
+    def test_a_heading_inside_a_fence_does_not_end_the_entry(self):
+        # Without code-stripping the example heading truncates the slice and
+        # the placeholder below it is never scanned — a silent false green.
+        doc = (
+            "## [Unreleased]\n\n### Added — entry\n\n"
+            "```markdown\n### Added — example\n```\n\n- Version: TBD\n"
+        )
+        self.assertIn("TBD", newest_entry(doc))
+
+    def test_a_sole_entry_runs_to_end_of_file(self):
+        sole = "# Changelog\n\n## [Unreleased]\n\n### Added — only entry\n\n- body\n"
+        self.assertIn("- body", newest_entry(sole))
+
+    def test_an_entry_with_no_level_3_heading_stops_at_the_next_release(self):
+        bare = "## [Unreleased]\n\n- loose body\n\n## [1.0.0]\n\n- released body\n"
+        entry = newest_entry(bare)
+        self.assertIn("loose body", entry)
+        self.assertNotIn("released body", entry)
+
+    def test_an_emptied_unreleased_section_is_skipped_not_returned(self):
+        # The post-release-cut shape: platforms/claude-code-plugin/CHANGELOG.md
+        # promotes the entry to a level-2 section and leaves [Unreleased] bare.
+        # Returning the empty section would scan nothing and pass vacuously.
+        cut = "## [Unreleased]\n\n## [0.25.0] — 2026-08-02\n\n### Added — the cut entry\n\n- body\n"
+        entry = newest_entry(cut)
+        self.assertTrue(entry.startswith("## [0.25.0]"))
+        self.assertIn("- body", entry)
+
+    def test_a_whitespace_only_section_counts_as_empty(self):
+        # `line.strip()` is what makes this an empty section. Without it a
+        # release cut that leaves an indented blank line behind returns the
+        # bare [Unreleased] and the real entry below goes unscanned.
+        cut = "## [Unreleased]\n\n   \n\n## [0.25.0]\n\n### Added\n\n- Version: TBD\n"
+        entry = newest_entry(cut)
+        self.assertTrue(entry.startswith("## [0.25.0]"))
+        self.assertEqual(placeholders_in(entry), ["TBD"])
+
+    def test_the_slice_is_original_text_not_code_stripped_text(self):
+        # Headings are located in stripped text; the slice must come from the
+        # original, or every code span in a published entry would be blanked.
+        doc = "## [Unreleased]\n\n### Added — entry\n\n- see `inline code` here\n"
+        self.assertIn("`inline code`", newest_entry(doc))
+
+    def test_no_level_2_heading_raises_rather_than_scanning_nothing(self):
+        with self.assertRaises(ValueError):
+            newest_entry("# Changelog\n\nno sections here\n")
+
+    def test_only_empty_level_2_sections_raises(self):
+        with self.assertRaises(ValueError):
+            newest_entry("## [Unreleased]\n\n## [1.0.0]\n")
+
 
 class ChangelogEntryTests(unittest.TestCase):
     def test_changelog_exists(self):
@@ -29,6 +368,9 @@ class ChangelogEntryTests(unittest.TestCase):
         # Match the version in any level-2/3 heading line, not just a bracketed
         # top-level one. The trailing lookahead avoids a prefix match (0.30.0 in
         # 0.30.01).
+        #
+        # Deliberately scans the WHOLE file: this is a presence check, and the
+        # heading may be a released section far below the newest entry.
         pattern = rf"^#{{2,3}}\s+.*{re.escape(version)}(?![\d.])"
         self.assertRegex(
             changelog,
@@ -40,6 +382,11 @@ class ChangelogEntryTests(unittest.TestCase):
     def test_no_placeholder_orphans(self):
         if not CHANGELOG.exists():
             self.skipTest("CHANGELOG.md not present")
-        changelog = CHANGELOG.read_text(encoding="utf-8")
-        for token in ["TBD", "TODO:", "FILL IN"]:
-            self.assertNotIn(token, changelog, f"CHANGELOG contains placeholder {token!r}")
+        found = placeholders_in(newest_entry(CHANGELOG.read_text(encoding="utf-8")))
+        self.assertEqual(
+            found,
+            [],
+            f"the newest CHANGELOG.md entry contains unfilled placeholder(s) {found}. "
+            "If the entry is *describing* a token rather than leaving one unfilled, "
+            "wrap it in backticks — a bare occurrence reads as an unfilled placeholder.",
+        )


### PR DESCRIPTION
**PLUGIN-PREPROD-001 PR 5 of 5 — first of the split.** PR 5's eight documents of record exceed the ≤3-surface governance cap, so it lands as a short sequence; this one carries no version bump. Closes `RELEASE-GATE-TBD-FALSE-POSITIVE`, which the handoff names as the blocker on the release cut.

## The defect

`tests/release/test_changelog_entry.py::test_no_placeholder_orphans` asserted the literal `TBD` was absent from the whole of `CHANGELOG.md`. The check landed in `982b06cb` (2026-05-31) and passed until `e73a8c91` (2026-07-08) added a quoted historical commit message recording a past review that fixed such a placeholder. That text is correct and, the file being append-only, must not be edited — so from that commit on the gate could not pass. 25 days red, and strictly worse over time.

Both fix shapes the backlog entry proposed are wrong, and are now recorded as wrong:

- **Scoping to `## [Unreleased]`** does nothing — this repo keeps every unreleased entry under that one heading, roughly 2,700 lines, so the quoted text is inside it.
- **Excluding quotations** does nothing — the line carries no `>` blockquote prefix.

## The fix — two parts, because one alone re-breaks it

Narrowing the scope alone turned the gate red against *this PR's own changelog entry*, which has to name the tokens it describes.

1. **Matcher.** Ignores tokens inside backticks or fenced blocks — markdown's own mention-vs-use marker — with an **alphanumeric-only** word boundary. Punctuation and hyphens deliberately do *not* exempt a token, so a dated heading left as `2026-08-TBD` still fails, as do `_TBD_` and `**TBD**`. `strip_code` is a line scanner, not a regex: a non-greedy fence pattern pairs an *unterminated* fence with the next one and blanks the prose between them, which hides placeholders.
2. **Scope.** `newest_entry` returns the first level-2 section **with a body**, truncated at its second level-3 heading, with headings located in code-stripped text so a `##` inside a fenced example cannot truncate the entry early. A section emptied by a release cut is skipped rather than returned — otherwise it scans nothing and passes vacuously.

**Accepted limitations, stated in the docstring rather than hidden:** only the newest entry is scanned, so a PR adding two level-3 entries has only the first checked; and in the window after a cut empties `## [Unreleased]`, the newest body-bearing section is a released one.

## Verification

```
tests/release/          49 passed, 11 subtests
tests/conformance/      410 passed, 780 subtests (with tests/release)
pre-commit              all hooks pass, no autofix drift
```

41 new cases. Every mutation in two author sets killed **against a baseline asserted green first**, plus the six consequential survivors an independent review found in a wider set (whitespace-only section bodies, the leading word boundary, case sensitivity, slicing from stripped rather than original text, the body-detection offset, the fence-indent allowance).

⚠️ Two earlier mutation runs in this session scored 11/11 and 17/17 and **both were worthless** — the first because the harness never imported the module, the second because the baseline was red. A perfect first-try kill rate is the symptom, not the result. That lesson is recorded in the backlog entry.

## Also opened, not closed

`RELEASE-TIER-STALE-SUBMODULE-PIN`. The obvious diagnosis — "nothing runs this tier" — is **wrong**, and a first draft of this PR shipped it. The umbrella runs it unguarded twice (`aidoc-flow/.github/workflows/pr-checks.yml:42` on every PR, `release.yml:37` on `v*` tags); it just pins this repo at `0ffa153c` (2026-06-15), three weeks *before* the offending line. Tier 🟡, queue-only — the umbrella is outside the ten-repo OPS-0076 carve-out.

The entry also refutes a claim in `CLAUDE.md` § "Durable traps": `test-plugin.sh` sets `set -uo pipefail` with no `-e`, and `run()` increments `FAILED` before returning, so the `|| true` suppresses nothing. Correcting `CLAUDE.md` needs a governance PR and is deferred to a later stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
