### PR TITLE
docs(handoff): regenerate for the #422 merge; relocate PR 5 detail to the plan

### DIFF
--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -56,6 +56,74 @@
 
 ## Open
 
+### `[build]` `SYNC-WEBSITE-SILENT-NOOP` — the version sync writes a sibling repo, misses, and says nothing → #423
+
+- *Context:* found 2026-08-02 while measuring the plugin `VERSION` fanout for
+  PLUGIN-PREPROD-001 PR 5c. `scripts/sync-version-refs.sh:180` writes
+  `../web-site/src/pages/index.astro` — an independent repo with its own remote,
+  outside this git tree. The badge there reads `Pre-release v0.20.1` (`:19`)
+  while this repo is at plugin `0.24.0`, so the script's `grep -qF` for the
+  *previous* value misses and `replace_in_file` returns 0 **without logging**
+  (`sync-version-refs.sh`, `replace_in_file`: `grep -qF "$old" "$file" || return 0`).
+  Two compounding facts: the script's own header (`:31-37`) documents the silence
+  for the case where `web-site/` is **absent**, not for a value mismatch; and the
+  prescribed way to test a sync script is a throwaway clone (`CLAUDE.md`
+  § "Local hooks and tooling"), which has no sibling `../web-site/` and is
+  therefore structurally blind to this write. It is self-sealing — every future
+  bump greps for a `prev` the site has not carried since `0.20.1`.
+- *Blast radius:* the public site advertises a five-minors-stale version. The
+  header comment at `:34` says this write exists to "close the v0.18.0
+  stale-badge drift bug", so the bug it was written to fix has recurred.
+- *Fix shape:* make a grep miss on the `web-site` path **warn** rather than
+  return silently (it must stay non-fatal — the sibling is legitimately absent in
+  CI), and repair the badge by hand in a `web-site` PR. Do not make
+  `replace_in_file` warn globally; most of its misses are the idempotent case.
+- *Stage:* the hand repair rides with PR 5c; the warn-on-miss fix is independent.
+
+### `[docs]` `PRECOMMIT-CONFIG-COMMENTS-STALE` — two comments in `.pre-commit-config.yaml` describe things that are not so
+
+- *Context:* found 2026-08-02 during the #422 `SECURITY.md` review; both are
+  comment-only, neither affects hook behaviour. (a) `:9` calls `legacy/` "the
+  frozen pre-migration archive" — it is a parking area for skills pulled from the
+  shipped plugin surface; the pre-migration archive is branch
+  `legacy-ucx-v3.2-read-only`. (b) `:92` says `pip-audit` runs in "the `manual`
+  stage (CI) + pre-push". It runs in **neither**: `stages: [manual]` (`:98`), the
+  CI caller passes no `run-stage` (`.github/workflows/pre-commit.yml:38-42`), and
+  `scripts/pre_push_check.sh` never invokes it.
+- *Fix shape:* correct both comments. Decide separately whether `pip-audit`
+  *should* run somewhere — the comment asserts an intent the config never had.
+- *Stage:* unassigned; one- and two-line edits.
+
+### `[docs]` `CONTRIBUTING-SECRET-TABLE-NO-CI-ROW` — the secret-scanning table omits the required CI pass, and links one way
+
+- *Context:* found 2026-08-02 during the #422 `SECURITY.md` review.
+  `CONTRIBUTING.md:94-97` tabulates secret scanning as `detect-secrets` (local)
+  - `gitleaks` (CI). ⚠️ **The `detect-secrets` row is explicitly scoped
+  `(local)` and is NOT wrong** — an earlier draft of this finding called it
+  false because CI runs `--all-files`, which would have deleted an accurate
+  scope. The real defect is an **omission**: there is no row for the required CI
+  `pre-commit` job, which runs the same hooks over the whole tree. Separately,
+  `SECURITY.md` carries this coverage as bullets (`:62`, `:76-77`, `:97`), not a
+  table, so the two surfaces overlap without either being a copy; and the link is
+  one-way — `CONTRIBUTING.md:104` points at `SECURITY.md`, nothing points back.
+- *Fix shape:* add the CI `pre-commit` row; leave the local row alone; add the
+  back-link from `SECURITY.md`.
+- *Stage:* unassigned.
+
+### `[ops]` `SYNC-SECRET-SCANNING-KNOBS` — push protection is on, two scanning knobs are off — FOUNDER DECISION
+
+- *Context:* found 2026-08-02 by `gh api repos/vladm3105/aidoc-flow-framework`
+  during the #422 review. `secret_scanning` and `secret_scanning_push_protection`
+  are enabled; `secret_scanning_non_provider_patterns` and
+  `secret_scanning_validity_checks` are **disabled**, which narrows what the one
+  merge-blocking control actually catches. Not a defect — a posture choice nobody
+  has made explicitly. `SECURITY.md:66` presents push protection as the control
+  that stops a change before it lands, without this qualifier.
+- *Fix shape:* founder decides whether to enable both (repo-settings write is
+  🔴 tier). If yes, enable and note the qualifier in `SECURITY.md`; if no, record
+  why in `plans/DECISIONS.md` so the next review does not re-file it.
+- *Stage:* unassigned; blocked on the founder.
+
 ### `[plugin]` `PREPROD-L7-BARE-DISPATCH` — the plugin dispatches its agents by bare name, so a consumer's same-named agent wins → #417
 
 - *Context:* found 2026-08-01 by security review during PLUGIN-PREPROD-001 PR 4,
@@ -112,14 +180,14 @@
 
 ### `[docs]` `PREPROD-PLAN-TESTPATH` — the PR 4 plan's file table names a path that does not exist
 
-- *Context:* `plans/PLUGIN-PREPROD-001-PLAN.md:326` names
+- *Context:* `plans/PLUGIN-PREPROD-001-PLAN.md:378` names
   `tests/conformance/test_agent_frontmatter.py`; it shipped at
   `tests/conformance/platforms/test_agent_frontmatter.py`, beside the 18 other
   plugin-platform checks. The `platforms/` placement is correct — the adjacent
   `:325` row (`test_plugin_hook_safety.py`, PR 1) is the one that is arguably
   misplaced. Not fixed in PR 4 because editing a `plans/*-PLAN.md` makes it a
   governance PR under the ≤3-doc-surface rule.
-- *Fix shape:* amend `:326` during PR 5, which closes the plan out anyway.
+- *Fix shape:* amend `:378` during PR 5, which closes the plan out anyway.
 - *Stage:* PR 5.
 
 ### `[plugin]` `SAGA-ALL-BRANCHES-FAILED-CLOSES` — a review where every lens failed still closes at exit 0

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -1,64 +1,68 @@
 # Session Handoff
 
-**Purpose:** everything a *fresh* session needs to start work here with zero prior
-context — current state, and what to do next. Nothing else.
-
-**This file is regenerated, not appended.** Status that is appended rots, and a wrong
-cause left standing gets re-read as fact by every later session. **Git is the archive** —
-prior states live in `git log -- plans/HANDOFF.md`. Do not restore them here.
-
-## What lives where — do not duplicate across these
-
-| Surface | Holds | Lifespan |
-|---|---|---|
-| `CHANGELOG.md` | what shipped | permanent, append |
-| `plans/DECISIONS.md` | why a non-obvious choice was made (`D-NNNN`) | permanent, append |
-| `framework/governance/DECISIONS.md` | spec-tier decisions (`GD-NN`) | permanent, append |
-| `plans/FRAMEWORK-TODO.md` | **the** open-task queue | until closed |
-| `plans/HERMES-BACKLOG.md` | Hermes-parity queue | until closed |
-| `CLAUDE.md` | the durable working agreement **and every settled trap**, auto-loaded every session | permanent |
-| **this file** | current state + next tasks + traps too fresh to have settled | **rewritten each merge** |
-
-**Traps live in `CLAUDE.md` § "Durable traps — do not re-derive these", not here** —
-merging/CI mechanics, reading CI output, local hooks and tooling, the acceptance harness,
-writing to GitHub from a script, and the process lessons. A trap recorded there is
-**never** repeated here; this file carries only what has not settled yet.
+**One reader: a fresh session with zero context.** Current state, then what to do next.
+**Rewritten wholesale each merge** — `git log -- plans/HANDOFF.md` is the archive; do not
+restore prior states here. Settled traps live in `CLAUDE.md` § "Durable traps" and are
+never repeated here; open work lives in `plans/FRAMEWORK-TODO.md`, never here.
 
 ## Where we are — 2026-08-02
 
 Framework spec `0.40.0`, plugin `0.24.0`, Hermes `0.12.1`.
-**Open PRs: 0. Open issues: 4** —
+**Open PRs: 0. Open issues: 5** —
 [#386](https://github.com/vladm3105/aidoc-flow-framework/issues/386),
 [#405](https://github.com/vladm3105/aidoc-flow-framework/issues/405),
 [#412](https://github.com/vladm3105/aidoc-flow-framework/issues/412),
-[#417](https://github.com/vladm3105/aidoc-flow-framework/issues/417).
+[#417](https://github.com/vladm3105/aidoc-flow-framework/issues/417),
+[#423](https://github.com/vladm3105/aidoc-flow-framework/issues/423).
 
-**Last merge: [#420](https://github.com/vladm3105/aidoc-flow-framework/pull/420), squash
-`28c40e94` — the release changelog gate, `RELEASE-GATE-TBD-FALSE-POSITIVE`.**
-`tests/release/` is now **green on `main` for the first time since 2026-07-08** (49 tests).
+**Last merge: [#422](https://github.com/vladm3105/aidoc-flow-framework/pull/422), squash
+`4cbaaad5` — `SECURITY.md` corrected, finding M7, PR 5 stage b.** The file had described
+a security posture this repo does not have; the enforcement half was inverted. Ground
+truth, as of 2026-08-02 and now recorded in `SECURITY.md` itself: **none** of the five
+scanners under `.github/workflows/` (`codeql`, `dep-scan`, `sast-scan`, `secret-scan`,
+`trivy-scan`) is a required status check, and the required
+`call / Lint / format / security hooks` context is the `pre-commit` job — so the only
+*checks* whose findings block a merge are `bandit`, `detect-secrets` and
+`detect-private-key`. Two qualifiers travel with that claim; do not drop them when
+re-summarizing:
 
-**⚠️ PR 5 is not one PR. It is five, and 5a is done — it was #420 above.** `PLUGIN-PREPROD-001-PLAN.md`
-"Docs to update" table (`:330-354`, the PR-5 rows) lists **eight** documents of record
-against the ≤3-surface governance cap, and the plan says to split (`:495`). The measured split, with the constraint that
-forces it, is task 1 below. **PRs 1–4 shipped; the `PREPROD-*` batch stays under
-`FRAMEWORK-TODO.md` `## Open` until 5d closes it — the entries do not tell you what has
-shipped; this file does.**
+- **`bandit` is scoped** `^(platforms/hermes/src/|tests/).*\.py$`
+  (`.pre-commit-config.yaml:50`), so most of `tools/` and the plugin tree is outside it.
+- **`SECURITY.md:66` names the one non-check control that does block** — GitHub
+  secret-scanning push protection. It is enabled.
+
+Branch protection is mutable and this claim now lives in a public file — re-derive with
+`gh api repos/vladm3105/aidoc-flow-framework/branches/main/protection --jq '.required_status_checks.contexts'`
+before citing it.
+
+**Private vulnerability reporting was DISABLED and is now on** (founder-authorized
+2026-08-02, verified by readback). `SECURITY.md` had pointed researchers at a Security-tab
+control that did not render while forbidding the public fallback, so its only reporting
+channel dead-ended. Do not re-file this; do not disable it.
+
+**⚠️ PR 5 is five PRs. 5a (#420) and 5b (#422) are done; 5c is next and is FOUNDER-GATED
+on the Rule 1 surface-cap exception.** `PLUGIN-PREPROD-001-PLAN.md` § "Docs to update"
+(`:532-536`) lists **eight** documents of record for PR 5 against the ≤3-surface
+governance cap, and the plan says to split (`:547`). The measured split is task 1 below.
+**PRs 1–4 shipped; the `PREPROD-*` batch stays under `FRAMEWORK-TODO.md` `## Open` until
+5d closes it — the entries do not tell you what has shipped; this file does.**
 
 **⚠️ Three `FRAMEWORK-TODO.md` entries are NOT part of the original 23 and must NOT be
 closed with the batch** — `PREPROD-L7-BARE-DISPATCH` (#417), `PREPROD-AGENT-WEBFETCH`,
 `PREPROD-PLAN-TESTPATH`. Only `PREPROD-PLAN-TESTPATH` is PR 5's to fix (a one-line path
-amendment at `PLUGIN-PREPROD-001-PLAN.md:326`).
+amendment at `PLUGIN-PREPROD-001-PLAN.md:378`).
 
 **⚠️ `L7` is resolved only because the *documentation* is now correct.** Plugin agents
 register under a scoped identifier, so installation overwrites nothing — but a **bare**
-name resolves by scope precedence, where a plugin ranks lowest of five. Every dispatch
-the plugin ships is bare. #417 is the machine-facing half.
+name resolves by scope precedence, where a plugin ranks lowest of five. Every dispatch the
+plugin ships is bare. #417 (task 2) is the machine-facing half.
 
 **⚠️ The `ai-review` gate WILL request changes on a code or CI PR with no root
-`CHANGELOG.md` entry.** Budget 2 real doc surfaces + `CHANGELOG.md`; #415, #418 and #420
-all did and passed. A failing run **uploads a verdict artifact**
-(`gh run download <id> -n ai-review-verdict`) — a run that fails *after* producing it is
-a verdict, not an outage.
+`CHANGELOG.md` entry.** The ≤3-surface cap is a *ceiling*, not observed practice — recent
+PRs have used one real surface + `CHANGELOG.md` and others three; what they share is the
+changelog entry. A failing run **uploads a verdict artifact**
+(`gh run download <id> -n ai-review-verdict`) — a run that fails *after* producing it is a
+verdict, not an outage.
 
 **⚠️ Two tiers are RED on `main` for pre-existing reasons, neither CI-gated, neither
 yours.** `Hermes pytest` — an unpinned `mcp[cli]>=1.0.0` floor, path-filtered, locally
@@ -66,68 +70,69 @@ green (570), see `HERMES-MCP-FLOATING-DEP`, do not re-diagnose. Phase 0 `lint-sm
 `tests/scripts/test-acceptance.sh` — example-corpus debt deferred to the wholesale regen;
 use `--skip-lint-smoke`.
 
-**V15 (schedule→`workflow_run` chain) is still unconfirmed** — never a gate; V14 proved
-the chain off a *dispatched* upstream only. `standards-drift` runs Mondays 09:00 UTC,
-**first observable 2026-08-03**. On or past that date, confirm a `pin-currency-reader` run
-followed it with `event=workflow_run`, then delete this paragraph. A failure there is a
-new bug, not a reopened plan.
+**V15 (schedule→`workflow_run` chain) is still unconfirmed** — never a gate; V14 proved the
+chain off a *dispatched* upstream only. `standards-drift` runs Mondays 09:00 UTC, **first
+observable 2026-08-03**. On or past that date, confirm a `pin-currency-reader` run followed
+it with `event=workflow_run`, then delete this paragraph. A failure there is a new bug, not
+a reopened plan.
 
 ## Next tasks — prioritized
 
 The full queue is `plans/FRAMEWORK-TODO.md` (`## Open`) and `plans/HERMES-BACKLOG.md`.
 This is only the ordering a fresh session should use.
 
-1. **PLUGIN-PREPROD-001 — PR 5, stages b–e. The last stage of the initiative.**
-   Read `plans/PLUGIN-PREPROD-001-PLAN.md` § "PR 5". The split below is **measured, not
-   proposed** — a plugin `VERSION` bump makes `scripts/sync-version-refs.sh` rewrite
-   **60 files including `CLAUDE.md`**, which pulls the bump under Governance PR
-   discipline. Verified 2026-08-02 in a throwaway clone; the fanout was **clean** (only
-   current-state tokens moved, no historical claim corrupted, so #405 did not fire on
-   this bump).
+1. **PLUGIN-PREPROD-001 — PR 5, stages c–e. The last stage of the initiative.**
+   Read `plans/PLUGIN-PREPROD-001-PLAN.md` § "PR 5" (`:292`).
 
-   **⚠️ 5c CANNOT be split, and this is a founder decision — do not start it blind.**
-   The hook re-stages its own writes, so the diff cannot be separated after the fact;
-   the plan states exactly this at `:486-493` and resolved the identical Hermes case by
-   **skipping the bump** (O2, `:505`). The plugin cannot skip — M6 needs `0.25.0`. So 5c
-   needs Rule 1's stated exception: **explicit founder OK plus an audit-trail line in the
-   commit message**. Ask for it before touching `VERSION`; do not self-grant it, and do
-   not conclude the split above is wrong because one stage will not fit.
+   **⚠️ STOP: 5c needs an explicit founder OK before you touch `VERSION`, plus an
+   audit-trail line in the commit message.** A plugin bump is a 60-file diff including
+   `CLAUDE.md` (Governance PR discipline), and the hook re-stages its own writes so it
+   **cannot be split**. Do not self-grant the Rule 1 exception; do not conclude the split
+   is wrong because one stage will not fit. The full argument, the stage table, and the
+   **four falsified plan claims 5e must correct** are now in the plan (§ "PR 5") — durable
+   content, kept there because this file is deleted at the next merge. Read it; do not
+   re-derive it.
 
-   | | Surfaces | Notes |
-   |---|---|---|
-   | **5b** | `SECURITY.md` (M7) + `CHANGELOG.md` | see M7 below — the plan's instruction is wrong |
-   | **5c** | `VERSION` `0.24.0`→`0.25.0` + the 60-file fanout + both CHANGELOGs | run the propagation, then **hand-verify** |
-   | **5d** | `ROADMAP.md` (M8) + `plans/DECISIONS.md` (`D-00NN`) + `plans/FRAMEWORK-TODO.md` (close the batch) | |
-   | **5e** | `PLUGIN-PREPROD-001-PLAN.md` (`:326` fix + status → `Completed`) + `HANDOFF.md` + `CLAUDE.md` | |
+   `CLAUDE.md` takes the **mechanical version token** at 5c (hook-written) and the
+   **authored** trap corrections + trap graduation at 5e. `CHANGELOG.md` takes a per-PR
+   entry at every stage — that is doc-currency, not duplication.
 
-   Two surfaces appear twice on purpose. `CLAUDE.md` takes the **mechanical version
-   token** at 5c (hook-written) and the **authored** trap correction + trap graduation at
-   5e. `CHANGELOG.md` takes a per-PR entry at every stage — that is doc-currency, not
-   duplication.
+   - **How to propagate (5c).** Edit `platforms/claude-code-plugin/VERSION` and commit;
+     the `sync-version-refs` pre-commit hook fires on `^platforms/[^/]+/VERSION$`
+     (`.pre-commit-config.yaml:116-124`), rewrites the fanout and re-stages itself.
+     `tools/sync-plugin-framework.sh` is **not** part of a plugin bump — it is
+     framework-spec-driven and references no `VERSION` file. Re-derive the 60 before
+     trusting it (throwaway clone, per the `CLAUDE.md` trap):
 
-   - **M7 — the plan says to *replace* `SECURITY.md`'s scanner list with what CI runs.
-     Do not.** The existing list is not false, it is *incomplete*: `bandit`,
-     `detect-secrets`, `detect-private-key` and `pip-audit` really are in
-     `.pre-commit-config.yaml`, and the file says "in CI **and via pre-commit**". Split
-     it by surface instead. **In CI:** semgrep (`sast-scan`), osv-scanner (`dep-scan`),
-     gitleaks over full history (`secret-scan`), `trivy config` (`trivy-scan`), CodeQL.
-     **Via pre-commit:** bandit (scoped to `platforms/hermes/src/` + `tests/`),
-     detect-secrets, detect-private-key, pip-audit (`stages: [manual]`, so *not* every
-     commit). Also wrong at `SECURITY.md:11`: spec `0.35.x` against an actual `0.40.0`;
-     and CodeQL is listed as Python-only when `codeql.yml:42` sets
-     `'["actions","python"]'`.
+     ```sh
+     d=$(mktemp -d) && git clone -q --no-hardlinks . "$d/f" && cd "$d/f" \
+       && echo 0.25.0 > platforms/claude-code-plugin/VERSION \
+       && bash scripts/sync-version-refs.sh >/dev/null 2>&1; git status --porcelain | wc -l
+     ```
+
+   - **⚠️ A clone cannot verify the whole fanout, and the part it cannot see is broken.**
+     `scripts/sync-version-refs.sh:180` also writes the **sibling repo**
+     `../web-site/src/pages/index.astro`, which no clone has. In the real tree that write
+     **silently no-ops**: the site badge reads `Pre-release v0.20.1` (`:19`), the script
+     greps for the *previous* value, and `replace_in_file` returns 0 without logging on a
+     miss. So 5c must update the site **by hand in a `web-site` PR**, or the public page
+     stays five minors stale — and no future bump will ever repair it. Filed as
+     [#423](https://github.com/vladm3105/aidoc-flow-framework/issues/423)
+     (`SYNC-WEBSITE-SILENT-NOOP`).
+   - **5d must correct `PREPROD-M7`'s *Context* line before closing it**
+     (`FRAMEWORK-TODO.md:390`) — it repeats the same rejected misconception
+     ("`SECURITY.md:49` names `bandit`"), which is now stale in line number *and*
+     substance. It also clears the GOV-TODO-ISSUE-SPLIT bar and has no `→ #N`.
    - **M8 — `ROADMAP.md:56` says the plugin is `0.23.4`.** `sync-version-refs.sh` does
      **not** touch `ROADMAP.md`, which is why M8 rides with 5d rather than landing early.
      ⚠️ **`ROADMAP.md:113` also says `0.24.0` and is a *historical* claim**
-     (IDGEN-NO-GENERATOR shipped at `0.24.0`) — it must survive untouched. That is
-     exactly [#405](https://github.com/vladm3105/aidoc-flow-framework/issues/405).
-   - **The plan's PR 5 section still says "add the README prerequisites section."** That
-     shipped in PR 1. Do not re-add it.
-   - **The plan's `--threshold` bullet is doubly stale** — PR 3 made the flag *live*.
-     The changelog entry must say that, not restate either version of the old claim.
-   - **M6 — cut `claude-code-plugin/v0.25.0` + publish a Release. FOUNDER-GATED**, after
+     (IDGEN-NO-GENERATOR shipped at `0.24.0`) — it must survive untouched. That is exactly
+     [#405](https://github.com/vladm3105/aidoc-flow-framework/issues/405).
+   - **M6 — cut `claude-code-plugin/v0.25.0` + publish a Release. SEPARATELY
+     FOUNDER-GATED** (an outward-facing tag + Release, not the Rule 1 exception), after
      5c. The latest Release is `claude-code-plugin/v0.18.0` (2026-06-12), six versions
      stale. The PRs merge normally; only the tag and the public Release wait.
+
 2. **[#417](https://github.com/vladm3105/aidoc-flow-framework/issues/417) — namespace the
    plugin's agent dispatch references.** 29 `subagent_type=` occurrences across 20 files,
    none scoped — but most are `subagent_type=<mapped agent>` *placeholders*, so the bare
@@ -142,9 +147,9 @@ This is only the ordering a fresh session should use.
 4. **[#412](https://github.com/vladm3105/aidoc-flow-framework/issues/412) — linting a
    single file reports every cross-document trace tag as a `TRACE-RES-001` ERROR.** Fix
    shape is the single-file gate `_check_forward_coverage` already carries
-   (`tools/sdd_doc_lint/__init__.py:1972-1973`, documented at `:1965-1967`). ⚠️ The
-   previous handoff cited `:1961-1963` for this and was wrong — those are run-mode
-   severity bullets. Re-derive a carried-forward line number before re-publishing it.
+   (`tools/sdd_doc_lint/__init__.py:1972-1973`, documented at `:1965-1967`). ⚠️ An earlier
+   handoff cited `:1961-1963` and was wrong — those are run-mode severity bullets.
+   Re-derive a carried-forward line number before re-publishing it.
 5. **Watch [aidoc-flow-ci#351](https://github.com/vladm3105/aidoc-flow-ci/issues/351) —
    when canon ships its own reader, DELETE ours.** `.github/workflows/pin-currency-reader.yml`
    plus `scripts/read-pin-currency-log.sh` and `scripts/reconcile-pin-currency-issue.sh`
@@ -155,9 +160,8 @@ This is only the ordering a fresh session should use.
    bump** (verified in a clone, 2026-08-02) — still open for framework-spec bumps.
 7. **[#386](https://github.com/vladm3105/aidoc-flow-framework/issues/386) — the
    framework-spec token gates five files on `CLAUDE.md`'s own state.** Outstanding is only
-   the **fix shape** — #389's approach cannot be reused because this `prev` is
-   load-bearing elsewhere; derive it from a fanout target nobody hand-edits
-   (`docs/PARITY.md`).
+   the **fix shape** — #389's approach cannot be reused because this `prev` is load-bearing
+   elsewhere; derive it from a fanout target nobody hand-edits (`docs/PARITY.md`).
 8. **`doc-maintainer` — nothing to do; it is PAUSED** (`kill_switch: true`, #397), CI
    green. Resume requires `aidoc-flow-ci` #352 **AND** #353 — #353 alone is 15 of the 23
    failures. Census in D-0072. ⚠️ **Do not re-file the `high_risk_paths` /
@@ -169,75 +173,79 @@ This is only the ordering a fresh session should use.
 
 ## Traps too fresh to have settled — not yet in `CLAUDE.md`
 
-- **A perfect first-try mutation kill rate is the symptom, not the result.** Two runs in
-  one session scored 11/11 and 17/17 and **both were worthless** — the first because the
-  harness copied the module to a scratch dir where its `sys.path` sibling did not resolve,
-  so every mutant died of `ModuleNotFoundError`; the second because two new tests were
-  failing, so every mutant died of the red baseline. **Assert the unmutated baseline is
-  green *inside* the harness, and include a control mutant that must die.** The valid run
-  then found six real survivors, every one of which drove a code change.
-  **The other half of this trap, still recorded nowhere else:** anything that mutates
-  source in place leaves the tree dirty in a way that reads as authored code. Restore from
-  a saved copy each iteration, **never in a `finally`** (killing a hung mutant skips it),
-  bound each run with a timeout, and verify `git diff --quiet <path>` before any run you
-  intend to trust.
-- **When a fix has a *scope* and a *matcher*, changing one re-breaks the other.** The
-  release gate's scope fix immediately failed against the PR's own changelog entry,
-  because an entry documenting a placeholder check has to name the tokens it checks for.
-  Ask which *other* dimension the change moved.
-- **`CLAUDE.md` § "Durable traps → Local hooks and tooling" carries two wrong claims in
-  one sentence, at `:829-836`.** (a) "`test-plugin.sh:257`/`:302` end in `|| true`, so
-  even the manual path cannot fail" — the script sets `set -uo pipefail` with **no `-e`**
-  (`:52`), `FAILED` is `declare -i` (`:114`), and `run()` increments it *before*
-  returning (`:123-137`), which `:369-376` turns into `exit 1`. The `|| true` suppresses
-  nothing. (b) "nothing calls that script" — refuted by umbrella `release.yml:32`.
-  **Fix both in 5e, not the one that is easier to see.**
-- **Before writing "nothing runs X", check the umbrella.** A first draft of
-  `RELEASE-TIER-STALE-SUBMODULE-PIN` shipped exactly that inversion. The umbrella runs
-  `tests/release/` unguarded on **every PR** (`aidoc-flow/.github/workflows/pr-checks.yml:42`)
-  and every `v*` tag (`release.yml:37`) — it just pins this repo at `0ffa153c`
-  (2026-06-15), three weeks before the defect. A green umbrella run is not evidence about
-  this repo's `main`.
-- **`check_plan.py` false-greens on a not-ready plan.** Its zero-findings check is a
-  phrase match, and it accepted a Review log whose final pass said *"**Result:** NOT
-  READY"* — because the surrounding prose contained "all folded". Canonical script is
+- **A review fold authors its own false claims, and the pass that produced the fold never
+  catches them.** Three on #422, each caught by the *next* cycle: "`codeql` fails on
+  findings" (its reusable has no findings gate at all); "tags lag `main` **by design**"
+  (`docs/TAGGING.md:97` calls it a known backlog); and a supported-versions table whose two
+  ✅ rows cancelled the ❌ row below them. No rate is implied — the removed-defect count was
+  never tallied. **Re-verify folded text against source, not against the findings list**,
+  and expect a fold that rewrites a section wholesale to need its own full pass.
+- **A document can name a channel, a control or a setting that does not exist, and nothing
+  in CI will ever notice** — `SECURITY.md` pointed at private vulnerability reporting for
+  months while it was disabled. Found only by running
+  `gh api repos/<r>/private-vulnerability-reporting`. **When a doc tells a reader to go
+  somewhere, go there.** The same pass found push protection on but
+  `secret_scanning_non_provider_patterns` and `..._validity_checks` off, which narrows what
+  it catches (`SYNC-SECRET-SCANNING-KNOBS` in `FRAMEWORK-TODO.md`).
+- **A cross-repo write is invisible to the isolation you verify in.** See the `../web-site/`
+  warning under task 1 — a throwaway clone is the prescribed way to test a sync script, and
+  it is structurally blind to the one write that leaves the repo. **Ask what the sandbox
+  cannot see**, and check whether a "skipped silently" path is silent about *absence* only
+  or about *a value mismatch* too.
+- **A perfect first-try mutation kill rate is the symptom, not the result.** Two runs in one
+  session scored 11/11 and 17/17 and **both were worthless** — one harness copied the module
+  where its `sys.path` sibling did not resolve, so every mutant died of
+  `ModuleNotFoundError`; the other ran against a red baseline. **Assert the unmutated
+  baseline green *inside* the harness, and include a control mutant that must die.** The
+  valid run then found six real survivors, every one of which drove a code change. Also:
+  anything mutating source in place leaves the tree dirty in a way that reads as authored
+  code — restore from a saved copy each iteration, **never in a `finally`** (killing a hung
+  mutant skips it), bound each run with a timeout, and verify `git diff --quiet <path>`
+  before any run you intend to trust.
+- **When a fix has a *scope* and a *matcher*, changing one re-breaks the other.** The release
+  gate's scope fix immediately failed against the PR's own changelog entry, because an entry
+  documenting a placeholder check has to name the tokens it checks for. Ask which *other*
+  dimension the change moved.
+- **`CLAUDE.md` § "Durable traps → Local hooks and tooling" carries two wrong claims in one
+  sentence, at `:829-836`.** (a) "`test-plugin.sh:257`/`:302` end in `|| true`, so even the
+  manual path cannot fail" — the script sets `set -uo pipefail` with **no `-e`** (`:52`),
+  `FAILED` is `declare -i` (`:114`), and `run()` increments it *before* returning
+  (`:123-137`), which `:369-376` turns into `exit 1`. The `|| true` suppresses nothing.
+  (b) "nothing calls that script" — refuted by umbrella `release.yml:32`. **Fix both in 5e,
+  not the one that is easier to see.** Related and durable: the umbrella runs
+  `tests/release/` unguarded on **every** PR (`aidoc-flow/.github/workflows/pr-checks.yml:42`)
+  and every `v*` tag, but pins this repo at `0ffa153c` (2026-06-15) — so a green umbrella run
+  is not evidence about this repo's `main`. **Before writing "nothing runs X", check the
+  umbrella.**
+- **`check_plan.py` false-greens on a not-ready plan.** Its zero-findings check is a phrase
+  match, and it accepted a Review log whose final pass said *"**Result:** NOT READY"* —
+  because the surrounding prose contained "all folded". Canonical script is
   `~/.claude/skills/verified-planning/check_plan.py`; no repo-local copy. **Not filed.**
-- **markdownlint silently corrupts claim-ledger citations.** Its autofix rewrites
-  `__init__.py` → `**init**.py` in an unbackticked table cell, which broke **ten**
-  citations at once and made the gate fail with the misleading `path '.py' does not
-  exist`. Workaround in #408: `<!-- markdownlint-disable MD050 -->` scoped around the
-  ledger. It also normalizes `_x_` → `*x*` across a **whole** changelog file you touch.
-  **Not filed.**
+- **markdownlint's `__init__.py` → `**init**.py` corruption is already in `CLAUDE.md`; two
+  things are not.** It made the citation gate fail with the misleading
+  `path '.py' does not exist`, and the workaround in #408 is
+  `<!-- markdownlint-disable MD050 -->` scoped around the ledger. It also normalizes
+  `_x_` → `*x*` across a **whole** changelog file you touch. **Fold these two into the
+  existing `CLAUDE.md` bullet at 5e; do not re-state the corruption itself.**
 
-**These four have settled and belong in `CLAUDE.md` — graduate them in 5e, which touches
-that file anyway.** They are kept here, condensed, because they are *not* there yet:
-
-- **A registration rule and a resolution rule live in different tables; you find the
-  reassuring one first.** "Installing it shadows nothing" ≠ "a bare name resolves to it".
-  Ask what resolves it *at call time*. No test and no green CI catches a wrong reassurance.
-- **Your own test can enshrine the defect you just introduced** — written beside its fix,
-  it inherits the fix's misconception, and mutation testing is blind because mutant and
-  test agree. When a fix has a *direction*, state it as an invariant in code.
-- **A surviving mutant usually indicts the test, not the fix.** Assert the classification,
-  not the downstream outcome, when the outcome has more than one possible cause.
-- **A fix can silently disarm an existing regression test and the suite stays green.**
-  When a change alters an exit code, return value or error type, grep for tests provoking
-  the OLD behaviour.
+**Four settled traps to graduate into `CLAUDE.md` at 5e** (it touches that file anyway).
+Titles only — the full text is in `git log -- plans/HANDOFF.md` at `4cbaaad5`:
+registration-rule vs resolution-rule; your own test can enshrine the defect it was written
+beside; a surviving mutant usually indicts the test, not the fix; a fix can silently disarm
+an existing regression test.
 
 Also unresolved and blocking nothing: the founder flagged plugin `requirements-analyst`'s
 `model: sonnet` as unratified.
-
-**Standing:** the example corpus is regenerated wholesale after framework changes, so
-corpus-remediation findings are deferred to that regen. IPLAN ↔ iplanic integration is
-deferred (`plans/IPLAN-IPLANIC-DEFERRED.md`).
 
 ## Stale advice — a fresh session will find these referenced, and they are FIXED
 
 | Stale claim | Reality |
 |---|---|
-| "no authoring surface computes SHA-256 in-prompt any more" (`ROADMAP.md:113`, `platforms/hermes/CHANGELOG.md` `[0.12.0]`, `plans/IDGEN-NO-GENERATOR-PLAN.md`) | **Still false, in a narrower way.** #406 closed the plugin-SKILL and Hermes-reference halves; `agent-skills/**/SKILL.md` is reached by no root and `sdd-orchestrator/SKILL.md:667` still hashes. `ROADMAP.md` also dates the claim to Hermes `0.12.0`, which was never true |
-| "`--admin` is required on every PR" (`aidoc-flow-ci#322`) | **Fixed at `ci/v2.16.0`.** Every PR since #378, most recently #420, reached mergeable with no `--admin`. Do not re-add PR numbers to this row — it is the one that accretes |
-| "Branch protection requires the phantom `Lint / format / security hooks`, so every PR is BLOCKED" | **Fixed.** The six required contexts, re-confirmed green on #420, are `call / Lint / format / security hooks`, `call / composition`, `call / ai-review`, `call / verify`, `Framework + platform conformance`, `Acceptance tier (deterministic)`. `call / trust` and `Hermes pytest` are **not** required |
+| "`--admin` is required on every PR" ([aidoc-flow-ci#322](https://github.com/vladm3105/aidoc-flow-ci/issues/322)) | **Fixed at `ci/v2.16.0`.** Every PR since #378 has reached mergeable with no `--admin`. Do not re-add PR numbers to this row — it is the one that accretes |
+| "Branch protection requires the phantom `Lint / format / security hooks`, so every PR is BLOCKED" | **Fixed.** The six required contexts are `call / Lint / format / security hooks`, `call / composition`, `call / ai-review`, `call / verify`, `Framework + platform conformance`, `Acceptance tier (deterministic)`. `call / trust` and `Hermes pytest` are **not** required |
 | `AIDOC-CI-COMPOSITION-CHECK-PRHEAD` — "`call / composition` is structurally unsatisfiable on a PR head" | **Stale.** composition reports success on PR heads. A reviewer once read this entry as proof that required checks gate nothing here, and it nearly killed a correct plan |
 | Three pin-currency claims: `NO-PIN-CURRENCY-CHECK`, `PIN-CURRENCY-NO-READER`, `PIN-CURRENCY-READER-PLAN.md:465`/`:469` | **All three dead.** The check runs on every weekly `standards-drift`; the reader SHIPPED at #392 and consumes the completed run's **log**; V14 exercised close-on-clean for real |
-| `plans/PLAN-*.md` as the governance-PR plan glob (`CHANGELOG.md`, `CI-CANON-V2.16-MIGRATION-PLAN.md:468`/`:784`) | **Fixed in `CLAUDE.md`** (#387/#390). The glob is a **suffix** — `plans/*-PLAN.md`. Merged plans and the CHANGELOG keep the old string as history; `CLAUDE.md` is the live rule |
+
+**Standing:** the example corpus is regenerated wholesale after framework changes, so
+corpus-remediation findings are deferred to that regen. IPLAN ↔ iplanic integration is
+deferred (`plans/IPLAN-IPLANIC-DEFERRED.md`).

--- a/plans/PLUGIN-PREPROD-001-PLAN.md
+++ b/plans/PLUGIN-PREPROD-001-PLAN.md
@@ -4,7 +4,7 @@
 | -------------- | ----------------------------------------------------------- |
 | Task           | PLUGIN-PREPROD-001                                           |
 | Type           | bugfix                                                       |
-| Status         | Draft                                                        |
+| Status         | In Progress (`Draft` → `In Progress` 2026-08-02; PRs 1–4 and 5a–5b merged, 5c–5e remain) |
 | Depends on     | none                                                         |
 | Feeds          | the `claude-code-plugin/v0.25.0` tag + first public marketplace announcement |
 | Version impact | plugin MINOR (`0.24.0` → `0.25.0`); **Hermes: no version bump** (founder decision O2 — see Risks); framework spec unchanged |
@@ -291,10 +291,62 @@ copy).
 
 ### PR 5 — docs, governance, and the release cut
 
-- **M7** — `SECURITY.md`: correct the spec version and replace the scanner list
-  with what CI actually runs — semgrep (SAST), osv-scanner (dependencies),
-  gitleaks (secrets), `trivy config` (IaC) and CodeQL. The draft's list was
-  itself incomplete: it omitted trivy and CodeQL.
+**PR 5 ships as five stages (a–e), not one PR.** § "Docs to update" (`:526`, PR-5
+sentence at `:532-536`) lists eight documents of record for this PR against the
+≤3-surface Governance PR cap, and this plan says to split (`:547`). The split
+is **measured**, not proposed:
+
+| Stage | Surfaces | State |
+|---|---|---|
+| 5a | the release changelog gate | **done** — #420 |
+| 5b | `SECURITY.md` + `CHANGELOG.md` (M7) | **done** — #422 |
+| 5c ⛔ **FOUNDER-GATED** | `VERSION` `0.24.0`→`0.25.0` + the 60-file fanout + both CHANGELOGs | next |
+| 5d | `ROADMAP.md` (M8) + `plans/DECISIONS.md` (`D-00NN`) + `plans/FRAMEWORK-TODO.md` (close the batch) | |
+| 5e | this plan (the corrections below + status → `Completed`) + `plans/HANDOFF.md` + `CLAUDE.md` | |
+
+**5c cannot be split** — see O2 (`:424`, risk row `:557`) and `:538-545`: the `sync-version-refs`
+pre-commit hook re-stages its own writes, so the diff cannot be separated after
+the fact, and it rewrites `CLAUDE.md`, which pulls the stage under Governance PR
+discipline. The Hermes case was resolved by skipping the bump (O2); the plugin
+cannot skip, since M6 needs `0.25.0`. So 5c requires Rule 1's stated exception:
+**explicit founder OK plus an audit-trail line in the commit message.** It is not
+self-grantable, and one stage exceeding the cap is not evidence the split is
+wrong.
+
+**⚠️ Four claims in this plan were falsified by the work that implemented it.
+5e must correct all four — not only the one that is easiest to see.**
+
+⚠️ These are **self-references, and every edit to this file shifts them.** Each is
+quoted as well as cited — match the quote, not the number, if they disagree.
+
+1. **`:344` (M7) — "replace the scanner list" is wrong.** #422 deliberately did
+   not replace it: the existing list was *incomplete*, not false, and replacing it
+   would have deleted four accurate `pre-commit` entries (`bandit`,
+   `detect-secrets`, `detect-private-key`, `pip-audit`). The shipped fix splits
+   the list **by configuring file** — CI scanners under `.github/workflows/`,
+   local/CI hooks in `.pre-commit-config.yaml` — and records which of them can
+   actually block a merge.
+2. **`:602` (claim-ledger row 34) is false.** It reads "`SECURITY.md` names
+   scanners CI does not run | bandit". `.github/workflows/pre-commit.yml` **does**
+   run bandit in CI, inside the required `call / Lint / format / security hooks`
+   context. A plan marked `Completed` while carrying a falsified ledger row is the
+   exact failure the ledger exists to prevent.
+3. **`:367-368` — the README prerequisites section already shipped in PR 1.**
+   Do not re-add it. (`:404` assigns it to PR 1; the two rows disagree.)
+4. **`:262-269` — the `--threshold` bullet is doubly stale.** PR 3 made the flag
+   live. The 5c changelog entry must say *that*, not restate either version of the
+   old claim.
+
+Also to fix at 5e: the § "File structure" row at **`:378`** names
+`tests/conformance/test_agent_frontmatter.py`; it shipped at
+`tests/conformance/platforms/test_agent_frontmatter.py` (`PREPROD-PLAN-TESTPATH`).
+
+- **M7** — `SECURITY.md`: correct the spec version and the scanner list.
+  ⚠️ **Superseded in part — read correction 1 above before acting on this
+  bullet.** Original text: "replace the scanner list with what CI actually runs —
+  semgrep (SAST), osv-scanner (dependencies), gitleaks (secrets), `trivy config`
+  (IaC) and CodeQL. The draft's list was itself incomplete: it omitted trivy and
+  CodeQL." The omission half was right and shipped; the *replace* half was not.
 - **M8** — `ROADMAP.md`: correct the stale plugin version.
 - **M6** — cut `claude-code-plugin/v0.25.0` and publish a GitHub Release. The
   latest Release is six versions stale, which is what a visitor sees first.


### PR DESCRIPTION
Session wrap for [#422](https://github.com/vladm3105/aidoc-flow-framework/pull/422)
(`4cbaaad5`). Volatile sections rewritten, not appended. **Three surfaces**, at the
Rule 1 governance cap: `plans/HANDOFF.md`, `plans/FRAMEWORK-TODO.md`,
`plans/PLUGIN-PREPROD-001-PLAN.md`. No code or CI touched, so no `CHANGELOG.md` entry.

## The structural change

PR 5's stage table, its unsplittability argument, and this plan's own falsified claims
moved **out** of the handoff and **into** `PLUGIN-PREPROD-001-PLAN.md` § "PR 5". They are
durable plan content, and the handoff is deleted at every merge — the previous revision
was the only record of a five-stage split that the plan itself still described as one PR.
The handoff now points at it.

## Corrections found by pre-push review

Four agents on the diff. Each of these was a false or misdirecting claim in the
regenerated handoff, not in the text it replaced:

| Claim | Reality |
|---|---|
| § "Docs to update" is at `:330-354` | It is `:526`; PR-5 sentence `:532-536`. The cited range was the `### Modified` table, whose PR-5 rows list **eleven paths**, not eight documents of record — so the "eight" was derivable only from the section that was not cited |
| "PRs #415, #418, #420 and #422 **each did**" 2 surfaces + CHANGELOG | #420 and #422 used **one** real surface; #415 touched twelve. Restated as a ceiling with no roster — the same file forbids accreting PR numbers four rows further down |
| "bandit/detect-secrets/detect-private-key are the **only** security tools that can block a merge" | Dropped two qualifiers: `SECURITY.md:66` names **push protection** as the one non-check control that blocks, and bandit is scoped to `platforms/hermes/src/` + `tests/`. Both restored, with a `gh api` re-derivation command — the claim now lives in a public file and branch protection is mutable |
| "a fold introduces false claims **at about the rate** it removes them" | A ratio with one side never tallied. A measured net-neutral rate argues for *skipping* a fold cycle — the opposite of the point. Rewritten as the three measured instances |
| `CONTRIBUTING.md`'s `detect-secrets` row "says staged files — false in CI" | The row is explicitly scoped `(local)` and is **not** false; the gap is a **missing row** for the required CI job. Acting on the old wording would have deleted an accurate scope — the same mistake #422 refused to make at M7 |

## New finding — [#423](https://github.com/vladm3105/aidoc-flow-framework/issues/423)

`scripts/sync-version-refs.sh:180` writes the **sibling repo**
`../web-site/src/pages/index.astro`. That badge reads `Pre-release v0.20.1`, so the grep
for the previous value misses and `replace_in_file` returns 0 **without logging**. The
public site is five minors stale and it is self-sealing — no future bump will repair it.

It is invisible to the prescribed throwaway-clone test, which has no sibling to write to.
So the previous revision's "the fanout was **clean**" claim was true about everything the
clone could observe, and structurally blind to the one write that leaves the repo. PR 5c
must repair the badge by hand in a `web-site` PR.

## Also

- **Plan status `Draft` → `In Progress`**, six merged PRs late, per the plan-status
  governance rule. It contradicted the handoff on its face.
- **Three parked #422 findings became real `FRAMEWORK-TODO.md` entries**, plus
  `SYNC-SECRET-SCANNING-KNOBS` (two secret-scanning knobs off — founder decision). The
  handoff had carried them under a heading reading "owned by no stage yet": open work
  parked in the one file guaranteed to be deleted.
- **Every cross-file citation re-derived after the edits shifted them — twice.** The plan
  insertion moved every line after `:292`, and the follow-up edits moved them again. The
  plan's self-references now carry an explicit warning to match the quote, not the number.

## Size

**251 lines, down from 276**, while *adding* the 5c propagation procedure and the
`web-site` warning. The remaining excess is guardrails, not retained history; four settled
traps are queued for graduation into `CLAUDE.md` at 5e, which touches that file anyway.

## Verification

- `pre-commit run` on all three files: green, markdownlint clean on two consecutive runs.
- Conformance suite: passed (pre-commit hook).
- Every `file:line` in added text re-derived against source; #423's body read back at
  3,733 chars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
