### PR TITLE
docs(security): correct the security posture SECURITY.md described — PLUGIN-PREPROD-001 PR 5b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,72 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — `SECURITY.md` described a security posture the repository does not have (2026-08-02)
+
+**PLUGIN-PREPROD-001 PR 5, stage b.** Closes finding **M7**. No version bump on
+any stream; the plugin's `0.24.0 → 0.25.0` cut is the next stage.
+
+- **The one reporting channel the file names did not exist.** `SECURITY.md`
+  directs researchers to GitHub's private vulnerability reporting and forbids
+  the public fallback, but private vulnerability reporting was disabled on the
+  repository — the Security tab rendered no "Report a vulnerability" control,
+  so the documented path dead-ended. It is now enabled (founder-authorized,
+  2026-08-02), which makes the existing text true; no wording changed. Found
+  while reviewing this change, in the one section the change does not touch.
+- **The enforcement picture was backwards, which is the defect that mattered.**
+  The file listed scanners without saying which of them gates anything. None of
+  the five configured in `.github/workflows/` is a required status check on
+  `main`; the required context `call / Lint / format / security hooks` is the
+  `pre-commit` job, so `bandit`, `detect-secrets` and `detect-private-key` are
+  the only security tools here whose findings can block a merge. A new opening
+  paragraph states that first, before any inventory.
+- **The scanner list omitted four of the five workflow-configured scanners.**
+  What it did name was accurate for `bandit`, `detect-secrets` and
+  `detect-private-key`, but of the tools configured in `.github/workflows/` it
+  listed only CodeQL, and called that one Python-only where `codeql.yml:42`
+  sets `'["actions","python"]'`. Each list is now headed by the file that
+  configures it, and the entries name what each tool actually is: semgrep,
+  osv-scanner, gitleaks over full commit history, `trivy config`.
+- **The pre-commit hooks are not local-only.** `.github/workflows/pre-commit.yml`
+  runs the same hook set over the whole tree, which is precisely why they are
+  the ones that gate. `pip-audit` is the exception and is no longer listed
+  beside them: it declares `stages: [manual]` and the CI caller requests no
+  stage override, so it runs on neither commit nor CI.
+- **Each workflow scanner reports twice, and only one of the two reflects
+  `fail-on-findings`.** Every one of the five uploads SARIF, so a pull request
+  carries both a workflow check and a separate code-scanning check run. Of the
+  workflow checks, three are `fail-on-findings: false`; `secret-scan` fails its
+  job on a finding and `codeql` has no findings gate at all. The section also
+  now warns that a fork pull request runs three of the five not at all and
+  produces no code-scanning check, so the missing checks are expected rather
+  than a broken pipeline.
+- **The pre-commit list did not mention the repository-wide `exclude:`.** It
+  hides `legacy/`, `framework/` and the plugin's vendored copy of the spec from
+  every hook in that file, both secret scanners included, so an unqualified
+  "detect-secrets + detect-private-key" read as covering the primary product.
+  Coverage of those paths comes from `secret-scan.yml`, which scans full
+  history and is not subject to the exclude; `.gitleaks.toml` allowlists none
+  of the three.
+- **The supported-versions table promised release lines that do not exist.** It
+  pinned the spec at `0.35.x` against an actual `0.40.0`, and conferred support
+  by "latest tagged release" when every stream ships well past its newest tag —
+  the framework spec by nineteen minor versions, Hermes by eleven.
+  `scripts/sync-version-refs.sh` does not touch this file, so every number in
+  it was hand-maintained and unchecked. The table now names no version, and no
+  longer implies a stale tag gets patched: support is `main`, where fixes land
+  first, plus each stream's most recent release, where the fix then ships. The
+  preamble tells a reporter on an untagged build — which both platforms
+  currently are — to report against `main`, and cites `docs/TAGGING.md` for the
+  tag-cut backlog rather than presenting the lag as intentional.
+- **Scope omitted the paths most likely to be reported against.** It now names
+  `tools/`, `.github/workflows/` and `scripts/` — the latter two implied in
+  scope by CodeQL's `actions` analysis and by workflows that run on a
+  self-hosted runner pool. Scope also called `legacy/` "frozen pre-migration content"; it is a parking
+  area for skills pulled from the shipped plugin surface, currently holding one
+  retired skill, and the pre-migration archive is the branch
+  `legacy-ucx-v3.2-read-only` — which the table had cited as "archive branch"
+  without ever naming.
+
 ### Fixed — the release changelog gate stopped failing on its own history (2026-08-02)
 
 **PLUGIN-PREPROD-001 PR 5 of 5.** PR 5's eight documents of record exceed the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,14 +3,22 @@
 ## Supported versions
 
 This is a specification + tooling project (an engine-agnostic `framework/` spec
-plus two platforms). Security fixes are applied to the latest release line.
+plus two platforms). The project, the spec, and each platform are versioned and
+released independently (`docs/PROJECT.md` §2), and each carries its own
+`VERSION` file.
+
+Security fixes land on `main` and ship in the next release of each affected
+stream; they are not backported to earlier releases. Report against `main`, or
+against whatever build you are running — including an untagged one. Both
+platforms currently ship ahead of their newest tag, because the tag-cut is a
+known backlog (`docs/TAGGING.md`), so the version you have may have no tag at
+all.
 
 | Component | Supported |
 |-----------|-----------|
-| Latest project release (`v1.x`) | ✅ |
-| `framework/` spec — latest (`0.35.x`) | ✅ |
-| Platforms — latest tagged release | ✅ |
-| Older / pre-cutover (`< v1.0`, archive branch) | ❌ |
+| `main` | ✅ — fixes land here first |
+| The most recent release of each stream | ✅ — fixed on `main`, shipped in that stream's next release |
+| Anything older, pre-cutover project releases (`< v1.0`) included, and branch `legacy-ucx-v3.2-read-only` | ❌ |
 
 ## Reporting a vulnerability
 
@@ -38,18 +46,70 @@ This opens a private advisory visible only to the maintainers.
 
 In scope: the `framework/` spec tooling, the Hermes MCP server
 (`platforms/hermes/`), the Claude Code plugin (`platforms/claude-code-plugin/`),
-and the shared `tests/` tooling. The `legacy/` archive is **out of scope**
-(frozen pre-migration content).
+the shared tooling in `tools/` (the SDD linter, the saga driver and the sync
+scripts among others), the shared `tests/` tooling, and this repository's own automation
+(`.github/workflows/`, `scripts/`) — workflow definitions and hook scripts
+both execute, and some workflows run on a self-hosted runner pool.
+
+Out of scope: `legacy/`, a parking area for plugin skills pulled from the
+shipped surface — nothing under it is discovered or shipped — and the
+pre-migration archive branch
+`legacy-ucx-v3.2-read-only`.
 
 ## Automated security checks
 
-This repository runs, in CI and via pre-commit:
+**Only three of the checks below can block a merge:** `bandit`,
+`detect-secrets` and `detect-private-key`. They run in the `pre-commit` job,
+which is a required status check on `main`
+(`call / Lint / format / security hooks`). Everything else reports without
+gating: a red advisory check leaves a pull request warned but mergeable, and
+maintainers triage those findings by hand. The one control that stops a change
+before it lands is GitHub's secret-scanning push protection, described at the
+end of this section.
 
-- **CodeQL** — static analysis (code scanning) for Python.
-- **bandit** — Python security linter (SAST).
-- **detect-secrets** + **detect-private-key** — secret scanning.
-- **pip-audit** — dependency vulnerability scanning.
-- **Dependabot** — dependency update PRs and security alerts.
+**Configured in `.github/workflows/`**, run in CI only:
 
-GitHub-native **secret scanning + push protection** and **Dependabot alerts**
-are enabled in the repository's security settings.
+- **CodeQL** — code scanning for `actions` and `python` (`codeql.yml`).
+- **semgrep** — SAST (`sast-scan.yml`).
+- **osv-scanner** — dependency vulnerability scanning across the repository's
+  manifests (`dep-scan.yml`).
+- **gitleaks** — secret scanning over the **full git commit history**, not the
+  working tree (`secret-scan.yml`); suppressions live in `.gitleaks.toml`.
+- **trivy config** — IaC / misconfiguration scanning (`trivy-scan.yml`).
+
+On a pull request from a branch of this repository, each reports both as its
+own workflow check and as a code-scanning check run built from uploaded SARIF
+(CodeQL produces one workflow check per language, so three in total). **On a
+pull request from a fork, `sast-scan`, `dep-scan` and `trivy-scan` do not run
+at all, and no code-scanning check is produced** — expect fewer checks there,
+not a broken pipeline.
+
+Only the workflow check reflects `fail-on-findings`, which `sast-scan`,
+`dep-scan` and `trivy-scan` set to `false`: a finding does not turn those jobs
+red, though a toolchain failure still can. `secret-scan` does fail its job on a
+finding, and `codeql` has no findings gate at all.
+
+**Configured in `.pre-commit-config.yaml`**, run on `git commit` and again in
+CI, where `pre-commit.yml` runs the same hooks over the whole tree:
+
+- **bandit** — Python security linter, scoped to `platforms/hermes/src/` and
+  `tests/`.
+- **detect-secrets** (baselined in `.secrets.baseline`) +
+  **detect-private-key** — secret scanning.
+
+`pip-audit` is configured in that file but runs in neither place: it declares
+`stages: [manual]`, so it scans `tests/conformance/requirements.txt` only when
+invoked explicitly.
+
+A repository-wide `exclude:` hides `legacy/`, `framework/` and the plugin's
+vendored copy of the spec from **every** hook in that file, both secret
+scanners included. Secrets under those paths are covered instead by
+`secret-scan.yml`, which scans the full history and is not subject to the
+exclude.
+
+**Configured in the repository's security settings**, outside any file here:
+**secret scanning with push protection**, which rejects a push containing a
+recognised provider token outright — scanning for non-provider and custom
+patterns is not enabled, so it does not catch every secret — and
+**Dependabot**, which raises security alerts and dependency-update pull
+requests.


### PR DESCRIPTION
**PLUGIN-PREPROD-001 PR 5, stage b.** Closes finding **M7**. No version bump on any stream; the plugin's `0.24.0 → 0.25.0` cut is stage 5c.

## What was wrong

`SECURITY.md` described a security posture this repository does not have.

- **The enforcement picture was inverted.** None of the five scanners configured in `.github/workflows/` is a required status check on `main`. The required context `call / Lint / format / security hooks` is the `pre-commit` job, which runs the same hooks over the whole tree — so `bandit`, `detect-secrets` and `detect-private-key` are the only security tools here whose findings can block a merge, and the file filed them under the surface a reader takes for local-only.
- **Four of the five workflow scanners were unlisted**, and CodeQL was called Python-only where `codeql.yml:42` sets `'["actions","python"]'`.
- **The repo-wide pre-commit `exclude:`** hides `legacy/`, `framework/` and the plugin's vendored copy from every hook, both secret scanners included — unstated, so an unqualified "detect-secrets + detect-private-key" read as covering the primary product.
- **Scope** omitted `tools/`, `.github/workflows/` and `scripts/`, and called `legacy/` "frozen pre-migration content" (it is a parking area for pulled plugin skills; the archive is branch `legacy-ucx-v3.2-read-only`, which the table cited without naming).
- **The supported-versions table promised release lines that do not exist** — spec pinned at `0.35.x` against `0.40.0`, and support conferred by "latest tagged release" when every stream ships well past its newest tag (framework by 19 minors, Hermes by 11).

## Deviation from the plan, stated deliberately

The plan's M7 instruction (`plans/PLUGIN-PREPROD-001-PLAN.md:294`) is to **replace** the scanner list with what CI runs. That would have deleted four accurate entries, so the list is **split by configuring file** instead. The plan's claim-ledger row 34 (`:550`) asserts `SECURITY.md` "names scanners CI does not run | bandit" — that is false; bandit runs in CI, in the required context. Both are queued for stage 5e.

## Repository setting changed

Private vulnerability reporting was **disabled**, so the file's only reporting channel dead-ended into a Security tab with no "Report a vulnerability" control — while line 23 forbids the public fallback. Enabled with founder authorization; the existing text needed no wording change.

## Verification

- `pre-commit run --files SECURITY.md CHANGELOG.md` — clean, no autofix collateral.
- `tests/release/` — 49 passed.
- Every factual claim re-verified against source: branch protection via `gh api .../branches/main/protection`, canon reusables via `git show ci/v2.16.0:<path>` (the sibling checkout is 6 commits ahead of the pin), check-run behaviour against PR #421's rollup.

Three review cycles (OPS-0066 cap), 6 agents. Cycles 1 and 2 each found that the *fold* had introduced new false claims — including a "codeql fails on findings" claim (it has no findings gate) and a "tags lag by design" claim contradicted by `docs/TAGGING.md:97`, which calls it a known backlog.

## Follow-ups captured, not fixed here

Kept to two surfaces. `.pre-commit-config.yaml:9` and `:92` carry claims this PR falsifies; `CONTRIBUTING.md:94-99` is an unlinked duplicate that says detect-secrets covers "staged files" (true locally, false in CI); `PREPROD-M7`'s TODO context repeats the rejected misconception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
