### PR TITLE
docs(preprod): close the reconciliation — ROADMAP, a D-0074 rider, fresh handoff — PR 3 of 3

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -112,8 +112,8 @@ Headline capabilities now in the framework (full detail in
 
 - **PLUGIN-PREPROD-001 (2026-08-02, plugin `0.25.0`).** The pre-production
   hardening that unblocked the plugin deploy: a five-lens review returned
-  **BLOCKER** on 2026-07-31 with 23 findings, and 22 are closed across five
-  staged PRs ([#410](https://github.com/vladm3105/aidoc-flow-framework/pull/410),
+  **BLOCKER** on 2026-07-31 with 23 findings, and **all 23 are closed** across
+  five staged PRs ([#410](https://github.com/vladm3105/aidoc-flow-framework/pull/410),
   [#413](https://github.com/vladm3105/aidoc-flow-framework/pull/413),
   [#415](https://github.com/vladm3105/aidoc-flow-framework/pull/415),
   [#418](https://github.com/vladm3105/aidoc-flow-framework/pull/418), and PR 5's
@@ -123,10 +123,12 @@ Headline capabilities now in the framework (full detail in
   on reviews that never ran, and its exit codes distinguish terminal states;
   missing PyYAML or an unmet Python floor is diagnosed rather than surfaced as
   lint findings; shipped agents declare their tools; the plugin ships its
-  `LICENSE`. **The 23rd finding (M6) is open**: cutting the
-  `claude-code-plugin/v0.25.0` tag and publishing the GitHub Release are
-  outward-facing acts, still founder-gated, so the latest published Release
-  remains `claude-code-plugin/v0.18.0`.
+  `LICENSE`. **The 23rd finding (M6) closed on 2026-08-02**: the tag cut and the
+  public Release are outward-facing acts and were separately founder-gated, and
+  the founder authorized both. `claude-code-plugin/v0.25.0` is cut (annotated →
+  `e6c6539d`, on the remote) and **the latest published Release is now
+  `claude-code-plugin/v0.25.0`**, a pre-release matching `v0.18.0`'s tier since
+  the plugin is a declared pre-1.0 preview.
 - **IDGEN-NO-GENERATOR (2026-07-26, plugin `0.24.0`, Hermes `0.12.0`).** The
   element-ID generator ships (`rehash --compute`), and no authoring surface
   computes SHA-256 in-prompt any more. 25 surfaces rewritten: BRD calls the tool;

--- a/plans/DECISIONS.md
+++ b/plans/DECISIONS.md
@@ -96,6 +96,19 @@ founder-gated; the version cut in PR 5c is not a release. `PREPROD-M6` stays ope
 under `## Open` for exactly that reason, and it is the only member of the 23-item
 batch that does.
 
+⚠️ **§4 superseded 2026-08-02 — the gate opened, on the same day this was
+written.** The founder authorized the cut. `claude-code-plugin/v0.25.0` is cut
+(annotated → `e6c6539d`, on the remote) and the GitHub Release is published as a
+pre-release, matching `v0.18.0`'s tier since the plugin is a declared pre-1.0
+preview — closing **M6**, so all 23 findings are now closed. `PREPROD-M6` moved
+to `## Closed` in `plans/FRAMEWORK-TODO.md` (PR #429). §4's present-tense claims
+— that the tag and Release "remain founder-gated" and that `PREPROD-M6` "stays
+open" — are therefore history, not live state; they are left unedited because
+this log is append-only. **§§1–3 are unaffected, and the decision §4 records
+still stands:** a tag cut and a public Release are outward-facing acts outside
+the AI auto-merge default. What changed is that the approval was given, not the
+rule that it was needed.
+
 ---
 
 ## D-0073 — Read the run that already ran; and a reader for a warning-only signal must itself fail loudly

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -8,113 +8,83 @@ never repeated here; open work lives in `plans/FRAMEWORK-TODO.md`, never here.
 ## Where we are — 2026-08-02
 
 Framework spec `0.40.0`, **plugin `0.25.0`**, Hermes `0.12.1`.
-**Open PRs: 0. Open issues: 5** — [#386](https://github.com/vladm3105/aidoc-flow-framework/issues/386),
+**Open issues: 5** — [#386](https://github.com/vladm3105/aidoc-flow-framework/issues/386),
 [#405](https://github.com/vladm3105/aidoc-flow-framework/issues/405),
 [#412](https://github.com/vladm3105/aidoc-flow-framework/issues/412),
 [#417](https://github.com/vladm3105/aidoc-flow-framework/issues/417),
 [#423](https://github.com/vladm3105/aidoc-flow-framework/issues/423).
+Re-derive with `gh issue list --state all --limit 200` — never `--search`, and never the
+default `--limit 30` (this repo is past #430).
 
-**PLUGIN-PREPROD-001 is functionally COMPLETE — all 23 findings, including M6.** Five PRs
-plus a five-stage PR 5. Merges: #424 (handoff), **#425 (`0.25.0` cut)**, **#426 (22
-closures + M8 + D-0074)**, #427 (5e).
+**PLUGIN-PREPROD-001 is COMPLETE and reconciled. Nothing about it is left.** All 23
+findings closed, the plan is `Completed`, and the seven surfaces the tag cut falsified
+were repaired across three governance PRs: **#429** (plan + `FRAMEWORK-TODO` +
+`docs/TAGGING.md`), **#430** (both changelogs), and **the PR carrying this file**
+(`ROADMAP.md` + `DECISIONS.md` rider + this handoff).
 
-**M6 landed 2026-08-02 — the founder authorized it and it is done.** Annotated tag
-`claude-code-plugin/v0.25.0` points at `e6c6539d` and is on the remote; the GitHub Release
-is **published as a pre-release** (matching `v0.18.0`'s tier, since the plugin is a declared
-pre-1.0 preview). Gate evidence at the tagged commit: conformance `361 passed, 769 subtests`,
-and `VERSION` / `.claude-plugin/plugin.json` / `.claude-plugin/marketplace.json` all reading
-`0.25.0` against `FRAMEWORK_SPEC_VERSION` `0.40.0` = `framework/VERSION`. ⚠️ The first two
-are under `platforms/claude-code-plugin/`; **`marketplace.json` is at the REPO ROOT** — a
-re-derivation that looks for it beside `plugin.json` gets "No such file" and reads this
-evidence as fabricated. Verify with
-`gh release view claude-code-plugin/v0.25.0` and `git rev-list -n1 claude-code-plugin/v0.25.0`.
+The release itself: annotated tag `claude-code-plugin/v0.25.0` → `e6c6539d`, on the
+remote; GitHub Release published as a **pre-release** (matching `v0.18.0`'s tier — the
+plugin is a declared pre-1.0 preview). Verify with
+`git rev-list -n1 claude-code-plugin/v0.25.0` and
+`gh release view claude-code-plugin/v0.25.0`.
 
-**⚠️ THE ONE TASK LEFT IS A DOC RECONCILIATION, AND IT IS THE TOP PRIORITY.** The tag cut
-falsified **seven** surfaces that still assert M6 is open. This was deliberately handed to a
-fresh session rather than appended to the tagging session; it is task 1 below, and nothing
-else picks it up. Until it lands the repo publicly contradicts its own Release.
+**`plans/DECISIONS.md` D-0074 §4 is superseded, not edited.** It still reads
+"remain founder-gated" / "`PREPROD-M6` stays open" in its own text; a dated rider
+directly below it records that the gate opened. That is deliberate — the log is
+append-only. Do not "fix" the original prose.
 
-**Consequences a fresh session must not misread:**
-
-- The plan and both changelogs are **stale, not authoritative.** The tag exists; the files
-  saying it does not are the defect. Do not "verify" against them.
-- The seven surfaces, each with the exact false claim: (a)
-  `plans/PLUGIN-PREPROD-001-PLAN.md:7` status row still `In Progress` + the M6 bullet at
-  `:358` still says "founder-gated"; (b) `plans/FRAMEWORK-TODO.md` queue header still
-  `⏳ OPEN ON RESIDUAL` with M6 its sole open member; (c) `docs/TAGGING.md:125` says "Tag
-  **not yet cut**", and `:99-100` still gives the cut high-water mark as
-  `claude-code-plugin/v0.20.1`; (d) `platforms/claude-code-plugin/CHANGELOG.md` keeps the
-  `0.25.0` entry under `## [Unreleased]` with a bullet saying the tag is not part of the
-  stage; (e) `CHANGELOG.md:47-51` says "No tag and no GitHub Release yet" **and**, at `:50-51`,
-  that `VERSION` is "not a published release"; (f) `ROADMAP.md:126-129` says "The 23rd
-  finding (M6) is open" **and** that the latest Release "remains
-  `claude-code-plugin/v0.18.0`" — the most publicly visible of the seven.
-- **(g) is different in kind and must not be edited like the others.**
-  `plans/DECISIONS.md:93-97` (D-0074 §4) says the tag and Release "**remain** founder-gated"
-  and that "`PREPROD-M6` **stays open** under `## Open`" — present-tense claims about live
-  state, now false, inside an **append-only** log that is also a governance surface. Fix it
-  with a **new dated entry or a `⚠️ superseded 2026-08-02` rider**, never by rewriting
-  D-0074. It is also the first hit a fresh session gets from `grep -rn M6 plans/`, which is
-  why it is listed rather than left to discovery.
-- **It is a governance PR** (`plans/*-PLAN.md`, `plans/DECISIONS.md`), so the ≤3-surface cap
-  applies — **three sequential PRs, not one.** Suggested split: (a)+(b)+(c) → (d)+(e) →
-  (f)+(g)+this handoff. Re-derive every `:NNN` above before citing it; they were measured
-  2026-08-02 and each PR shifts the next one's lines.
-- **⚠️ Two `FRAMEWORK-TODO.md` items are FIXED-BUT-NOT-CLOSED, deliberately, because
-  closing them would have been a 4th doc surface against the ≤3 cap on the initiative's
-  last stage.** Neither blocks anything; both are ~2-line edits. (a)
-  `PREPROD-PLAN-TESTPATH` — 5e corrected the path, but the entry still sits under
-  `## Open` and both its `:378` citations now land on a blank line; move it to
-  `## Closed` and re-cite the current line. (b) `PREPROD-M6`'s entry is now **closed by the
-  tag cut**, not merely mis-stated — fold it into task 1's surface (b) rather than repairing
-  its "six versions stale" heading, which the cut made moot. **5e was the last stage, so
-  nothing later picks these up — they are yours.**
+**⚠️ This repo does not auto-merge.** `.github/ai-review/config.json:22` records it as
+deliberately omitted from the **operations-side** `auto_merge.repos` allowlist — it is the
+spec/governance repo, `tier:spec`, human-always. ⚠️ That allowlist is read from
+`trust_config_repo` (`vladm3105/aidoc-flow-operations@main`), **not** from this repo, so
+do not go looking for it here. `CLAUDE.md` separately excepts any PR touching a governance
+surface (`plans/*-PLAN.md`, `plans/DECISIONS.md`, `CLAUDE.md`, `.github/ai-review/`) from
+the AI auto-merge default. The three PRs above merged on **explicit founder authorization
+given in-session**. Ask; do not infer standing approval from the fact that they merged.
 
 **⚠️ A plugin `VERSION` bump needs a hand-authored `docs/TAGGING.md` row, or conformance
 goes red.** `tests/conformance/platforms/test_plugin_release_metadata.py:137` asserts the
-file contains the current plugin tag string, and `scripts/sync-version-refs.sh` deliberately
-does not write it (`:56-60` lists TAGGING/ROADMAP/HANDOFF release rows as human-authored).
-Cost a conformance failure during 5c. **Not in the plan and not in any earlier handoff.**
+file contains the current plugin tag string, and `scripts/sync-version-refs.sh`
+deliberately does not write it (`:56-60` lists TAGGING/ROADMAP/HANDOFF release rows as
+human-authored). ⚠️ That assertion is a **bare substring check**, so it is satisfied by
+the § "Release inventory" preamble as well as by the inventory row — see
+`TAGGING-GATE-SUBSTRING-ONLY`.
 
-**⚠️ The `sync-version-refs.sh` fanout reaches OUTSIDE this repo, and that write is broken.**
-`:180` writes `../web-site/src/pages/index.astro`, a sibling repo with its own remote. The
-badge there reads `Pre-release v0.20.1`; the script greps for the *previous* value, misses,
-and `replace_in_file` returns 0 **without logging**. Self-sealing — no future bump repairs
-it. A throwaway clone (the prescribed test method) has no sibling and is structurally blind
-to it. [#423](https://github.com/vladm3105/aidoc-flow-framework/issues/423); the founder
-declined the repair during 5c, so **the public site still advertises `v0.20.1`.**
+**⚠️ The `sync-version-refs.sh` fanout reaches OUTSIDE this repo, and that write is
+broken.** `:180` writes `../web-site/src/pages/index.astro`, a sibling repo with its own
+remote. The badge there reads `Pre-release v0.20.1`; the script greps for the *previous*
+value, misses, and `replace_in_file` returns 0 **without logging** — self-sealing, so no
+future bump repairs it, and a throwaway clone (the prescribed test method) has no sibling
+and is structurally blind to it. The founder declined the repair, so **the public site
+still advertises `v0.20.1`** ([#423](https://github.com/vladm3105/aidoc-flow-framework/issues/423)).
 
 **⚠️ The `ai-review` gate WILL request changes on a code or CI PR with no root
-`CHANGELOG.md` entry.** The ≤3-surface cap is a *ceiling*, not observed practice — what
-passing PRs share is the changelog entry, not a surface count. A failing run **uploads a
-verdict artifact** (`gh run download <id> -n ai-review-verdict`) — a run that fails *after*
-producing it is a verdict, not an outage. Docs-of-record-only PRs need none — #424
-(`plans/` only) and #426 (`plans/` **plus `ROADMAP.md`**) both passed without one.
+`CHANGELOG.md` entry.** Docs-of-record-only PRs need none — #424, #426 and #429 all
+passed without one. Measured this session: **nothing on the PR path enforces it
+mechanically** — `tests/release/` is invoked by nothing on *this* repo's PR path, only by
+`tests/scripts/test-plugin.sh:317`, which the **umbrella** runs on `v*` tags; and
+GATE-SPEC E008 is diff-aware and skips when `framework/` is untouched. The pressure is
+the LLM verdict, not a rule.
 
 **⚠️ Two tiers are RED on `main` for pre-existing reasons, neither CI-gated, neither
-yours.** `Hermes pytest` — an unpinned `mcp[cli]>=1.0.0` floor, path-filtered, locally green
-(570), see `HERMES-MCP-FLOATING-DEP`, do not re-diagnose. Phase 0 `lint-smoke` in
+yours.** `Hermes pytest` — an unpinned `mcp[cli]>=1.0.0` floor, path-filtered, locally
+green (570), see `HERMES-MCP-FLOATING-DEP`, do not re-diagnose. Phase 0 `lint-smoke` in
 `tests/scripts/test-acceptance.sh` — example-corpus debt deferred to the wholesale regen;
 use `--skip-lint-smoke`.
 
-**V15 (schedule→`workflow_run` chain) is still unconfirmed** — never a gate; V14 proved the
-chain off a *dispatched* upstream only. `standards-drift` runs Mondays 09:00 UTC, **first
-observable 2026-08-03 (tomorrow).** On or past that date, confirm a `pin-currency-reader`
-run followed it with `event=workflow_run`, then delete this paragraph. A failure there is a
-new bug, not a reopened plan.
+**V15 (schedule→`workflow_run` chain) is still unconfirmed** — never a gate; V14 proved
+the chain off a *dispatched* upstream only. `standards-drift` runs Mondays 09:00 UTC,
+**first observable 2026-08-03 (tomorrow).** On or past that date, confirm a
+`pin-currency-reader` run followed it with `event=workflow_run`, then delete this
+paragraph. A failure there is a new bug, not a reopened plan.
 
 ## Next tasks — prioritized
 
-The full queue is `plans/FRAMEWORK-TODO.md` (`## Open`) and `plans/HERMES-BACKLOG.md`.
-This is only the ordering a fresh session should use.
+The full queue is `plans/FRAMEWORK-TODO.md` (`## Open`, 46 entries) and
+`plans/HERMES-BACKLOG.md`. This is only the ordering a fresh session should use.
+**Nothing below is blocked, and nothing is mid-flight.**
 
-1. **Reconcile the seven surfaces the M6 tag cut falsified — START HERE.** Enumerated with
-   their exact false claims in § "Consequences" above. Three sequential governance PRs.
-   The plan goes `In Progress` → `Completed`, the `FRAMEWORK-TODO.md` queue header
-   `⏳ OPEN ON RESIDUAL` → `✅ CLOSED`, both changelog `0.25.0` entries out of
-   `[Unreleased]` under a dated release heading, and `docs/TAGGING.md`'s high-water mark to
-   `claude-code-plugin/v0.25.0`. **No discovery needed; no founder decision pending.**
-2. **[#417](https://github.com/vladm3105/aidoc-flow-framework/issues/417) — namespace the
+1. **[#417](https://github.com/vladm3105/aidoc-flow-framework/issues/417) — namespace the
    plugin's agent dispatch references.** 29 `subagent_type=` occurrences across 20 files,
    none scoped — but most are `subagent_type=<mapped agent>` *placeholders*, so the bare
    names live in the per-skill lens→agent mapping tables and
@@ -123,90 +93,84 @@ This is only the ordering a fresh session should use.
    scoped form for `--agent` and @-mention but do not state it for `subagent_type`. If it
    does not, this reopens as a rename of the definitions. This is the live half of `L7`,
    which closed on documentation only.
-3. **`PREPROD-B2-GATE-SCOPE` — a release gate that greps a literal stopped measuring.**
-   `tests/release/test_marketplace_gate.py:42` forbids `--dangerously-skip-permissions` in
-   `skills/**/SKILL.md`; PR 3 renamed the mechanism to `--allow-skip-permissions`, so the
-   gate still passes and no longer measures anything live. Conformance *does* cover the
-   property (`test_bypass_absent_by_default`, `test_flag_defaults_off`), so this is a
-   gate-quality gap, not an exposure. Also `skill_dirs()` scans `skills/` only —
-   `commands/` and `agents/` are outside both. Fix shape: assert the property, extend the
-   scan. See **D-0074 §1**.
-4. **`SDD-CORPUS-UNVERIFIED` — START WITH THE FOUNDER DECISION; it gates the plan.**
+2. **Gates that stopped measuring — `PREPROD-B2-GATE-SCOPE` + `TAGGING-GATE-SUBSTRING-ONLY`
+   (filed #429). One pass; same class.** (a) `tests/release/test_marketplace_gate.py:39`
+   forbids `--dangerously-skip-permissions`, but PR 3 renamed the mechanism to
+   `--allow-skip-permissions`, so the gate passes and measures nothing; `skill_dirs()` also
+   scans `skills/` only, missing `commands/` and `agents/`. Conformance *does* cover the
+   property, so this is gate quality, not exposure (**D-0074 §1**). (b) Four gates in
+   `tests/conformance/platforms/test_plugin_release_metadata.py` assert only that a token
+   appears *somewhere* in a doc. ⚠️ **They share the weakness but NOT the remedy** — the
+   token sits in a table row (`docs/TAGGING.md`), a third table cell (`README.md`), a
+   blockquote (`docs/PARITY.md`) and a prose line (`CLAUDE.md`). One regex will not do it;
+   assuming otherwise turns green required checks red.
+3. **`SDD-CORPUS-UNVERIFIED` — START WITH THE FOUNDER DECISION; it gates the plan.**
    Census in the `FRAMEWORK-TODO.md` entry. Two rules not there: **build the gate before
    touching content**, and this needs a `plans/` plan with the two-cycle gap review.
-5. **[#412](https://github.com/vladm3105/aidoc-flow-framework/issues/412) — linting a
+4. **[#412](https://github.com/vladm3105/aidoc-flow-framework/issues/412) — linting a
    single file reports every cross-document trace tag as a `TRACE-RES-001` ERROR.** Fix
    shape is the single-file gate `_check_forward_coverage` already carries
    (`tools/sdd_doc_lint/__init__.py:1972-1973`, documented at `:1965-1967`). ⚠️ An earlier
    handoff cited `:1961-1963` and was wrong — those are run-mode severity bullets.
    Re-derive a carried-forward line number before re-publishing it.
-6. **[#423](https://github.com/vladm3105/aidoc-flow-framework/issues/423) — the
+5. **[#423](https://github.com/vladm3105/aidoc-flow-framework/issues/423) — the
    `web-site` badge.** Two halves: repair `Pre-release v0.20.1` by hand in a `web-site` PR,
    and make a grep miss on that path **warn** instead of returning silently. Keep it
    non-fatal — the sibling is legitimately absent in CI — and do **not** make
    `replace_in_file` warn globally; most of its misses are the benign idempotent case.
-7. **Watch [aidoc-flow-ci#351](https://github.com/vladm3105/aidoc-flow-ci/issues/351) —
+6. **Watch [aidoc-flow-ci#351](https://github.com/vladm3105/aidoc-flow-ci/issues/351) —
    when canon ships its own reader, DELETE ours.** `.github/workflows/pin-currency-reader.yml`
    plus `scripts/read-pin-currency-log.sh` and `scripts/reconcile-pin-currency-issue.sh`
    are an override, not a permanent local surface (plan R9). Nothing else says so.
-8. **[#405](https://github.com/vladm3105/aidoc-flow-framework/issues/405) —
+7. **[#405](https://github.com/vladm3105/aidoc-flow-framework/issues/405) —
    `sync-version-refs.sh` rewrites historical "shipped in vX" claims.** Corrupted
    `docs/PARITY.md:65` on three consecutive bumps. **Did NOT fire on the `0.25.0` plugin
-   bump** — verified line by line during 5c, in the real tree. Still open for
-   framework-spec bumps.
-9. **[#386](https://github.com/vladm3105/aidoc-flow-framework/issues/386) — the
+   bump** — verified line by line in the real tree. Still open for framework-spec bumps.
+8. **[#386](https://github.com/vladm3105/aidoc-flow-framework/issues/386) — the
    framework-spec token gates five files on `CLAUDE.md`'s own state.** Outstanding is only
    the **fix shape** — #389's approach cannot be reused because this `prev` is load-bearing
    elsewhere; derive it from a fanout target nobody hand-edits (`docs/PARITY.md`).
-10. **`doc-maintainer` — nothing to do; it is PAUSED** (`kill_switch: true`, #397), CI
+9. **`doc-maintainer` — nothing to do; it is PAUSED** (`kill_switch: true`, #397), CI
    green. Resume requires `aidoc-flow-ci` #352 **AND** #353 — #353 alone is 15 of the 23
    failures. Census in D-0072. ⚠️ **Do not re-file the `high_risk_paths` / `allowed_paths`
    mismatch** — deliberate and documented; #396 recorded it as a bug and was wrong.
-11. **Hermes parity — the residual arc.** `plans/HERMES-BACKLOG.md`.
-12. **Everything else** is in `FRAMEWORK-TODO.md` by tag. An entry under `## Open` with no
+10. **Hermes parity — the residual arc.** `plans/HERMES-BACKLOG.md`.
+11. **Everything else** is in `FRAMEWORK-TODO.md` by tag. An entry under `## Open` with no
    `⏳ OPEN ON RESIDUAL` marker is genuinely open work (#403). Nothing there is blocking.
 
 ## Traps too fresh to have settled — not yet in `CLAUDE.md`
 
-The four that had settled were **graduated into `CLAUDE.md` § "Durable traps → Process"**
-by this stage, and are deliberately not repeated here. What remains:
-
+- **A documentation edit can disarm a gate, and it looks like an improvement.** A draft of
+  #429 added a "these marks go stale" warning to `docs/TAGGING.md` that quoted the current
+  tag. The gate guarding that file is a bare `assertIn`, so the new prose would have
+  satisfied it on its own — letting a future bump ship with the inventory row missing.
+  Caught before push only because the added sentence claimed "nothing in CI checks this
+  paragraph" and that absence was verified rather than assumed. **Before adding text that
+  contains a token some gate greps for, find the gate and read its assertion.**
+- **A shared weakness does not imply a shared remedy.** Four gates had the identical bare-
+  substring defect; the row-matching fix drafted for them was valid for exactly one,
+  because the guarded token sits in a different structure in each file. A fix shape written
+  once and prescribed for a class is a claim about every member of that class.
 - **A review fold authors its own false claims, and the pass that produced the fold never
-  catches them.** Three on #422, each caught by the *next* cycle. Measured again this
-  session at a larger scale: the 5d closure audit produced a finding ("the release gate no
-  longer measures the invariant") that was **false** and had already been written into a
-  decision-log draft before one `grep` refuted it — conformance covers the property; only
-  the *gate's literal* is stale. **Re-verify folded text against source, not against the
-  findings list**, and treat a subagent's finding as a claim, never as a result.
-- **An absence is the easiest thing to assert and the hardest to verify** — and it is
-  the shape agents produce most confidently. Two instances this session, both refuted by a
-  single command: "nothing calls `test-plugin.sh`" (umbrella `release.yml:32` does) and the
-  gate claim above. **Before writing "X does not happen", run the command that would show
-  it happening.**
+  catches them.** Measured again on #429: the fold of pass 1 introduced *two* new false
+  statements — a fix shape valid for one of three gates, and a claim that a plan's
+  `:343-345` "records the correction" when it was an unexecuted open instruction. Both were
+  caught only by a second, independent pass over the folded diff. **Re-verify folded text
+  against source, not against the findings list**, and treat a subagent's finding as a
+  claim, never as a result.
 - **A self-citation inside a file you are editing is invalid the moment you edit it.**
-  Correcting the plan shifted every line after `:292` — twice, because the follow-up edits
-  shifted them again — silently invalidating eight `:NNN` references I had just written.
-  **Derive self-references last, in one pass, after content is final**, and state the quote
-  beside the number so a future reader can recover from the drift. The plan now carries that
-  warning inline.
+  `PLUGIN-PREPROD-001-PLAN.md` cites its own lines ~13 times. Two edits to it had to be
+  made **line-count neutral** (874 → 874, verified against `git show HEAD:`) because a
+  one-line drift moved `:389` off the row two other documents cite. **Check
+  `wc -l` against `HEAD` before pushing any edit to a self-citing file.**
 - **A document can name a channel, a control or a setting that does not exist, and nothing
   in CI will ever notice** — `SECURITY.md` pointed at private vulnerability reporting for
-  months while it was disabled. Found only by running
-  `gh api repos/<r>/private-vulnerability-reporting`. **When a doc tells a reader to go
-  somewhere, go there.** Two scanning knobs are still off — `SYNC-SECRET-SCANNING-KNOBS`,
-  founder decision.
-- **A perfect first-try mutation kill rate is the symptom, not the result.** Two runs scored
-  11/11 and 17/17 and **both were worthless** — one harness copied the module where its
-  `sys.path` sibling did not resolve, so every mutant died of `ModuleNotFoundError`; the
-  other ran against a red baseline. **Assert the unmutated baseline green *inside* the
-  harness, and include a control mutant that must die.** Also: anything mutating source in
-  place leaves the tree dirty in a way that reads as authored code — restore from a saved
-  copy each iteration, **never in a `finally`** (killing a hung mutant skips it), bound each
-  run with a timeout, and verify `git diff --quiet <path>` before any run you intend to trust.
-- **When a fix has a *scope* and a *matcher*, changing one re-breaks the other.** The release
-  gate's scope fix immediately failed against the PR's own changelog entry, because an entry
-  documenting a placeholder check has to name the tokens it checks for. Ask which *other*
-  dimension the change moved.
+  months while it was disabled. **When a doc tells a reader to go somewhere, go there.**
+  Two scanning knobs are still off — `SYNC-SECRET-SCANNING-KNOBS`, founder decision.
+- **A perfect first-try mutation kill rate is the symptom, not the result.** Assert the
+  unmutated baseline green *inside* the harness, with a control mutant that must die.
+  Restore source from a saved copy each iteration, **never in a `finally`** (killing a
+  hung mutant skips it), and verify `git diff --quiet <path>` before any trusted run.
 - **`check_plan.py` false-greens on a not-ready plan.** Its zero-findings check is a phrase
   match, and it accepted a Review log whose final pass said *"**Result:** NOT READY"* —
   because the surrounding prose contained "all folded". Canonical script is
@@ -223,8 +187,11 @@ Also unresolved and blocking nothing: the founder flagged plugin `requirements-a
 | "Branch protection requires the phantom `Lint / format / security hooks`" | **Fixed.** The six required contexts are `call / Lint / format / security hooks`, `call / composition`, `call / ai-review`, `call / verify`, `Framework + platform conformance`, `Acceptance tier (deterministic)`. `call / trust` and `Hermes pytest` are **not** required |
 | `AIDOC-CI-COMPOSITION-CHECK-PRHEAD` — "`call / composition` is structurally unsatisfiable on a PR head" | **Stale.** composition reports success on PR heads. A reviewer once read this entry as proof that required checks gate nothing here, and it nearly killed a correct plan |
 | Three pin-currency claims: `NO-PIN-CURRENCY-CHECK`, `PIN-CURRENCY-NO-READER`, `PIN-CURRENCY-READER-PLAN.md:465`/`:469` | **All three dead.** The check runs on every weekly `standards-drift`; the reader SHIPPED at #392 and consumes the completed run's **log**; V14 exercised close-on-clean for real |
-| The plan's PR 5 section as a guide to what PR 5 does | **Four of its claims were falsified by its own implementation** and are annotated in place (M7's "replace the list", ledger row 34, the README prerequisites row, the `--threshold` bullet). Read the annotations, not the original text |
+| `PLUGIN-PREPROD-001-PLAN.md`'s PR 5 section as a guide to what PR 5 did | **Six of its claims were falsified by its own implementation** and are annotated in place. Read the annotations, not the original text |
+| Any handoff or plan text saying M6 / the tag / the Release is open or pending | **Dead.** The cut happened 2026-08-02 and every surface is reconciled. `DECISIONS.md` D-0074 §4 still *reads* that way by design — see its rider |
 
 **Standing:** the example corpus is regenerated wholesale after framework changes, so
 corpus-remediation findings are deferred to that regen. IPLAN ↔ iplanic integration is
-deferred (`plans/IPLAN-IPLANIC-DEFERRED.md`).
+deferred (`plans/IPLAN-IPLANIC-DEFERRED.md`). All **17** `aidoc-flow-ci` call sites across
+16 files are pinned `@ci/v2.16.0` — re-count with
+`grep -rho 'aidoc-flow-ci/\.github/workflows/[^@]*@ci/v[0-9.]*' .github/workflows/ | wc -l`.


### PR DESCRIPTION
**PR 3 of 3**, closing the reconciliation the `claude-code-plugin/v0.25.0` tag cut made necessary. #429 and #430 carried the first five surfaces; this carries the last two plus the handoff.

## What changed

**`ROADMAP.md`** — the most publicly visible of the seven falsified surfaces. "22 are closed" → all 23; "**The 23rd finding (M6) is open** … the latest published Release remains `claude-code-plugin/v0.18.0`" → M6 closed on 2026-08-02, latest Release now `v0.25.0`.

**`plans/DECISIONS.md`** — D-0074 §4 gets a dated superseding **rider, not an edit**. Its prose is byte-for-byte untouched — the diff has **zero deletions** in this file — because the log is append-only:

```
$ git diff origin/main -- plans/DECISIONS.md | grep -c '^-[^-]'
0
```

The rider names the two present-tense state claims that went false ("remain founder-gated", "`PREPROD-M6` stays open"), says why they are left unedited, scopes §§1–3 as unaffected, and preserves the decision itself: a tag cut and a public Release are outward-facing acts outside the AI auto-merge default. **What changed is that the approval was given, not the rule that it was needed.**

**`plans/HANDOFF.md`** — regenerated wholesale as a current-state snapshot, **230 → 197 lines**. Every carried-forward claim was re-derived against source rather than copied (versions, the 5 open issues, the 17 canon call sites, the 46 open TODO entries, and every `file:line`). One trap that had already graduated into `CLAUDE.md` was dropped rather than repeated.

## Review

Approved after folding **1 load-bearing finding** and 3 cosmetic.

The load-bearing one is worth recording: the handoff asserted **this PR's own number as `#431`** in two places — including a claim about a CI outcome that had not run yet. Issues and PRs share one number sequence, so a single issue filed before `gh pr create` would have made both references 404 in the repo's most-read file. Replaced with a self-reference.

Also folded: a non-verbatim quote of `.github/ai-review/config.json` that dropped the word **"operations-side"** (the allowlist is read from `trust_config_repo`, not from this repo — the omission would have sent a reader looking in the wrong place); an unqualified "`tests/release/` is invoked by no workflow and no hook" that the **umbrella** refutes; and a gate citation at `:42` where three other files cite `:39`.

**Declined:** graduating the `docs/TAGGING.md`-row trap into `CLAUDE.md`. Correct in principle, but `CLAUDE.md` is a fourth doc surface and would breach the ≤3 governance cap.

## Verification

- Conformance **379 tests, OK**; `markdownlint` clean on all three files
- `gh release list` confirms `claude-code-plugin/v0.25.0` is the newest release and a pre-release, and that `v0.18.0` is also a pre-release (so "matching `v0.18.0`'s tier" is exact)
- Three doc surfaces — at the governance cap, not over it

## After this merges

The repo no longer contradicts its own Release anywhere. `PLUGIN-PREPROD-001` is complete, reconciled, and needs nothing further.
