### PR TITLE
docs(preprod): close 22 of 23 findings, M8 + D-0074 — PLUGIN-PREPROD-001 PR 5d

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,7 +53,7 @@ Near-term, in-flight work.
 
 Planned, scoped, not yet started.
 
-- **Claude Code plugin `1.0` cut** — the plugin ships as a pre-1.0 preview (`0.23.4`).
+- **Claude Code plugin `1.0` cut** — the plugin ships as a pre-1.0 preview (`0.25.0`).
   The enumerated gates for the `1.0` release (consolidated from the 2026-07-11 pre-prod
   audit; previously scattered across `CLAUDE.md` / stubs):
   1. **Hermes parity** — Hermes no longer lags the plugin on the recent spec (see the
@@ -110,6 +110,23 @@ Strategic direction.
 Headline capabilities now in the framework (full detail in
 [`CHANGELOG.md`](CHANGELOG.md)):
 
+- **PLUGIN-PREPROD-001 (2026-08-02, plugin `0.25.0`).** The pre-production
+  hardening that unblocked the plugin deploy: a five-lens review returned
+  **BLOCKER** on 2026-07-31 with 23 findings, and 22 are closed across five
+  staged PRs ([#410](https://github.com/vladm3105/aidoc-flow-framework/pull/410),
+  [#413](https://github.com/vladm3105/aidoc-flow-framework/pull/413),
+  [#415](https://github.com/vladm3105/aidoc-flow-framework/pull/415),
+  [#418](https://github.com/vladm3105/aidoc-flow-framework/pull/418), and PR 5's
+  stages). The review hook no longer executes code from the user's working
+  directory and gates on project adoption; the permission-model bypass is
+  disclosed and opt-in; the saga driver cannot wedge permanently or report `PASS`
+  on reviews that never ran, and its exit codes distinguish terminal states;
+  missing PyYAML or an unmet Python floor is diagnosed rather than surfaced as
+  lint findings; shipped agents declare their tools; the plugin ships its
+  `LICENSE`. **The 23rd finding (M6) is open**: cutting the
+  `claude-code-plugin/v0.25.0` tag and publishing the GitHub Release are
+  outward-facing acts, still founder-gated, so the latest published Release
+  remains `claude-code-plugin/v0.18.0`.
 - **IDGEN-NO-GENERATOR (2026-07-26, plugin `0.24.0`, Hermes `0.12.0`).** The
   element-ID generator ships (`rehash --compute`), and no authoring surface
   computes SHA-256 in-prompt any more. 25 surfaces rewritten: BRD calls the tool;

--- a/plans/DECISIONS.md
+++ b/plans/DECISIONS.md
@@ -10,6 +10,94 @@ graduation.
 
 ---
 
+## D-0074 — Ship a safety fix quieter than the behaviour it replaces, and make the bypass it needs opt-in and disclosed
+
+**2026-08-02.** Decisions from `PLUGIN-PREPROD-001`
+(`plans/PLUGIN-PREPROD-001-PLAN.md`), shipped across PRs
+[#410](https://github.com/vladm3105/aidoc-flow-framework/pull/410),
+[#413](https://github.com/vladm3105/aidoc-flow-framework/pull/413),
+[#415](https://github.com/vladm3105/aidoc-flow-framework/pull/415),
+[#418](https://github.com/vladm3105/aidoc-flow-framework/pull/418) and PR 5, and
+recorded here at stage 5d because the two choices below are **policy embedded in
+shipped code** — the class `plans/DECISIONS.md` exists to authorize. Both cross
+PR boundaries, which is why neither was filed in the PR that implemented it.
+**Supersedes nothing.**
+
+**1. The permission-model bypass stays available, but opt-in and disclosed —
+rather than removed.** Nine autopilot skills mandated
+`--dangerously-skip-permissions` on the child sessions they spawn, and no shipped
+file said so. Three options were on the table: delete the bypass (breaks
+unattended cascades, which are the feature), keep it silent (the status quo, and
+indefensible for a marketplace plugin a stranger installs), or gate it. Gating
+won: `tools/saga_driver.py` defaults `allow_skip_permissions` to `False`
+(`:261`), appends the flag only when explicitly set (`:569-570`), and
+`platforms/claude-code-plugin/README.md:33-44` discloses what the flag does
+before anyone installs.
+
+**The reasoning that makes this a decision and not an implementation detail:**
+the safe default is the one that *cannot* silently widen a stranger's trust
+boundary, even though it is the default that makes the headline feature
+(hands-off cascade) require an explicit argument. We accepted a worse
+out-of-the-box demo for a defensible install.
+
+⚠️ **The invariant IS guarded — but not by the gate whose name suggests it, and
+not everywhere.** Stating this precisely, because the imprecise version ("the
+invariant is no longer measured") is false and was nearly recorded here:
+
+- **Covered:** conformance asserts the property — `test_bypass_absent_by_default`
+  and `test_flag_defaults_off` (`tests/conformance/test_saga_driver_recovery.py:88`,
+  `:114`) prove the driver ships the bypass off, and
+  `test_driver_invocation_passes_the_permission_flag`
+  (`tests/conformance/platforms/test_autopilot_saga_parity.py:105`) pins which
+  skills opt in.
+- **Not covered:** the *release* gate
+  (`tests/release/test_marketplace_gate.py:42`) greps `skills/**/SKILL.md` for the
+  literal `--dangerously-skip-permissions`. PR 3 moved the mechanism behind
+  `--allow-skip-permissions`, which that string does not match — so the gate still
+  runs, still forbids the **old** spelling, and no longer measures the **live**
+  one. And `skill_dirs()` scans `skills/` only, so a `commands/` or `agents/`
+  surface enabling a bypass is outside both.
+
+Tracked as `PREPROD-B2-GATE-SCOPE`, whose fix is to assert the *property* rather
+than a spelling. **The lesson worth more than the finding: a gate that greps a
+literal stops measuring the moment the implementation is renamed, and it keeps
+passing — so a green gate named for an invariant is not evidence the invariant
+holds.**
+
+**2. A hook that used to always speak now defaults to nudge-only, and that is a
+deliberate regression in visibility.** The review hook behaved unconditionally as
+`verbose`; the documented `review_hook` enum (`on`/`off`/`verbose`) was unwired
+entirely. Wiring it meant choosing which value becomes the default, and the
+documented default was `on` — quieter than the shipped behaviour. We honoured the
+**documentation** over the **behaviour**, so existing users lose output they had.
+
+Rationale: the hook fires on every file edit, and the same PR gated it on project
+adoption (`PREPROD-H1`) precisely because it was emitting findings in repos that
+never adopted the framework. A hook that is both always-on and always-verbose is
+the shape that gets uninstalled. Recovery is one line —
+`review_hook: "verbose"` in `.claude/aidoc-flow.config.yaml` — and it is
+documented, which is the condition that made the regression acceptable.
+
+**3. Where a fix had a documentation option, we took it only when the mechanical
+half was separately tracked.** `PREPROD-L7` (a shipped `code-reviewer` agent can
+collide with a consumer's own) allowed either a rename or documenting the
+collision. Documentation shipped. That is defensible **only** because the live
+half — every dispatch reference the plugin ships is a *bare* name, and a bare
+name resolves by scope precedence where a plugin ranks lowest of five — is
+carried by `PREPROD-L7-BARE-DISPATCH`
+([#417](https://github.com/vladm3105/aidoc-flow-framework/issues/417)). Closing
+L7 on documentation without that successor entry would have been closing a
+partial finding. **The general rule: a documentation-only closure needs a named
+owner for the mechanism, or it is not a closure.**
+
+**4. What was NOT decided here.** The `claude-code-plugin/v0.25.0` tag and the
+public GitHub Release (finding **M6**) are outward-facing acts that remain
+founder-gated; the version cut in PR 5c is not a release. `PREPROD-M6` stays open
+under `## Open` for exactly that reason, and it is the only member of the 23-item
+batch that does.
+
+---
+
 ## D-0073 — Read the run that already ran; and a reader for a warning-only signal must itself fail loudly
 
 **2026-07-31.** Decisions from `PIN-CURRENCY-NO-READER`

--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -241,7 +241,7 @@
   **Not done in PR 3:** the plan forbids amending that gate, and PR 5 cuts the
   release off it.
 
-### `[plugin]` `PLUGIN-PREPROD-001` — the pre-prod review queue (23 findings, one entry each below)
+### `[plugin]` `PLUGIN-PREPROD-001` — the pre-prod review queue — ⏳ OPEN ON RESIDUAL (22 of 23 findings closed 2026-08-02 across PRs #410/#413/#415/#418/#422 + PR 5; **M6 — the `claude-code-plugin/v0.25.0` tag cut and the public GitHub Release — is founder-gated and still open**)
 
 - *Context:* a five-lens pre-production review of `platforms/claude-code-plugin`
   on 2026-07-31 returned **BLOCKER**. Every blocker and HIGH was reproduced
@@ -259,205 +259,12 @@
   platform with its own runtime surface. Plugin runtime and packaging items carry
   it; linter, harness and doc items keep their existing tags.
 
-### `[plugin]` `PREPROD-B1` — the review hook executes code from the user's working directory
-
-- *Context:* `hooks/sdd-doc-review.sh:43` (pre-PR-1) invokes the linter with `python3 -m`,
-  which puts the CWD ahead of `PYTHONPATH`. A `sdd_doc_lint/` package in any
-  cloned repo shadows the vendored one; reproduced — the payload ran and the hook
-  still exited 0.
-- *Fix shape:* `PYTHONSAFEPATH=1` on the invocation. Invoking `__main__.py` by
-  absolute path is **not** an alternative — it fails the relative imports.
-- *Stage:* PR 1.
-
-### `[plugin]` `PREPROD-B2` — nine skills mandate a permission-model bypass disclosed in no shipped file
-
-- *Context:* `tools/saga_driver.py:398` spawns child sessions with
-  `--dangerously-skip-permissions`, and nine autopilot skills name the driver as
-  the MANDATORY orchestration step (e.g.
-  `skills/doc-brd-autopilot/SKILL.md:85`). Zero shipped `.md`/`.json` discloses it.
-- *Fix shape:* make the bypass opt-in behind a flag the skills pass explicitly,
-  and disclose it. A doc-only disclosure would strip the bypass from the plugin's
-  primary path, since every invoker passes only `--layer`.
-- *Stage:* PR 3. The literal flag string must not reach a `SKILL.md` —
-  `tests/release/test_marketplace_gate.py:39` fails the release if it does.
-
-### `[plugin]` `PREPROD-B3` — the saga driver can wedge permanently and can report PASS on reviews that never ran
-
-- *Context:* three distinct sub-defects. **B3a** — an illegal transition raises
-  (`saga_driver.py:305`) and `PARTIAL_TIMEOUT` is unreachable from
-  `BRANCH_FAILED`/`BRANCH_COMPENSATING`/`SYNTHESIZED` (`:47`, `:48`, `:51`), so
-  four call sites can wedge. **B3b** — `dispatch_phase` writes its stale
-  in-memory dict back after the subprocess returns (`:406`), discarding
-  transitions the child wrote. **B3c** — the resume filter ignores transition
-  scope (`:370`).
-- *Fix shape:* a forced-transition path plus write-ordering, not a redesign of
-  the transition table. B3c must use `t.get("scope", "run")` — a bare `== "run"`
-  fails the existing scope-less fixture (`tests/conformance/test_saga_driver_invariants.py:71`).
-- *Stage:* PR 3.
-
-### `[lint]` `PREPROD-B4` — PyYAML and Python ≥3.11 are undeclared, and their absence is reported as lint findings
-
-- *Context:* `tools/sdd_doc_lint/__init__.py:30` imports `yaml` unguarded and
-  `:27` requires `StrEnum` (3.11+). Either absence exits 1 — the same code the
-  hook reads as structural findings — so a traceback is injected into model
-  context labelled as a finding.
-- *Fix shape:* a distinct exit code (3) plus a diagnostic naming the dependency,
-  and a hook-side filter that forwards only lines matching the finding grammar.
-- *Stage:* PR 1 (hook half) and PR 2 (linter half).
-
-### `[plugin]` `PREPROD-H1` — the hook emits findings in repos that never adopted the framework
-
-- *Context:* the plugin bundles a registry and `find_registry`
-  (`tools/sdd_doc_lint/__init__.py:46`) falls back to the module's own location,
-  so the documented "skip silently when there is no framework/" path is
-  unreachable once installed.
-- *Fix shape:* gate findings on an adoption marker — the scaffolded
-  `<docs_root>/0N_<ARTIFACT>/` tree, or a project-local registry / `.aidoc/`
-  found by walking up. Bound the walk at `$HOME`: a user-global
-  `~/.aidoc/profile.yaml` is documented and would otherwise make every project
-  under `$HOME` pass.
-- *Stage:* PR 1.
-
-### `[plugin]` `PREPROD-H2` — the documented `review_hook` on/off/verbose enum is unwired
-
-- *Context:* `docs/CONFIG.md` documents three values controlling the hook
-  (`review_hook:` in the schema block).
-  The hook reads no config at all, so there is no way to turn it off.
-- *Fix shape:* locate `.claude/aidoc-flow.config.yaml` by walking up from the
-  edited file (not from the CWD) and honour the enum. Parse with `grep`/`sed` —
-  the hook must keep working when Python or PyYAML is absent.
-- *Stage:* PR 1. Note the default `on` becomes quieter than today's behavior,
-  which is `verbose`.
-
-### `[plugin]` `PREPROD-H3` — untrusted file content crosses into instruction context unframed
-
-- *Context:* `hooks/sdd-doc-review.sh:45` (pre-PR-1) concatenates linter output
-  onto an instruction string, and `:34` interpolates the filename. Finding messages quote
-  raw tokens from the document (`tools/sdd_doc_lint/__init__.py:642`).
-- *Fix shape:* an explicit `<untrusted-tool-output source="...">` envelope
-  preceded by a sentence stating it is data, not instructions; the same framing
-  for the filename.
-- *Stage:* PR 1.
-
-### `[plugin]` `PREPROD-M1` — the hook declares no timeout
-
-- *Context:* `hooks/hooks.json` (pre-PR-1) declared a `PostToolUse` command with
-  no `timeout`, so a hung linter hung the edit.
-- *Fix shape:* `"timeout": 15` in `hooks.json`. **Not** a `timeout 10` wrapper —
-  GNU `timeout` is absent on stock macOS, where the invocation returns 127.
-- *Stage:* PR 1.
-
-### `[plugin]` `PREPROD-M2` — one agent declares neither `tools:` nor `model:`
-
-- *Context:* `agents/requirements-analyst.md:3` is the only one of 11, so it
-  inherits every tool including `Write`, `Edit` and `Bash`.
-- *Fix shape:* scope it to match its siblings; add a conformance test asserting
-  every agent declares both.
-- *Stage:* PR 4.
-
-### `[plugin]` `PREPROD-M3` — the driver wraps the child in GNU `timeout`, absent on stock macOS
-
-- *Context:* `tools/saga_driver.py:393`. On macOS the invocation returns 127 and
-  the driver's subprocess half is dead.
-- *Fix shape:* probe for it, or implement the bound in-process.
-- *Stage:* PR 3.
-
-### `[plugin]` `PREPROD-M4` — `main()` returns 0 regardless of terminal saga status
-
-- *Context:* `tools/saga_driver.py:732`, and again at `:679` straight after the
-  break circuit sets `PARTIAL_TIMEOUT`. Both return sites are the complete set.
-- *Fix shape:* a meaningful exit code. `tests/scripts/test-acceptance.sh:1177`
-  consumes it and records FAIL on non-zero, so the harness moves with it.
-- *Stage:* PR 3.
-
-### `[plugin]` `PREPROD-M5` — `verdict.json` is read with no freshness check and never unlinked
-
-- *Context:* `tools/saga_driver.py:425`. A stale verdict from a prior run is
-  indistinguishable from this run's.
-- *Fix shape:* unlink before dispatch, or stamp and verify the run id. Coerce
-  `int(... or 0)` before any score comparison.
-- *Stage:* PR 3.
-
 ### `[docs]` `PREPROD-M6` — the latest GitHub Release is six versions stale
 
 - *Context:* what a visitor to the repo sees first. Not a code defect.
 - *Fix shape:* cut `claude-code-plugin/v0.25.0` and publish a Release.
 - *Stage:* PR 5. **Founder-gated** — a tag cut and a public Release are
   outward-facing acts outside the AI auto-merge default.
-
-### `[docs]` `PREPROD-M7` — `SECURITY.md` names a stale spec version and scanners CI does not run
-
-- *Context:* `SECURITY.md:11` says `0.35.x`; `:49` names `bandit`. CI runs
-  semgrep, osv-scanner, gitleaks, `trivy config` and CodeQL.
-- *Fix shape:* correct both to what is true.
-- *Stage:* PR 5.
-
-### `[docs]` `PREPROD-M8` — `ROADMAP.md` states a stale plugin version
-
-- *Context:* `ROADMAP.md:56` says `0.23.4`.
-- *Fix shape:* correct it with the PR 5 bump.
-- *Stage:* PR 5.
-
-### `[plugin]` `PREPROD-L1` — the plugin declares MIT and ships no license text
-
-- *Context:* `.claude-plugin/plugin.json:10` declares `"license": "MIT"`; the
-  installed artifact contains no `LICENSE`.
-- *Fix shape:* add `platforms/claude-code-plugin/LICENSE`.
-- *Stage:* PR 4.
-
-### `[plugin]` `PREPROD-L2` — `--threshold` is accepted and ignored
-
-- *Context:* `tools/saga_driver.py:644` declares it; nothing reads it as a gate.
-  `CHANGELOG.md:1125` already claims the removal shipped — for the driver it
-  never did.
-- *Fix shape:* honour it. **Do not remove the flag** —
-  `tests/scripts/test-acceptance.sh:1175` passes `--threshold 90` on every
-  cascade layer, so deleting the argparse entry makes the driver exit 2 on a
-  usage error before any saga work.
-- *Stage:* PR 3.
-
-### `[plugin]` `PREPROD-L3` — `playbook_loader` joins caller-supplied segments with no traversal guard
-
-- *Context:* `tools/playbook_loader.py:18` `resolve_playbook_path`.
-- *Fix shape:* resolve and assert containment under the playbook root.
-- *Stage:* PR 3.
-
-### `[plugin]` `PREPROD-L4` — the hook's layer path test hardcodes `/docs/`
-
-- *Context:* `hooks/sdd-doc-review.sh:21` (pre-PR-1), defeating the configurable
-  `docs_root` (`docs/CONFIG.md:47`, documented with a trailing slash and
-  possibly multi-segment).
-- *Fix shape:* substitute the configured value, normalizing the trailing slash
-  and escaping regex metacharacters first.
-- *Stage:* PR 1.
-
-### `[lint]` `PREPROD-L5` — warning-severity findings can never reach the hook
-
-- *Context:* `tools/sdd_doc_lint/__main__.py:118` exits 0 unless a finding is
-  `error`, and the hook acts only on exit 1.
-- *Fix shape:* a `--warn-exit` flag — which closes nothing unless the hook passes
-  it, so the hook's invocation line moves in the same PR.
-- *Stage:* PR 2 (depends on PR 1).
-
-### `[docs]` `PREPROD-L6` — `marketplace.json` ships a personal email
-
-- *Context:* `.claude-plugin/marketplace.json:6`, on a public manifest.
-- *Fix shape:* a role address, if the founder wants it off the manifest.
-- *Stage:* PR 4.
-
-### `[plugin]` `PREPROD-L7` — `agents/code-reviewer.md` can collide with a consumer's own agent
-
-- *Context:* a generic name in a namespace the consumer shares.
-- *Fix shape:* rename under the plugin's namespace, or document the collision.
-- *Stage:* PR 4.
-
-### `[plugin]` `PREPROD-P1` — unreproduced `jq: Argument list too long` from the hook
-
-- *Context:* reported, never reproduced. The mechanism would be an unbounded
-  findings block reaching `jq`.
-- *Fix shape:* closed by construction — a file-size cap and a byte budget on the
-  findings block remove the mechanism.
-- *Stage:* PR 1.
 
 ### `[harness]` `RELEASE-TIER-STALE-SUBMODULE-PIN` — the release tier runs on every umbrella PR, against a framework checkout seven weeks stale
 
@@ -1328,6 +1135,212 @@
 - *Status:* OPEN — P3.
 
 ## Closed
+
+### `[plugin]` `PREPROD-B1` — the review hook executes code from the user's working directory — ✅ CLOSED (2026-08-02, #410, `3bbadbb1`)
+
+- *Context:* `hooks/sdd-doc-review.sh:43` (pre-PR-1) invokes the linter with `python3 -m`,
+  which puts the CWD ahead of `PYTHONPATH`. A `sdd_doc_lint/` package in any
+  cloned repo shadows the vendored one; reproduced — the payload ran and the hook
+  still exited 0.
+- *Fix shape:* `PYTHONSAFEPATH=1` on the invocation. Invoking `__main__.py` by
+  absolute path is **not** an alternative — it fails the relative imports.
+- *Stage:* PR 1.
+
+### `[plugin]` `PREPROD-B2` — nine skills mandate a permission-model bypass disclosed in no shipped file — ✅ CLOSED (2026-08-02, #415, `889d85c5` — bypass is opt-in and disclosed; conformance guards the property, but the release gate still greps the OLD literal and the scan misses `commands/`/`agents/` — carried by `PREPROD-B2-GATE-SCOPE`)
+
+- *Context:* `tools/saga_driver.py:398` spawns child sessions with
+  `--dangerously-skip-permissions`, and nine autopilot skills name the driver as
+  the MANDATORY orchestration step (e.g.
+  `skills/doc-brd-autopilot/SKILL.md:85`). Zero shipped `.md`/`.json` discloses it.
+- *Fix shape:* make the bypass opt-in behind a flag the skills pass explicitly,
+  and disclose it. A doc-only disclosure would strip the bypass from the plugin's
+  primary path, since every invoker passes only `--layer`.
+- *Stage:* PR 3. The literal flag string must not reach a `SKILL.md` —
+  `tests/release/test_marketplace_gate.py:39` fails the release if it does.
+
+### `[plugin]` `PREPROD-B3` — the saga driver can wedge permanently and can report PASS on reviews that never ran — ✅ CLOSED (2026-08-02, #415, `889d85c5`)
+
+- *Context:* three distinct sub-defects. **B3a** — an illegal transition raises
+  (`saga_driver.py:305`) and `PARTIAL_TIMEOUT` is unreachable from
+  `BRANCH_FAILED`/`BRANCH_COMPENSATING`/`SYNTHESIZED` (`:47`, `:48`, `:51`), so
+  four call sites can wedge. **B3b** — `dispatch_phase` writes its stale
+  in-memory dict back after the subprocess returns (`:406`), discarding
+  transitions the child wrote. **B3c** — the resume filter ignores transition
+  scope (`:370`).
+- *Fix shape:* a forced-transition path plus write-ordering, not a redesign of
+  the transition table. B3c must use `t.get("scope", "run")` — a bare `== "run"`
+  fails the existing scope-less fixture (`tests/conformance/test_saga_driver_invariants.py:71`).
+- *Stage:* PR 3.
+
+### `[lint]` `PREPROD-B4` — PyYAML and Python ≥3.11 are undeclared, and their absence is reported as lint findings — ✅ CLOSED (2026-08-02, #410 + #413, `3bbadbb1` + `f0dc63f3` — hook half PR 1, linter half PR 2)
+
+- *Context:* `tools/sdd_doc_lint/__init__.py:30` imports `yaml` unguarded and
+  `:27` requires `StrEnum` (3.11+). Either absence exits 1 — the same code the
+  hook reads as structural findings — so a traceback is injected into model
+  context labelled as a finding.
+- *Fix shape:* a distinct exit code (3) plus a diagnostic naming the dependency,
+  and a hook-side filter that forwards only lines matching the finding grammar.
+- *Stage:* PR 1 (hook half) and PR 2 (linter half).
+
+### `[plugin]` `PREPROD-H1` — the hook emits findings in repos that never adopted the framework — ✅ CLOSED (2026-08-02, #410, `3bbadbb1`)
+
+- *Context:* the plugin bundles a registry and `find_registry`
+  (`tools/sdd_doc_lint/__init__.py:46`) falls back to the module's own location,
+  so the documented "skip silently when there is no framework/" path is
+  unreachable once installed.
+- *Fix shape:* gate findings on an adoption marker — the scaffolded
+  `<docs_root>/0N_<ARTIFACT>/` tree, or a project-local registry / `.aidoc/`
+  found by walking up. Bound the walk at `$HOME`: a user-global
+  `~/.aidoc/profile.yaml` is documented and would otherwise make every project
+  under `$HOME` pass.
+- *Stage:* PR 1.
+
+### `[plugin]` `PREPROD-H2` — the documented `review_hook` on/off/verbose enum is unwired — ✅ CLOSED (2026-08-02, #410, `3bbadbb1`)
+
+- *Context:* `docs/CONFIG.md` documents three values controlling the hook
+  (`review_hook:` in the schema block).
+  The hook reads no config at all, so there is no way to turn it off.
+- *Fix shape:* locate `.claude/aidoc-flow.config.yaml` by walking up from the
+  edited file (not from the CWD) and honour the enum. Parse with `grep`/`sed` —
+  the hook must keep working when Python or PyYAML is absent.
+- *Stage:* PR 1. Note the default `on` becomes quieter than today's behavior,
+  which is `verbose`.
+
+### `[plugin]` `PREPROD-H3` — untrusted file content crosses into instruction context unframed — ✅ CLOSED (2026-08-02, #410, `3bbadbb1`)
+
+- *Context:* `hooks/sdd-doc-review.sh:45` (pre-PR-1) concatenates linter output
+  onto an instruction string, and `:34` interpolates the filename. Finding messages quote
+  raw tokens from the document (`tools/sdd_doc_lint/__init__.py:642`).
+- *Fix shape:* an explicit `<untrusted-tool-output source="...">` envelope
+  preceded by a sentence stating it is data, not instructions; the same framing
+  for the filename.
+- *Stage:* PR 1.
+
+### `[plugin]` `PREPROD-M1` — the hook declares no timeout — ✅ CLOSED (2026-08-02, #410, `3bbadbb1`)
+
+- *Context:* `hooks/hooks.json` (pre-PR-1) declared a `PostToolUse` command with
+  no `timeout`, so a hung linter hung the edit.
+- *Fix shape:* `"timeout": 15` in `hooks.json`. **Not** a `timeout 10` wrapper —
+  GNU `timeout` is absent on stock macOS, where the invocation returns 127.
+- *Stage:* PR 1.
+
+### `[plugin]` `PREPROD-M2` — one agent declares neither `tools:` nor `model:` — ✅ CLOSED (2026-08-02, #418, `81a3b7a6`)
+
+- *Context:* `agents/requirements-analyst.md:3` is the only one of 11, so it
+  inherits every tool including `Write`, `Edit` and `Bash`.
+- *Fix shape:* scope it to match its siblings; add a conformance test asserting
+  every agent declares both.
+- *Stage:* PR 4.
+
+### `[plugin]` `PREPROD-M3` — the driver wraps the child in GNU `timeout`, absent on stock macOS — ✅ CLOSED (2026-08-02, #415, `889d85c5`)
+
+- *Context:* `tools/saga_driver.py:393`. On macOS the invocation returns 127 and
+  the driver's subprocess half is dead.
+- *Fix shape:* probe for it, or implement the bound in-process.
+- *Stage:* PR 3.
+
+### `[plugin]` `PREPROD-M4` — `main()` returns 0 regardless of terminal saga status — ✅ CLOSED (2026-08-02, #415, `889d85c5`)
+
+- *Context:* `tools/saga_driver.py:732`, and again at `:679` straight after the
+  break circuit sets `PARTIAL_TIMEOUT`. Both return sites are the complete set.
+- *Fix shape:* a meaningful exit code. `tests/scripts/test-acceptance.sh:1177`
+  consumes it and records FAIL on non-zero, so the harness moves with it.
+- *Stage:* PR 3.
+
+### `[plugin]` `PREPROD-M5` — `verdict.json` is read with no freshness check and never unlinked — ✅ CLOSED (2026-08-02, #415, `889d85c5`)
+
+- *Context:* `tools/saga_driver.py:425`. A stale verdict from a prior run is
+  indistinguishable from this run's.
+- *Fix shape:* unlink before dispatch, or stamp and verify the run id. Coerce
+  `int(... or 0)` before any score comparison.
+- *Stage:* PR 3.
+
+### `[docs]` `PREPROD-M7` — `SECURITY.md` names a stale spec version and scanners CI does not run — ✅ CLOSED (2026-08-02, #422, `4cbaaad5`)
+
+- *Context:* `SECURITY.md`'s supported-versions table pinned a **stale spec
+  version** (`0.35.x`, against a `framework/VERSION` that had moved on), and its
+  automated-checks list was **incomplete** — it omitted `trivy config` and CodeQL,
+  and drew no line between the scanners configured in `.github/workflows/` and
+  those in `.pre-commit-config.yaml`.
+- ⚠️ *Correction (2026-08-02):* this entry originally read "`:49` names `bandit`",
+  implying `bandit` is a scanner CI does not run. **That is false.**
+  `.github/workflows/pre-commit.yml:37` calls canon's reusable, which runs
+  `pre-commit run --all-files`, so `bandit` (`.pre-commit-config.yaml:45-50`) does
+  run in CI, inside the required `call / Lint / format / security hooks` context.
+  The defect was an incomplete list plus a missing configuring-file distinction,
+  never a phantom scanner. The plan carries the same falsification as its
+  correction 2 against claim-ledger row 34; stage 5e fixes it there.
+- *No `→ #N`:* found and fixed in one session, so no issue was opened; recorded
+  here rather than filed retroactively.
+- *Fix shape:* correct both to what is true.
+- *Stage:* PR 5.
+
+### `[docs]` `PREPROD-M8` — `ROADMAP.md` states a stale plugin version — ✅ CLOSED (2026-08-02, PR 5d — `ROADMAP.md:56` now reads `0.25.0`)
+
+- *Context:* `ROADMAP.md:56` says `0.23.4`.
+- *Fix shape:* correct it with the PR 5 bump.
+- *Stage:* PR 5.
+
+### `[plugin]` `PREPROD-L1` — the plugin declares MIT and ships no license text — ✅ CLOSED (2026-08-02, #418, `81a3b7a6`)
+
+- *Context:* `.claude-plugin/plugin.json:10` declares `"license": "MIT"`; the
+  installed artifact contains no `LICENSE`.
+- *Fix shape:* add `platforms/claude-code-plugin/LICENSE`.
+- *Stage:* PR 4.
+
+### `[plugin]` `PREPROD-L2` — `--threshold` is accepted and ignored — ✅ CLOSED (2026-08-02, #415, `889d85c5` — the flag survives and now gates a `PASS`; it was never removed)
+
+- *Context:* `tools/saga_driver.py:644` declares it; nothing reads it as a gate.
+  `CHANGELOG.md:1494` (and `platforms/claude-code-plugin/CHANGELOG.md:186`) already claims the removal shipped — for the driver it
+  never did.
+- *Fix shape:* honour it. **Do not remove the flag** —
+  `tests/scripts/test-acceptance.sh:1175` passes `--threshold 90` on every
+  cascade layer, so deleting the argparse entry makes the driver exit 2 on a
+  usage error before any saga work.
+- *Stage:* PR 3.
+
+### `[plugin]` `PREPROD-L3` — `playbook_loader` joins caller-supplied segments with no traversal guard — ✅ CLOSED (2026-08-02, #415, `889d85c5`)
+
+- *Context:* `tools/playbook_loader.py:18` `resolve_playbook_path`.
+- *Fix shape:* resolve and assert containment under the playbook root.
+- *Stage:* PR 3.
+
+### `[plugin]` `PREPROD-L4` — the hook's layer path test hardcodes `/docs/` — ✅ CLOSED (2026-08-02, #410, `3bbadbb1`)
+
+- *Context:* `hooks/sdd-doc-review.sh:21` (pre-PR-1), defeating the configurable
+  `docs_root` (`docs/CONFIG.md:47`, documented with a trailing slash and
+  possibly multi-segment).
+- *Fix shape:* substitute the configured value, normalizing the trailing slash
+  and escaping regex metacharacters first.
+- *Stage:* PR 1.
+
+### `[lint]` `PREPROD-L5` — warning-severity findings can never reach the hook — ✅ CLOSED (2026-08-02, #413, `f0dc63f3`)
+
+- *Context:* `tools/sdd_doc_lint/__main__.py:118` exits 0 unless a finding is
+  `error`, and the hook acts only on exit 1.
+- *Fix shape:* a `--warn-exit` flag — which closes nothing unless the hook passes
+  it, so the hook's invocation line moves in the same PR.
+- *Stage:* PR 2 (depends on PR 1).
+
+### `[docs]` `PREPROD-L6` — `marketplace.json` ships a personal email — ✅ CLOSED (2026-08-02, #418, `81a3b7a6`)
+
+- *Context:* `.claude-plugin/marketplace.json:6`, on a public manifest.
+- *Fix shape:* a role address, if the founder wants it off the manifest.
+- *Stage:* PR 4.
+
+### `[plugin]` `PREPROD-L7` — `agents/code-reviewer.md` can collide with a consumer's own agent — ✅ CLOSED (2026-08-02, #418, `81a3b7a6` — documentation only; the collision MECHANISM is still live, since every shipped dispatch is a bare name — carried by `PREPROD-L7-BARE-DISPATCH` → #417)
+
+- *Context:* a generic name in a namespace the consumer shares.
+- *Fix shape:* rename under the plugin's namespace, or document the collision.
+- *Stage:* PR 4.
+
+### `[plugin]` `PREPROD-P1` — unreproduced `jq: Argument list too long` from the hook — ✅ CLOSED (2026-08-02, #410, `3bbadbb1`)
+
+- *Context:* reported, never reproduced. The mechanism would be an unbounded
+  findings block reaching `jq`.
+- *Fix shape:* closed by construction — a file-size cap and a byte budget on the
+  findings block remove the mechanism.
+- *Stage:* PR 1.
 
 ### `[harness]` `RELEASE-GATE-TBD-FALSE-POSITIVE` — ✅ CLOSED (2026-08-02, PR #420) — the release changelog gate was red on `main` and would have blocked the PLUGIN-PREPROD release cut
 


### PR DESCRIPTION
**PLUGIN-PREPROD-001 PR 5, stage d.** Three surfaces, at the Rule 1 cap — `ROADMAP.md`,
`plans/DECISIONS.md`, `plans/FRAMEWORK-TODO.md`. **No exception needed** this time, unlike
5c. No code or CI touched.

## ⚠️ The batch closes 22 of 23, not 23

All 23 findings were audited **against source**, not against the plan or the changelog.
Result: **22 closeable, 1 not, 0 partial.**

**`PREPROD-M6` stays OPEN.** Its fix is cutting the `claude-code-plugin/v0.25.0` tag and
publishing the GitHub Release — outward-facing acts that remain founder-gated, and the
founder has not authorized them. Verified, not assumed: `git tag -l` stops at `v0.20.1`,
and `gh release list` returns exactly one row, `claude-code-plugin/v0.18.0` (2026-06-12).

So the queue header becomes **`⏳ OPEN ON RESIDUAL`** rather than moving to `## Closed`,
and M6 is its sole open member. Closing it would have been the failure the file's own
header warns about — an entry under `Closed` that hides live work.

## Refs are empirical, not inferred

Each closure cites the PR that actually shipped it, attributed with `git log -S` on the
distinguishing symbol:

| PR | Findings |
|---|---|
| [#410](https://github.com/vladm3105/aidoc-flow-framework/pull/410) | B1, H1, H2, H3, M1, L4, P1 |
| [#413](https://github.com/vladm3105/aidoc-flow-framework/pull/413) | L5 |
| [#415](https://github.com/vladm3105/aidoc-flow-framework/pull/415) | B2, B3, M3, M4, M5, L2, L3 |
| [#418](https://github.com/vladm3105/aidoc-flow-framework/pull/418) | M2, L1, L6, L7 |
| [#422](https://github.com/vladm3105/aidoc-flow-framework/pull/422) | M7 |
| this PR | M8 |
| #410 + #413 | B4 (hook half / linter half) |

**Two closures carry a caveat in the marker**, because the finding closes on only one of
its two legs: **L7** shipped documentation while the collision *mechanism* is still live
(every shipped dispatch is a bare name — carried by `PREPROD-L7-BARE-DISPATCH` /
[#417](https://github.com/vladm3105/aidoc-flow-framework/issues/417)), and **B2**'s
release gate now greps an obsolete spelling.

## Corrected before closing

- **`PREPROD-M7`'s Context accused `bandit` of being a scanner CI does not run.** It is
  not: `.github/workflows/pre-commit.yml:37` calls canon's reusable, which runs
  `pre-commit run --all-files`, so `bandit` runs in CI inside the **required** context.
  Closing it on a false premise would have preserved the misconception. The plan carries
  the same falsification as its correction 2 against claim-ledger row 34; 5e fixes it there.
- **`PREPROD-L2`'s Context cited `CHANGELOG.md:1125`, which has drifted.** An append-only
  file grows, so a line citation into it rots by design. The false "flag removed" claim is
  at `:1494` and `platforms/claude-code-plugin/CHANGELOG.md:186`.

## M8 — `ROADMAP.md`

`:56` said `0.23.4`; it now says `0.25.0`. **Exactly one line changed.** The historical
claims survive untouched — `:113` (IDGEN-NO-GENERATOR at plugin `0.24.0`), `:189`, `:191`,
`:199` — which is precisely what
[#405](https://github.com/vladm3105/aidoc-flow-framework/issues/405) is about.
`sync-version-refs.sh` does not touch this file, which is why M8 could not ride with 5c.
Also added a "Recently shipped" entry, since a completed milestone is a roadmap event.

## D-0074 — and a claim it nearly shipped false

Records two policy choices embedded in shipped code, both spanning PR boundaries (which is
why neither belonged in the PR that implemented it): the permission bypass is **opt-in and
disclosed** rather than removed, and the review hook now defaults to **nudge-only** —
honouring the documentation over the shipped behaviour, and deliberately losing visibility
existing users had.

⚠️ **An earlier draft asserted "the invariant is no longer measured." That is false**, and
it came from the review agent's own finding — caught by re-deriving it. Conformance *does*
guard the property (`test_bypass_absent_by_default`, `test_flag_defaults_off`,
`test_driver_invocation_passes_the_permission_flag`). What is stale is the *release gate's
literal*; what is unscanned is `commands/` + `agents/`. The entry now says which surface
covers what, and records the transferable lesson: **a gate that greps a literal stops
measuring the moment the implementation is renamed, and it keeps passing.**

## Verification

- **379 conformance tests: OK**
- **49 release-gate tests: OK**
- `pre-commit run --all-files`: clean on two consecutive runs
- M6 left open, verified by `git tag -l` + `gh release list`
- `ROADMAP.md` diff inspected line by line

🤖 Generated with [Claude Code](https://claude.com/claude-code)
