### PR TITLE
docs(preprod): cut the plugin 0.25.0 changelog section; correct the root record — PR 2 of 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,11 +44,21 @@ stages 5d/5e.
   still describes the flag as "accepted and ignored", which was the pre-PR-3
   state; the plan records the staleness at `:336-338` and corrects the bullet in
   stage 5e.
-- **No tag and no GitHub Release yet.** The `claude-code-plugin/v0.25.0` tag and
-  the public Release are outward-facing acts, separately founder-gated as finding
-  M6, and are not part of this stage. The entry stays under `[Unreleased]` until
-  that cut happens — `platforms/claude-code-plugin/VERSION` reading `0.25.0` is
-  the version this tree builds, not a published release.
+- **The tag and Release landed later the same day.** ⚠️ **Superseded 2026-08-02.**
+  The `claude-code-plugin/v0.25.0` tag was cut on explicit founder approval
+  (annotated → `e6c6539d`, on the remote) and the GitHub Release published as a
+  **pre-release**, matching `v0.18.0`'s tier since the plugin is a declared pre-1.0
+  preview. That closed finding **M6** and the per-platform entry was promoted to
+  its own `## [0.25.0]` section in
+  [`platforms/claude-code-plugin/CHANGELOG.md`](platforms/claude-code-plugin/CHANGELOG.md).
+  This file keeps every plugin and Hermes entry under `[Unreleased]` by design —
+  only project-stream and framework-spec releases cut a level-2 section here — so
+  this entry stays where it is, corrected in place rather than by a new dated
+  entry, because it is still under `[Unreleased]` and the append-only rule binds
+  released sections. Original text: "**No tag and no GitHub Release
+  yet.** … The entry stays under `[Unreleased]` until that cut happens —
+  `platforms/claude-code-plugin/VERSION` reading `0.25.0` is the version this tree
+  builds, not a published release."
 - **Framework spec unchanged** at `0.40.0`;
   `platforms/claude-code-plugin/FRAMEWORK_SPEC_VERSION` still matches it. Hermes
   is untouched (founder decision O2 — no Hermes version bump in this initiative).

--- a/platforms/claude-code-plugin/CHANGELOG.md
+++ b/platforms/claude-code-plugin/CHANGELOG.md
@@ -14,6 +14,14 @@ this platform adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.25.0] — the pre-production hardening cut (PLUGIN-PREPROD-001) (2026-08-02)
+
+> **Released 2026-08-02.** Tag `claude-code-plugin/v0.25.0` (annotated) →
+> `e6c6539d`; GitHub Release published as a **pre-release**, matching `v0.18.0`'s
+> tier since the plugin is a declared pre-1.0 preview. This closes finding **M6**,
+> the 23rd and last of the pre-production review — the cut was separately
+> founder-gated and authorized on the day.
+
 ### Changed — version `0.24.0` → `0.25.0` (2026-08-02)
 
 **PLUGIN-PREPROD-001 PR 5, stage c.** The version cut for the pre-production
@@ -42,10 +50,13 @@ pre-1.0, so MINOR rather than MAJOR.
   hand-edited trigger, not a target).
 - **`FRAMEWORK_SPEC_VERSION` stays `0.40.0`** and still matches
   `framework/VERSION`. This is a platform-only bump; no spec change.
-- **The `claude-code-plugin/v0.25.0` tag and the GitHub Release are NOT part of
-  this stage.** They are separately founder-gated (finding M6). The latest
-  published Release remains `claude-code-plugin/v0.18.0` until that cut, so this
-  entry stays under `[Unreleased]`.
+- **The tag and the GitHub Release were not part of stage 5c — they landed
+  separately, on 2026-08-02.** ⚠️ **Superseded 2026-08-02**, when the cut happened
+  and this entry was promoted out of `[Unreleased]` per the condition it set for
+  itself. Original text: "**The `claude-code-plugin/v0.25.0` tag and the GitHub
+  Release are NOT part of this stage.** They are separately founder-gated (finding
+  M6). The latest published Release remains `claude-code-plugin/v0.18.0` until
+  that cut, so this entry stays under `[Unreleased]`."
 
 ### Fixed — the autopilot's saga driver: no permanent wedge, no clobbered journal, no false success (2026-08-01)
 


### PR DESCRIPTION
**PR 2 of 3** reconciling the surfaces the `claude-code-plugin/v0.25.0` tag cut falsified. PR 1 was #429 (merged).

The tag is cut (annotated → `e6c6539d`, on the remote) and its GitHub Release published as a **pre-release** — so both changelogs asserting neither existed were false.

## The two files are treated differently, on purpose

| File | Action | Why |
|---|---|---|
| `platforms/claude-code-plugin/CHANGELOG.md` | **Release cut** — new `## [0.25.0]` section | This file cuts a level-2 section per plugin release |
| `CHANGELOG.md` (root) | **Rider only**, entry stays under `[Unreleased]` | This file has *never* cut one for a plugin or Hermes version |

That second claim is load-bearing, so it was verified rather than assumed: all **ten** level-2 sections in the root changelog are project-stream or framework-spec releases, and 13+ plugin/Hermes entries sit under `[Unreleased]` today. Promoting here would have invented a convention the file does not have.

## The plugin cut

The three `###` entries that had accumulated under `[Unreleased]` now sit under `## [0.25.0] — the pre-production hardening cut (PLUGIN-PREPROD-001) (2026-08-02)`, which records the tag and Release and closes finding **M6**. Each of the three was checked against the commit record to confirm it belongs to this release and not an adjacent one.

`## [Unreleased]` is left **present but empty** — that is the exact shape `newest_entry` in `tests/release/test_changelog_entry.py:102-106` is built to skip, and its fixture for that case uses `## [0.25.0]` literally. Removing the heading would be the defect.

## Append-only

Neither hunk touches an already-released section. Both replace a now-false forward-looking claim while **quoting the original text inline** rather than deleting it — the plugin quote verbatim, the root quote with one contiguous marked elision whose two load-bearing facts (the M6 attribution and the founder-gating) are restated in the replacement prose.

## Verification

- Release gate **49 tests, OK** — and `newest_entry` returns a slice that *includes* the edited rider, so the gate scans the change rather than passing around it
- Conformance **379 tests, OK**
- `markdownlint` clean on both files, byte-compared before/after to confirm `--fix` rewrote nothing (the MD049/MD050 whole-file-rewrite trap did not fire)
- Every surviving `v0.18.0` / "not yet cut" string confirmed to be **inside** a quoted historical block, not live prose

## Next

PR 3 covers `ROADMAP.md`, `plans/DECISIONS.md` D-0074 §4 (a superseding rider — it is append-only governance, not an edit) and the handoff.
