### PR TITLE
docs(preprod): correct the plan's own falsified claims, graduate 4 traps — PLUGIN-PREPROD-001 PR 5e

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -826,14 +826,26 @@ fresh to have settled, and never repeats one that is already here.
   `tools/sdd_doc_lint/tests` and Hermes' own suite; `pre_push_check.sh` invokes no
   `unittest` at all. So ~30 modules under `tests/unit/` (including
   `test_sync_scripts.py`) are **unguarded after merge** — a test placed there proves
-  something once, locally, and never again. **The one runner that exists is worse
-  than none:** `tests/scripts/test-plugin.sh:257`/`:302` do
-  `python3 -m unittest discover tests/unit`, but nothing calls that script (grep
-  `.github/workflows/`, `.pre-commit-config.yaml`, `scripts/`) and both call sites end
-  in `|| true`, so even the manual path cannot fail. The registration shim is
+  something once, locally, and never again. The registration shim is
   `tests/conformance/test_repo_scripts.py` — add new modules to its `REGISTERED`
-  tuple. Wiring the hook is reuse, not authoring; dropping the `|| true` is the
-  deeper fix.
+  tuple. Wiring `tests/unit` into the existing `conformance` hook
+  (`.pre-commit-config.yaml:104-106`) is reuse, not authoring.
+  - ⚠️ **This bullet used to carry two wrong claims about the one runner that
+    does exist; both are corrected here (2026-08-02), because each was reassuring
+    in the wrong direction.** (a) It said `tests/scripts/test-plugin.sh:257`/`:302`
+    "both end in `|| true`, so even the manual path cannot fail." **The `|| true`
+    suppresses nothing.** The script sets `set -uo pipefail` with **no `-e`**
+    (`:52`), `FAILED` is `declare -i` (`:114`), and `run()` increments it *before*
+    returning (`:123-137`), which `:369-376` turns into `exit 1`. (b) It said
+    "nothing calls that script" — **refuted by the umbrella.** The nuances matter
+    more than the refutation: the umbrella **pins this repo at `0ffa153c`
+    (2026-06-15)**, so *no* umbrella run is evidence about current `main`; and it
+    reaches `tests/unit/` two ways — `release.yml:32` (this harness, `v*` tags) and
+    `pr-checks.yml:36` (`unittest discover tests/unit -v` directly, on **every
+    umbrella PR**). Neither guards *this* repo's PR path, which is the real gap.
+    **Before writing "nothing runs X", check the umbrella — then check what SHA it
+    pins.** *(`pr-checks.yml:28` also mentions this script in a comment, at the
+    wrong path — `framework/scripts/` rather than `framework/tests/scripts/`.)*
 - **Local `pre-commit` on changed files ≠ CI's `--all-files`.** A rebase conflict
   resolution once dropped a blank line before a CHANGELOG heading; local hooks never
   re-linted the seam and CI failed on MD022. **Run `pre-commit run --all-files` after
@@ -844,6 +856,13 @@ fresh to have settled, and never repeats one that is already here.
   backtick any path containing underscores. **Seven** older plan files still carry the
   `**init**.py` corruption from before this was documented (re-measure with
   `grep -rl '\*\*init\*\*\.py' plans/`; the figure was recorded as eight and was wrong).
+  Two further facts, and **they are two different rules** — disabling one does not stop
+  the other. The corruption makes the citation gate fail with the **misleading**
+  `path '.py' does not exist`; the workaround (#408) is
+  `<!-- markdownlint-disable MD050 -->` scoped around the ledger — **MD050** is
+  strong-style, the `__x__` case. Separately **MD049** (emphasis-style) normalizes
+  `_x_` → `*x*` across a **whole** changelog file you touch, not just the lines you
+  edited, and MD050 does not cover it.
 - **`sync-version-refs` reporting "files were modified" is usually a knock-on**, not
   a second defect — it re-stages whatever an earlier autofix touched. Verify by
   running it alone against a clean HEAD.
@@ -984,3 +1003,27 @@ at the published artifact — never by a test asserting on the call sequence.
   surface** (**D-0071 §2**). #373 asked to SHA-pin an action; adopting canon's caller
   closed it and removed the class of defect, where editing the `uses:` lines would
   have fixed the symptom and left the workflow to drift at the next release.
+- **A registration rule and a resolution rule live in different tables, and you find
+  the reassuring one first.** "Installing it shadows nothing" ≠ "a bare name resolves
+  to it". Ask what resolves the name *at call time*. No test and no green CI catches a
+  wrong reassurance — the plugin agent case (`PREPROD-L7` / #417) is the worked example:
+  agents register under a scoped identifier, so installation overwrites nothing, but
+  every dispatch the plugin ships is *bare*, and a bare name resolves by scope
+  precedence where a plugin ranks lowest of five.
+- **Your own test can enshrine the defect you just introduced.** Written beside its
+  fix, a test inherits the fix's misconception, and mutation testing is blind to it
+  because the mutant and the test agree. When a fix has a *direction*, state it as an
+  invariant in code, not only as an assertion about one case.
+- **A surviving mutant usually indicts the test, not the fix.** Assert the
+  *classification*, not the downstream outcome, whenever the outcome has more than one
+  possible cause — otherwise the test passes for the wrong reason and the mutant lives.
+- **A fix can silently disarm an existing regression test, and the suite stays green
+  because nothing happened.** When a change alters an exit code, a return value or an
+  error type, **grep for tests that arrange the OLD behaviour** — they now pass
+  vacuously. (Sibling of the gate-greps-a-literal lesson in **D-0074 §1**: a check
+  named for an invariant stops measuring it the moment the implementation is renamed.)
+- **A "documentation-only" closure needs a named owner for the mechanism, or it is not
+  a closure** (**D-0074 §3**). `PREPROD-L7` allowed either a rename or documenting the
+  collision; documentation shipped, and that was defensible *only* because the live
+  half went to `PREPROD-L7-BARE-DISPATCH` (#417). Without the successor entry it would
+  have been closing a partial finding.

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -7,132 +7,82 @@ never repeated here; open work lives in `plans/FRAMEWORK-TODO.md`, never here.
 
 ## Where we are — 2026-08-02
 
-Framework spec `0.40.0`, plugin `0.24.0`, Hermes `0.12.1`.
-**Open PRs: 0. Open issues: 5** —
-[#386](https://github.com/vladm3105/aidoc-flow-framework/issues/386),
+Framework spec `0.40.0`, **plugin `0.25.0`**, Hermes `0.12.1`.
+**Open PRs: 0. Open issues: 5** — [#386](https://github.com/vladm3105/aidoc-flow-framework/issues/386),
 [#405](https://github.com/vladm3105/aidoc-flow-framework/issues/405),
 [#412](https://github.com/vladm3105/aidoc-flow-framework/issues/412),
 [#417](https://github.com/vladm3105/aidoc-flow-framework/issues/417),
 [#423](https://github.com/vladm3105/aidoc-flow-framework/issues/423).
 
-**Last merge: [#422](https://github.com/vladm3105/aidoc-flow-framework/pull/422), squash
-`4cbaaad5` — `SECURITY.md` corrected, finding M7, PR 5 stage b.** The file had described
-a security posture this repo does not have; the enforcement half was inverted. Ground
-truth, as of 2026-08-02 and now recorded in `SECURITY.md` itself: **none** of the five
-scanners under `.github/workflows/` (`codeql`, `dep-scan`, `sast-scan`, `secret-scan`,
-`trivy-scan`) is a required status check, and the required
-`call / Lint / format / security hooks` context is the `pre-commit` job — so the only
-*checks* whose findings block a merge are `bandit`, `detect-secrets` and
-`detect-private-key`. Two qualifiers travel with that claim; do not drop them when
-re-summarizing:
+**PLUGIN-PREPROD-001 is done except for one founder act.** Five PRs plus a five-stage
+PR 5; **22 of 23 findings closed**. Merges this session: #424 (handoff), **#425 (`0.25.0`
+cut)**, **#426 (22 closures + M8 + D-0074)**, and 5e — this one.
 
-- **`bandit` is scoped** `^(platforms/hermes/src/|tests/).*\.py$`
-  (`.pre-commit-config.yaml:50`), so most of `tools/` and the plugin tree is outside it.
-- **`SECURITY.md:66` names the one non-check control that does block** — GitHub
-  secret-scanning push protection. It is enabled.
+**⚠️ The ONE thing left, and it is yours, not an agent's: `PREPROD-M6`.** Cut
+`claude-code-plugin/v0.25.0` and publish the GitHub Release. Verified 2026-08-02: the
+newest tag is `claude-code-plugin/v0.20.1` and `gh release list` returns exactly one row,
+`v0.18.0` (2026-06-12) — **seven versions stale.** A tag cut and a public Release are
+outward-facing acts outside the AI auto-merge default. Everything else shipped.
 
-Branch protection is mutable and this claim now lives in a public file — re-derive with
-`gh api repos/vladm3105/aidoc-flow-framework/branches/main/protection --jq '.required_status_checks.contexts'`
-before citing it.
+**Consequences a fresh session must not misread:**
 
-**Private vulnerability reporting was DISABLED and is now on** (founder-authorized
-2026-08-02, verified by readback). `SECURITY.md` had pointed researchers at a Security-tab
-control that did not render while forbidding the public fallback, so its only reporting
-channel dead-ended. Do not re-file this; do not disable it.
+- `PLUGIN-PREPROD-001-PLAN.md` is **`In Progress`, deliberately NOT `Completed`** — 5e's
+  own instruction said to set `Completed`, and that instruction was wrong while a declared
+  item is live. Flip it when M6 lands.
+- The `FRAMEWORK-TODO.md` queue header is **`⏳ OPEN ON RESIDUAL`** with M6 its sole open
+  member. The other 22 are under `## Closed` with empirically-attributed refs.
+- `VERSION` reading `0.25.0` is **the version this tree builds, not a published release.**
+  Both changelog entries sit under `[Unreleased]` for exactly that reason.
+- **⚠️ Two `FRAMEWORK-TODO.md` items are FIXED-BUT-NOT-CLOSED, deliberately, because
+  closing them would have been a 4th doc surface against the ≤3 cap on the initiative's
+  last stage.** Neither blocks anything; both are ~2-line edits. (a)
+  `PREPROD-PLAN-TESTPATH` — 5e corrected the path, but the entry still sits under
+  `## Open` and both its `:378` citations now land on a blank line; move it to
+  `## Closed` and re-cite the current line. (b) `PREPROD-M6`'s heading still says "six
+  versions stale"; it is **seven** now, because 5c's own bump falsified it. **5e was the
+  last stage, so nothing later picks these up — they are yours.**
 
-**⚠️ PR 5 is five PRs. 5a (#420) and 5b (#422) are done; 5c is next and is FOUNDER-GATED
-on the Rule 1 surface-cap exception.** `PLUGIN-PREPROD-001-PLAN.md` § "Docs to update"
-(`:532-536`) lists **eight** documents of record for PR 5 against the ≤3-surface
-governance cap, and the plan says to split (`:547`). The measured split is task 1 below.
-**PRs 1–4 shipped; the `PREPROD-*` batch stays under `FRAMEWORK-TODO.md` `## Open` until
-5d closes it — the entries do not tell you what has shipped; this file does.**
+**⚠️ A plugin `VERSION` bump needs a hand-authored `docs/TAGGING.md` row, or conformance
+goes red.** `tests/conformance/platforms/test_plugin_release_metadata.py:137` asserts the
+file contains the current plugin tag string, and `scripts/sync-version-refs.sh` deliberately
+does not write it (`:56-60` lists TAGGING/ROADMAP/HANDOFF release rows as human-authored).
+Cost a conformance failure during 5c. **Not in the plan and not in any earlier handoff.**
 
-**⚠️ Three `FRAMEWORK-TODO.md` entries are NOT part of the original 23 and must NOT be
-closed with the batch** — `PREPROD-L7-BARE-DISPATCH` (#417), `PREPROD-AGENT-WEBFETCH`,
-`PREPROD-PLAN-TESTPATH`. Only `PREPROD-PLAN-TESTPATH` is PR 5's to fix (a one-line path
-amendment at `PLUGIN-PREPROD-001-PLAN.md:378`).
-
-**⚠️ `L7` is resolved only because the *documentation* is now correct.** Plugin agents
-register under a scoped identifier, so installation overwrites nothing — but a **bare**
-name resolves by scope precedence, where a plugin ranks lowest of five. Every dispatch the
-plugin ships is bare. #417 (task 2) is the machine-facing half.
+**⚠️ The `sync-version-refs.sh` fanout reaches OUTSIDE this repo, and that write is broken.**
+`:180` writes `../web-site/src/pages/index.astro`, a sibling repo with its own remote. The
+badge there reads `Pre-release v0.20.1`; the script greps for the *previous* value, misses,
+and `replace_in_file` returns 0 **without logging**. Self-sealing — no future bump repairs
+it. A throwaway clone (the prescribed test method) has no sibling and is structurally blind
+to it. [#423](https://github.com/vladm3105/aidoc-flow-framework/issues/423); the founder
+declined the repair during 5c, so **the public site still advertises `v0.20.1`.**
 
 **⚠️ The `ai-review` gate WILL request changes on a code or CI PR with no root
-`CHANGELOG.md` entry.** The ≤3-surface cap is a *ceiling*, not observed practice — recent
-PRs have used one real surface + `CHANGELOG.md` and others three; what they share is the
-changelog entry. A failing run **uploads a verdict artifact**
-(`gh run download <id> -n ai-review-verdict`) — a run that fails *after* producing it is a
-verdict, not an outage.
+`CHANGELOG.md` entry.** The ≤3-surface cap is a *ceiling*, not observed practice — what
+passing PRs share is the changelog entry, not a surface count. A failing run **uploads a
+verdict artifact** (`gh run download <id> -n ai-review-verdict`) — a run that fails *after*
+producing it is a verdict, not an outage. Docs-of-record-only PRs need none — #424
+(`plans/` only) and #426 (`plans/` **plus `ROADMAP.md`**) both passed without one.
 
 **⚠️ Two tiers are RED on `main` for pre-existing reasons, neither CI-gated, neither
-yours.** `Hermes pytest` — an unpinned `mcp[cli]>=1.0.0` floor, path-filtered, locally
-green (570), see `HERMES-MCP-FLOATING-DEP`, do not re-diagnose. Phase 0 `lint-smoke` in
+yours.** `Hermes pytest` — an unpinned `mcp[cli]>=1.0.0` floor, path-filtered, locally green
+(570), see `HERMES-MCP-FLOATING-DEP`, do not re-diagnose. Phase 0 `lint-smoke` in
 `tests/scripts/test-acceptance.sh` — example-corpus debt deferred to the wholesale regen;
 use `--skip-lint-smoke`.
 
 **V15 (schedule→`workflow_run` chain) is still unconfirmed** — never a gate; V14 proved the
 chain off a *dispatched* upstream only. `standards-drift` runs Mondays 09:00 UTC, **first
-observable 2026-08-03**. On or past that date, confirm a `pin-currency-reader` run followed
-it with `event=workflow_run`, then delete this paragraph. A failure there is a new bug, not
-a reopened plan.
+observable 2026-08-03 (tomorrow).** On or past that date, confirm a `pin-currency-reader`
+run followed it with `event=workflow_run`, then delete this paragraph. A failure there is a
+new bug, not a reopened plan.
 
 ## Next tasks — prioritized
 
 The full queue is `plans/FRAMEWORK-TODO.md` (`## Open`) and `plans/HERMES-BACKLOG.md`.
 This is only the ordering a fresh session should use.
 
-1. **PLUGIN-PREPROD-001 — PR 5, stages c–e. The last stage of the initiative.**
-   Read `plans/PLUGIN-PREPROD-001-PLAN.md` § "PR 5" (`:292`).
-
-   **⚠️ STOP: 5c needs an explicit founder OK before you touch `VERSION`, plus an
-   audit-trail line in the commit message.** A plugin bump is a 60-file diff including
-   `CLAUDE.md` (Governance PR discipline), and the hook re-stages its own writes so it
-   **cannot be split**. Do not self-grant the Rule 1 exception; do not conclude the split
-   is wrong because one stage will not fit. The full argument, the stage table, and the
-   **four falsified plan claims 5e must correct** are now in the plan (§ "PR 5") — durable
-   content, kept there because this file is deleted at the next merge. Read it; do not
-   re-derive it.
-
-   `CLAUDE.md` takes the **mechanical version token** at 5c (hook-written) and the
-   **authored** trap corrections + trap graduation at 5e. `CHANGELOG.md` takes a per-PR
-   entry at every stage — that is doc-currency, not duplication.
-
-   - **How to propagate (5c).** Edit `platforms/claude-code-plugin/VERSION` and commit;
-     the `sync-version-refs` pre-commit hook fires on `^platforms/[^/]+/VERSION$`
-     (`.pre-commit-config.yaml:116-124`), rewrites the fanout and re-stages itself.
-     `tools/sync-plugin-framework.sh` is **not** part of a plugin bump — it is
-     framework-spec-driven and references no `VERSION` file. Re-derive the 60 before
-     trusting it (throwaway clone, per the `CLAUDE.md` trap):
-
-     ```sh
-     d=$(mktemp -d) && git clone -q --no-hardlinks . "$d/f" && cd "$d/f" \
-       && echo 0.25.0 > platforms/claude-code-plugin/VERSION \
-       && bash scripts/sync-version-refs.sh >/dev/null 2>&1; git status --porcelain | wc -l
-     ```
-
-   - **⚠️ A clone cannot verify the whole fanout, and the part it cannot see is broken.**
-     `scripts/sync-version-refs.sh:180` also writes the **sibling repo**
-     `../web-site/src/pages/index.astro`, which no clone has. In the real tree that write
-     **silently no-ops**: the site badge reads `Pre-release v0.20.1` (`:19`), the script
-     greps for the *previous* value, and `replace_in_file` returns 0 without logging on a
-     miss. So 5c must update the site **by hand in a `web-site` PR**, or the public page
-     stays five minors stale — and no future bump will ever repair it. Filed as
-     [#423](https://github.com/vladm3105/aidoc-flow-framework/issues/423)
-     (`SYNC-WEBSITE-SILENT-NOOP`).
-   - **5d must correct `PREPROD-M7`'s *Context* line before closing it**
-     (`FRAMEWORK-TODO.md:390`) — it repeats the same rejected misconception
-     ("`SECURITY.md:49` names `bandit`"), which is now stale in line number *and*
-     substance. It also clears the GOV-TODO-ISSUE-SPLIT bar and has no `→ #N`.
-   - **M8 — `ROADMAP.md:56` says the plugin is `0.23.4`.** `sync-version-refs.sh` does
-     **not** touch `ROADMAP.md`, which is why M8 rides with 5d rather than landing early.
-     ⚠️ **`ROADMAP.md:113` also says `0.24.0` and is a *historical* claim**
-     (IDGEN-NO-GENERATOR shipped at `0.24.0`) — it must survive untouched. That is exactly
-     [#405](https://github.com/vladm3105/aidoc-flow-framework/issues/405).
-   - **M6 — cut `claude-code-plugin/v0.25.0` + publish a Release. SEPARATELY
-     FOUNDER-GATED** (an outward-facing tag + Release, not the Rule 1 exception), after
-     5c. The latest Release is `claude-code-plugin/v0.18.0` (2026-06-12), six versions
-     stale. The PRs merge normally; only the tag and the public Release wait.
-
+1. **`PREPROD-M6` — FOUNDER ACT, blocks nothing else.** Cut the tag, publish the Release.
+   Nothing an agent should do unprompted. When it lands, flip the plan to `Completed` and
+   move the queue header from `⏳ OPEN ON RESIDUAL` to `✅ CLOSED`.
 2. **[#417](https://github.com/vladm3105/aidoc-flow-framework/issues/417) — namespace the
    plugin's agent dispatch references.** 29 `subagent_type=` occurrences across 20 files,
    none scoped — but most are `subagent_type=<mapped agent>` *placeholders*, so the bare
@@ -140,111 +90,109 @@ This is only the ordering a fresh session should use.
    `platforms/claude-code-plugin/README.md:215+` (`:213` is the table header). Mechanical,
    but **verify first that `subagent_type` accepts `plugin:agent`**; the docs confirm the
    scoped form for `--agent` and @-mention but do not state it for `subagent_type`. If it
-   does not, this reopens as a rename of the definitions.
-3. **`SDD-CORPUS-UNVERIFIED` — START WITH THE FOUNDER DECISION; it gates the plan.**
+   does not, this reopens as a rename of the definitions. This is the live half of `L7`,
+   which closed on documentation only.
+3. **`PREPROD-B2-GATE-SCOPE` — a release gate that greps a literal stopped measuring.**
+   `tests/release/test_marketplace_gate.py:42` forbids `--dangerously-skip-permissions` in
+   `skills/**/SKILL.md`; PR 3 renamed the mechanism to `--allow-skip-permissions`, so the
+   gate still passes and no longer measures anything live. Conformance *does* cover the
+   property (`test_bypass_absent_by_default`, `test_flag_defaults_off`), so this is a
+   gate-quality gap, not an exposure. Also `skill_dirs()` scans `skills/` only —
+   `commands/` and `agents/` are outside both. Fix shape: assert the property, extend the
+   scan. See **D-0074 §1**.
+4. **`SDD-CORPUS-UNVERIFIED` — START WITH THE FOUNDER DECISION; it gates the plan.**
    Census in the `FRAMEWORK-TODO.md` entry. Two rules not there: **build the gate before
    touching content**, and this needs a `plans/` plan with the two-cycle gap review.
-4. **[#412](https://github.com/vladm3105/aidoc-flow-framework/issues/412) — linting a
+5. **[#412](https://github.com/vladm3105/aidoc-flow-framework/issues/412) — linting a
    single file reports every cross-document trace tag as a `TRACE-RES-001` ERROR.** Fix
    shape is the single-file gate `_check_forward_coverage` already carries
    (`tools/sdd_doc_lint/__init__.py:1972-1973`, documented at `:1965-1967`). ⚠️ An earlier
    handoff cited `:1961-1963` and was wrong — those are run-mode severity bullets.
    Re-derive a carried-forward line number before re-publishing it.
-5. **Watch [aidoc-flow-ci#351](https://github.com/vladm3105/aidoc-flow-ci/issues/351) —
+6. **[#423](https://github.com/vladm3105/aidoc-flow-framework/issues/423) — the
+   `web-site` badge.** Two halves: repair `Pre-release v0.20.1` by hand in a `web-site` PR,
+   and make a grep miss on that path **warn** instead of returning silently. Keep it
+   non-fatal — the sibling is legitimately absent in CI — and do **not** make
+   `replace_in_file` warn globally; most of its misses are the benign idempotent case.
+7. **Watch [aidoc-flow-ci#351](https://github.com/vladm3105/aidoc-flow-ci/issues/351) —
    when canon ships its own reader, DELETE ours.** `.github/workflows/pin-currency-reader.yml`
    plus `scripts/read-pin-currency-log.sh` and `scripts/reconcile-pin-currency-issue.sh`
    are an override, not a permanent local surface (plan R9). Nothing else says so.
-6. **[#405](https://github.com/vladm3105/aidoc-flow-framework/issues/405) —
+8. **[#405](https://github.com/vladm3105/aidoc-flow-framework/issues/405) —
    `sync-version-refs.sh` rewrites historical "shipped in vX" claims.** Corrupted
    `docs/PARITY.md:65` on three consecutive bumps. **Did NOT fire on the `0.25.0` plugin
-   bump** (verified in a clone, 2026-08-02) — still open for framework-spec bumps.
-7. **[#386](https://github.com/vladm3105/aidoc-flow-framework/issues/386) — the
+   bump** — verified line by line during 5c, in the real tree. Still open for
+   framework-spec bumps.
+9. **[#386](https://github.com/vladm3105/aidoc-flow-framework/issues/386) — the
    framework-spec token gates five files on `CLAUDE.md`'s own state.** Outstanding is only
    the **fix shape** — #389's approach cannot be reused because this `prev` is load-bearing
    elsewhere; derive it from a fanout target nobody hand-edits (`docs/PARITY.md`).
-8. **`doc-maintainer` — nothing to do; it is PAUSED** (`kill_switch: true`, #397), CI
+10. **`doc-maintainer` — nothing to do; it is PAUSED** (`kill_switch: true`, #397), CI
    green. Resume requires `aidoc-flow-ci` #352 **AND** #353 — #353 alone is 15 of the 23
-   failures. Census in D-0072. ⚠️ **Do not re-file the `high_risk_paths` /
-   `allowed_paths` mismatch** — deliberate and documented; #396 recorded it as a bug and
-   was wrong.
-9. **Hermes parity — the residual arc.** `plans/HERMES-BACKLOG.md`.
-10. **Everything else** is in `FRAMEWORK-TODO.md` by tag. An entry under `## Open` with no
+   failures. Census in D-0072. ⚠️ **Do not re-file the `high_risk_paths` / `allowed_paths`
+   mismatch** — deliberate and documented; #396 recorded it as a bug and was wrong.
+11. **Hermes parity — the residual arc.** `plans/HERMES-BACKLOG.md`.
+12. **Everything else** is in `FRAMEWORK-TODO.md` by tag. An entry under `## Open` with no
    `⏳ OPEN ON RESIDUAL` marker is genuinely open work (#403). Nothing there is blocking.
 
 ## Traps too fresh to have settled — not yet in `CLAUDE.md`
 
+The four that had settled were **graduated into `CLAUDE.md` § "Durable traps → Process"**
+by this stage, and are deliberately not repeated here. What remains:
+
 - **A review fold authors its own false claims, and the pass that produced the fold never
-  catches them.** Three on #422, each caught by the *next* cycle: "`codeql` fails on
-  findings" (its reusable has no findings gate at all); "tags lag `main` **by design**"
-  (`docs/TAGGING.md:97` calls it a known backlog); and a supported-versions table whose two
-  ✅ rows cancelled the ❌ row below them. No rate is implied — the removed-defect count was
-  never tallied. **Re-verify folded text against source, not against the findings list**,
-  and expect a fold that rewrites a section wholesale to need its own full pass.
+  catches them.** Three on #422, each caught by the *next* cycle. Measured again this
+  session at a larger scale: the 5d closure audit produced a finding ("the release gate no
+  longer measures the invariant") that was **false** and had already been written into a
+  decision-log draft before one `grep` refuted it — conformance covers the property; only
+  the *gate's literal* is stale. **Re-verify folded text against source, not against the
+  findings list**, and treat a subagent's finding as a claim, never as a result.
+- **An absence is the easiest thing to assert and the hardest to verify** — and it is
+  the shape agents produce most confidently. Two instances this session, both refuted by a
+  single command: "nothing calls `test-plugin.sh`" (umbrella `release.yml:32` does) and the
+  gate claim above. **Before writing "X does not happen", run the command that would show
+  it happening.**
+- **A self-citation inside a file you are editing is invalid the moment you edit it.**
+  Correcting the plan shifted every line after `:292` — twice, because the follow-up edits
+  shifted them again — silently invalidating eight `:NNN` references I had just written.
+  **Derive self-references last, in one pass, after content is final**, and state the quote
+  beside the number so a future reader can recover from the drift. The plan now carries that
+  warning inline.
 - **A document can name a channel, a control or a setting that does not exist, and nothing
   in CI will ever notice** — `SECURITY.md` pointed at private vulnerability reporting for
   months while it was disabled. Found only by running
   `gh api repos/<r>/private-vulnerability-reporting`. **When a doc tells a reader to go
-  somewhere, go there.** The same pass found push protection on but
-  `secret_scanning_non_provider_patterns` and `..._validity_checks` off, which narrows what
-  it catches (`SYNC-SECRET-SCANNING-KNOBS` in `FRAMEWORK-TODO.md`).
-- **A cross-repo write is invisible to the isolation you verify in.** See the `../web-site/`
-  warning under task 1 — a throwaway clone is the prescribed way to test a sync script, and
-  it is structurally blind to the one write that leaves the repo. **Ask what the sandbox
-  cannot see**, and check whether a "skipped silently" path is silent about *absence* only
-  or about *a value mismatch* too.
-- **A perfect first-try mutation kill rate is the symptom, not the result.** Two runs in one
-  session scored 11/11 and 17/17 and **both were worthless** — one harness copied the module
-  where its `sys.path` sibling did not resolve, so every mutant died of
-  `ModuleNotFoundError`; the other ran against a red baseline. **Assert the unmutated
-  baseline green *inside* the harness, and include a control mutant that must die.** The
-  valid run then found six real survivors, every one of which drove a code change. Also:
-  anything mutating source in place leaves the tree dirty in a way that reads as authored
-  code — restore from a saved copy each iteration, **never in a `finally`** (killing a hung
-  mutant skips it), bound each run with a timeout, and verify `git diff --quiet <path>`
-  before any run you intend to trust.
+  somewhere, go there.** Two scanning knobs are still off — `SYNC-SECRET-SCANNING-KNOBS`,
+  founder decision.
+- **A perfect first-try mutation kill rate is the symptom, not the result.** Two runs scored
+  11/11 and 17/17 and **both were worthless** — one harness copied the module where its
+  `sys.path` sibling did not resolve, so every mutant died of `ModuleNotFoundError`; the
+  other ran against a red baseline. **Assert the unmutated baseline green *inside* the
+  harness, and include a control mutant that must die.** Also: anything mutating source in
+  place leaves the tree dirty in a way that reads as authored code — restore from a saved
+  copy each iteration, **never in a `finally`** (killing a hung mutant skips it), bound each
+  run with a timeout, and verify `git diff --quiet <path>` before any run you intend to trust.
 - **When a fix has a *scope* and a *matcher*, changing one re-breaks the other.** The release
   gate's scope fix immediately failed against the PR's own changelog entry, because an entry
   documenting a placeholder check has to name the tokens it checks for. Ask which *other*
   dimension the change moved.
-- **`CLAUDE.md` § "Durable traps → Local hooks and tooling" carries two wrong claims in one
-  sentence, at `:829-836`.** (a) "`test-plugin.sh:257`/`:302` end in `|| true`, so even the
-  manual path cannot fail" — the script sets `set -uo pipefail` with **no `-e`** (`:52`),
-  `FAILED` is `declare -i` (`:114`), and `run()` increments it *before* returning
-  (`:123-137`), which `:369-376` turns into `exit 1`. The `|| true` suppresses nothing.
-  (b) "nothing calls that script" — refuted by umbrella `release.yml:32`. **Fix both in 5e,
-  not the one that is easier to see.** Related and durable: the umbrella runs
-  `tests/release/` unguarded on **every** PR (`aidoc-flow/.github/workflows/pr-checks.yml:42`)
-  and every `v*` tag, but pins this repo at `0ffa153c` (2026-06-15) — so a green umbrella run
-  is not evidence about this repo's `main`. **Before writing "nothing runs X", check the
-  umbrella.**
 - **`check_plan.py` false-greens on a not-ready plan.** Its zero-findings check is a phrase
   match, and it accepted a Review log whose final pass said *"**Result:** NOT READY"* —
   because the surrounding prose contained "all folded". Canonical script is
   `~/.claude/skills/verified-planning/check_plan.py`; no repo-local copy. **Not filed.**
-- **markdownlint's `__init__.py` → `**init**.py` corruption is already in `CLAUDE.md`; two
-  things are not.** It made the citation gate fail with the misleading
-  `path '.py' does not exist`, and the workaround in #408 is
-  `<!-- markdownlint-disable MD050 -->` scoped around the ledger. It also normalizes
-  `_x_` → `*x*` across a **whole** changelog file you touch. **Fold these two into the
-  existing `CLAUDE.md` bullet at 5e; do not re-state the corruption itself.**
-
-**Four settled traps to graduate into `CLAUDE.md` at 5e** (it touches that file anyway).
-Titles only — the full text is in `git log -- plans/HANDOFF.md` at `4cbaaad5`:
-registration-rule vs resolution-rule; your own test can enshrine the defect it was written
-beside; a surviving mutant usually indicts the test, not the fix; a fix can silently disarm
-an existing regression test.
 
 Also unresolved and blocking nothing: the founder flagged plugin `requirements-analyst`'s
-`model: sonnet` as unratified.
+`model: sonnet` as unratified. It now also declares an eight-tool allowlist (PR 4).
 
 ## Stale advice — a fresh session will find these referenced, and they are FIXED
 
 | Stale claim | Reality |
 |---|---|
 | "`--admin` is required on every PR" ([aidoc-flow-ci#322](https://github.com/vladm3105/aidoc-flow-ci/issues/322)) | **Fixed at `ci/v2.16.0`.** Every PR since #378 has reached mergeable with no `--admin`. Do not re-add PR numbers to this row — it is the one that accretes |
-| "Branch protection requires the phantom `Lint / format / security hooks`, so every PR is BLOCKED" | **Fixed.** The six required contexts are `call / Lint / format / security hooks`, `call / composition`, `call / ai-review`, `call / verify`, `Framework + platform conformance`, `Acceptance tier (deterministic)`. `call / trust` and `Hermes pytest` are **not** required |
+| "Branch protection requires the phantom `Lint / format / security hooks`" | **Fixed.** The six required contexts are `call / Lint / format / security hooks`, `call / composition`, `call / ai-review`, `call / verify`, `Framework + platform conformance`, `Acceptance tier (deterministic)`. `call / trust` and `Hermes pytest` are **not** required |
 | `AIDOC-CI-COMPOSITION-CHECK-PRHEAD` — "`call / composition` is structurally unsatisfiable on a PR head" | **Stale.** composition reports success on PR heads. A reviewer once read this entry as proof that required checks gate nothing here, and it nearly killed a correct plan |
 | Three pin-currency claims: `NO-PIN-CURRENCY-CHECK`, `PIN-CURRENCY-NO-READER`, `PIN-CURRENCY-READER-PLAN.md:465`/`:469` | **All three dead.** The check runs on every weekly `standards-drift`; the reader SHIPPED at #392 and consumes the completed run's **log**; V14 exercised close-on-clean for real |
+| The plan's PR 5 section as a guide to what PR 5 does | **Four of its claims were falsified by its own implementation** and are annotated in place (M7's "replace the list", ledger row 34, the README prerequisites row, the `--threshold` bullet). Read the annotations, not the original text |
 
 **Standing:** the example corpus is regenerated wholesale after framework changes, so
 corpus-remediation findings are deferred to that regen. IPLAN ↔ iplanic integration is

--- a/plans/PLUGIN-PREPROD-001-PLAN.md
+++ b/plans/PLUGIN-PREPROD-001-PLAN.md
@@ -4,7 +4,7 @@
 | -------------- | ----------------------------------------------------------- |
 | Task           | PLUGIN-PREPROD-001                                           |
 | Type           | bugfix                                                       |
-| Status         | In Progress (`Draft` → `In Progress` 2026-08-02; PRs 1–4 and 5a–5b merged, 5c–5e remain) |
+| Status         | In Progress — **22 of 23 findings closed; M6 (the `claude-code-plugin/v0.25.0` tag + public Release) is founder-gated and OPEN.** `Draft` → `In Progress` 2026-08-02. ⚠️ Deliberately **not** `Completed`: 5e's own instruction said to set it, but a declared item is still live, and `Completed` on unfinished work is the defect the status rule exists to prevent. The founder flips this when M6 lands. |
 | Depends on     | none                                                         |
 | Feeds          | the `claude-code-plugin/v0.25.0` tag + first public marketplace announcement |
 | Version impact | plugin MINOR (`0.24.0` → `0.25.0`); **Hermes: no version bump** (founder decision O2 — see Risks); framework spec unchanged |
@@ -259,7 +259,7 @@ copy).
    or failure attribution in that harness becomes ambiguous.
 7. **M5 — invalidate `verdict.json` between iterations.** Unlink it before each
    audit dispatch, so a stale `PASS` cannot be read as current.
-8. **L2 — `--threshold` is accepted and ignored.** **Do not remove the flag.**
+8. **L2 — `--threshold` is accepted and ignored.** ✅ **NO LONGER TRUE — PR 3 made it a live gate** (`tools/saga_driver.py`, `_meets_threshold` at `:814`, enforced at `:874`): a `PASS` whose `content_score` is under the threshold no longer counts as converged, and the flag string survived as required. The rest of this bullet is the pre-PR-3 state, kept for the audit trail — **except its "Also correct the record" clause, which was an instruction, not a description: the `0.23.4` changelog correction it demands SHIPPED in the root `CHANGELOG.md` `[Unreleased]` entry.** **Do not remove the flag.**
    `tests/scripts/test-acceptance.sh` passes `--threshold 90` on every cascade
    layer (claim 52); deleting the argparse entry makes the driver exit 2 on a
    usage error before any saga work, failing layer 1 and aborting the whole
@@ -291,9 +291,9 @@ copy).
 
 ### PR 5 — docs, governance, and the release cut
 
-**PR 5 ships as five stages (a–e), not one PR.** § "Docs to update" (`:526`, PR-5
-sentence at `:532-536`) lists eight documents of record for this PR against the
-≤3-surface Governance PR cap, and this plan says to split (`:547`). The split
+**PR 5 ships as five stages (a–e), not one PR.** § "Docs to update" (`:537`, PR-5
+sentence at `:543-547`) lists eight documents of record for this PR against the
+≤3-surface Governance PR cap, and this plan says to split (`:558`). The split
 is **measured**, not proposed:
 
 | Stage | Surfaces | State |
@@ -304,7 +304,7 @@ is **measured**, not proposed:
 | 5d | `ROADMAP.md` (M8) + `plans/DECISIONS.md` (`D-00NN`) + `plans/FRAMEWORK-TODO.md` (close the batch) | |
 | 5e | this plan (the corrections below + status → `Completed`) + `plans/HANDOFF.md` + `CLAUDE.md` | |
 
-**5c cannot be split** — see O2 (`:424`, risk row `:557`) and `:538-545`: the `sync-version-refs`
+**5c cannot be split** — see O2 (`:435`, risk row `:568`) and `:549-556`: the `sync-version-refs`
 pre-commit hook re-stages its own writes, so the diff cannot be separated after
 the fact, and it rewrites `CLAUDE.md`, which pulls the stage under Governance PR
 discipline. The Hermes case was resolved by skipping the bump (O2); the plugin
@@ -313,43 +313,52 @@ cannot skip, since M6 needs `0.25.0`. So 5c requires Rule 1's stated exception:
 self-grantable, and one stage exceeding the cap is not evidence the split is
 wrong.
 
-**⚠️ Four claims in this plan were falsified by the work that implemented it.
-5e must correct all four — not only the one that is easiest to see.**
+**✅ FIVE claims in this plan were falsified by the work that implemented it** — the
+four identified before 5e, plus a fifth that **5c itself created** (the "six versions
+stale" figure, which its own bump made seven). All five were corrected in stage 5e
+(2026-08-02), annotated in place below, with the originals kept for the audit trail
+rather than deleted.**
 
 ⚠️ These are **self-references, and every edit to this file shifts them.** Each is
 quoted as well as cited — match the quote, not the number, if they disagree.
 
-1. **`:344` (M7) — "replace the scanner list" is wrong.** #422 deliberately did
+1. **`:347` (M7) — "replace the scanner list" is wrong.** #422 deliberately did
    not replace it: the existing list was *incomplete*, not false, and replacing it
    would have deleted four accurate `pre-commit` entries (`bandit`,
    `detect-secrets`, `detect-private-key`, `pip-audit`). The shipped fix splits
    the list **by configuring file** — CI scanners under `.github/workflows/`,
    local/CI hooks in `.pre-commit-config.yaml` — and records which of them can
    actually block a merge.
-2. **`:602` (claim-ledger row 34) is false.** It reads "`SECURITY.md` names
+2. **`:613` (claim-ledger row 34) is false.** It reads "`SECURITY.md` names
    scanners CI does not run | bandit". `.github/workflows/pre-commit.yml` **does**
    run bandit in CI, inside the required `call / Lint / format / security hooks`
    context. A plan marked `Completed` while carrying a falsified ledger row is the
    exact failure the ledger exists to prevent.
-3. **`:367-368` — the README prerequisites section already shipped in PR 1.**
-   Do not re-add it. (`:404` assigns it to PR 1; the two rows disagree.)
-4. **`:262-269` — the `--threshold` bullet is doubly stale.** PR 3 made the flag
+3. **`:377` — the README prerequisites section already shipped in PR 1.**
+   Do not re-add it. (`:415` assigns it to PR 1; the two rows disagree.)
+4. **`:262-272` — the `--threshold` bullet is doubly stale.** PR 3 made the flag
    live. The 5c changelog entry must say *that*, not restate either version of the
    old claim.
 
-Also to fix at 5e: the § "File structure" row at **`:378`** names
+Also to fix at 5e: the § "File structure" row at **`:389`** names
 `tests/conformance/test_agent_frontmatter.py`; it shipped at
 `tests/conformance/platforms/test_agent_frontmatter.py` (`PREPROD-PLAN-TESTPATH`).
 
 - **M7** — `SECURITY.md`: correct the spec version and the scanner list.
-  ⚠️ **Superseded in part — read correction 1 above before acting on this
-  bullet.** Original text: "replace the scanner list with what CI actually runs —
-  semgrep (SAST), osv-scanner (dependencies), gitleaks (secrets), `trivy config`
-  (IaC) and CodeQL. The draft's list was itself incomplete: it omitted trivy and
-  CodeQL." The omission half was right and shipped; the *replace* half was not.
+  ✅ **SHIPPED in #422, and NOT as this bullet specified.** The bullet said to
+  *replace* the list with what CI runs; that would have deleted four accurate
+  `pre-commit` entries. What shipped splits the list **by configuring file** — CI
+  scanners under `.github/workflows/`, hooks in `.pre-commit-config.yaml` — and
+  states which three checks can actually block a merge. The bullet's *omission*
+  half was right and did ship: `trivy config` and CodeQL were missing. Superseded
+  text kept for the audit trail: "replace the scanner list with what CI actually
+  runs — semgrep (SAST), osv-scanner (dependencies), gitleaks (secrets),
+  `trivy config` (IaC) and CodeQL."
 - **M8** — `ROADMAP.md`: correct the stale plugin version.
 - **M6** — cut `claude-code-plugin/v0.25.0` and publish a GitHub Release. The
-  latest Release is six versions stale, which is what a visitor sees first.
+  latest Release is **seven** versions stale (`0.18.0` against `VERSION` `0.25.0`) —
+  it read *six* until 5c's own bump falsified it, making this a **fifth** claim this
+  plan's implementation falsified. That is what a visitor sees first.
   **Founder-gated:** a tag cut and a public Release are outward-facing acts
   outside the AI auto-merge default, so PR 5 merges but the tag and Release wait
   on explicit founder approval.
@@ -364,8 +373,10 @@ Also to fix at 5e: the § "File structure" row at **`:378`** names
   stages leaves a readable queue rather than nothing.
 - Version bump `0.24.0` → `0.25.0` in the documented propagation order, then
   hand-verify the fanout because of the two open `sync-version-refs.sh` defects.
-- `CHANGELOG.md` entries for the plugin and the project; add the README
-  prerequisites section (jq, Python ≥3.11, PyYAML) that PR 2's guards diagnose.
+- `CHANGELOG.md` entries for the plugin and the project. ⚠️ **The README
+  prerequisites section (jq, Python ≥3.11, PyYAML) already SHIPPED in PR 1**
+  (`platforms/claude-code-plugin/README.md:19-23`). Do not re-add it — `:404`
+  assigns it to PR 1 (`:415`), and this row contradicted that.
 
 ## File structure
 
@@ -375,7 +386,7 @@ Also to fix at 5e: the § "File structure" row at **`:378`** names
 | ---- | ------- |
 | `platforms/claude-code-plugin/LICENSE` | MIT text inside the installed artifact (L1) |
 | `tests/conformance/test_plugin_hook_safety.py` | locks B1 (shadow package cannot execute), M1 (timeout present), H3 (untrusted envelope present) |
-| `tests/conformance/test_agent_frontmatter.py` | every agent declares `tools:` and `model:` (M2) |
+| `tests/conformance/platforms/test_agent_frontmatter.py` | every agent declares `tools:` and `model:` (M2) — shipped under `platforms/`, beside the other plugin-platform checks (`PREPROD-PLAN-TESTPATH`) |
 
 ### Modified
 
@@ -599,7 +610,7 @@ the code PR.
 | 31 | The plugin manifest declares MIT while shipping no license text | `"license": "MIT"` | platforms/claude-code-plugin/.claude-plugin/plugin.json:10 |
 | 32 | The marketplace manifest ships a personal email | `"email"` | .claude-plugin/marketplace.json:6 |
 | 33 | `SECURITY.md` names a spec version five minors stale | `0.35.x` | SECURITY.md:11 |
-| 34 | `SECURITY.md` names scanners CI does not run | `bandit` | SECURITY.md:49 |
+| 34 | ❌ **FALSE — retracted 2026-08-02.** `SECURITY.md` names scanners CI does not run | `bandit` | SECURITY.md:49 — **`bandit` DOES run in CI**: `.github/workflows/pre-commit.yml:37` calls canon's reusable, which runs `pre-commit run --all-files`, so `.pre-commit-config.yaml:45-50` executes inside the required `call / Lint / format / security hooks` context. The row's *shape* held for a different entry: `pip-audit` is configured in that file and runs automatically nowhere (`stages: [manual]`, `.pre-commit-config.yaml:98`), which #422 resolved by **stating** it at `SECURITY.md:100-102` rather than by deletion. The real defect was an incomplete list plus one unqualified entry — the cited *symbol* was simply wrong |
 | 35 | `ROADMAP.md` states a stale plugin version | `0.23.4` | ROADMAP.md:56 |
 | 36 | `playbook_loader` joins caller-supplied segments with no traversal guard | `resolve_playbook_path` | tools/playbook_loader.py:18 |
 | 37 | Raw file tokens are embedded in finding messages that reach model context | `malformed element id` | tools/sdd_doc_lint/__init__.py:642 |


### PR DESCRIPTION
**The final stage of PLUGIN-PREPROD-001.** Three surfaces, at the Rule 1 cap — `CLAUDE.md`,
`plans/PLUGIN-PREPROD-001-PLAN.md`, `plans/HANDOFF.md`.

## ⚠️ The plan is NOT marked `Completed`, which overrides 5e's own instruction

5e was specified to set `Status: Completed`. **That instruction was wrong.** M6 — the tag
cut and public Release — is a declared item and is still open, founder-gated. Marking a
plan `Completed` with live declared work is the same defect class as closing a partial TODO
entry, and the plan-status rule exists to prevent exactly that. Status is **`In Progress`**
with the residual named; the founder flips it when M6 lands.

## FIVE falsified claims corrected, not four

The plan asserted four. **A fifth was found during review**: "the latest Release is six
versions stale" was true at `0.24.0`, and **5c's own bump made it seven** — so the
implementation falsified a claim while correcting others. All five are annotated in place,
originals kept for the audit trail:

1. **M7's "replace the scanner list"** — shipped as a split *by configuring file* instead;
   replacing would have deleted four accurate `pre-commit` entries.
2. **Claim-ledger row 34, retracted.** `bandit` *does* run in CI, in the required context.
   ⚠️ **The retraction was itself too broad on first draft** — the row's *shape* held for
   `pip-audit`, which is configured in that file and runs automatically nowhere
   (`stages: [manual]`). Only the cited **symbol** was wrong.
3. **The README prerequisites row** — shipped in PR 1; the file table already said so.
4. **The `--threshold` bullet** — PR 3 made the flag a live gate, and its "also correct the
   record" clause was an *instruction*, not a description. It was discharged in 5c.
5. **The six/seven versions figure.**

## `CLAUDE.md`

Corrected the two wrong claims about `test-plugin.sh`: the `|| true` **suppresses nothing**
(`set -uo pipefail` with no `-e`, `FAILED` is `declare -i`, `run()` increments before
returning, `:369-376` exits 1), and the script **is** called.

⚠️ **The correction's own first draft was also wrong, and is fixed here.** It said the
umbrella caller "fires on `v*` tags only." The umbrella runs
`unittest discover tests/unit -v` **directly, on every umbrella PR** (`pr-checks.yml:36`),
and it **pins this repo at `0ffa153c` (2026-06-15)** — so *no* umbrella run is evidence
about current `main`. That pin caveat existed only in the handoff and would have been lost
at the next regeneration.

**Graduated four settled traps** into § Process: registration-vs-resolution rules, a test
enshrining the defect it was written beside, a surviving mutant indicting the test, and a
fix disarming an existing regression test. Added the documentation-only-closure rule from
**D-0074 §3**. Split the markdownlint bullet's two rules apart — **MD050** is the `__x__`
case, **MD049** the `_x_` case, and disabling one does not stop the other.

## Handoff

Regenerated, **199 lines**. Records the one remaining founder act and names two
`FRAMEWORK-TODO.md` items that are **fixed-but-not-closed** because closing them would be a
4th doc surface on the last stage: `PREPROD-PLAN-TESTPATH`'s citations now point at a blank
line, and `PREPROD-M6`'s heading still says "six versions stale".

## Verification

- **379 conformance tests: OK**
- **49 release-gate tests: OK**
- `pre-commit run --all-files`: clean on two consecutive runs
- **All 12 plan self-citations derived LAST, in one pass**, and re-verified to land on the
  intended content *both before and after* the hooks ran. Self-citation drift recurred
  **three times** this session — deriving them last is the fix, and the plan now carries
  that warning inline.

Pre-push review returned **10 findings, all folded**. Five were load-bearing, and **three
of those were false claims authored by this fold** rather than defects in the text it
replaced — which is itself the trap the handoff now records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
