### PR TITLE
fix(lint): skip cross-document TRACE-RES-001 on single-file runs (#412)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,33 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — single-file lint runs no longer report every upstream trace tag as an ERROR (2026-08-15)
+
+Closes [#412](https://github.com/vladm3105/aidoc-flow-framework/issues/412)
+(`LINT-TRACE-RES-SINGLE-FILE`). `sdd_doc_lint` resolves `@<layer>:` tags
+against a `doc_index` built from **the paths passed on the invocation**, so
+linting one file made every upstream tag unresolvable by construction — 66
+false `TRACE-RES-001` ERRORs on the corpus's `SPEC-01` alone, and 11–66 across
+the other layer-02..08 documents. The plugin's `PostToolUse` review hook lints
+exactly one file, so its normal operating mode spent the 4000-byte findings
+budget drowning real findings. The fix gates the cross-document arm on the
+invocation shape: `whole_corpus=target.is_dir()` — directory runs (`pre_merge`,
+pre-commit, CI) are unaffected, measured rather than asserted: the example
+corpus yields an identical 46 findings before and after, and a one-document
+directory corpus an identical 32. A same-corpus directory run still fires
+(asserted by test), so the skip is invocation-shaped, not a blanket disable.
+
+Scope stated precisely, because an earlier draft of this entry overstated it:
+on a single-file run `TRACE-RES-001` does **not** fire at all. The self-
+referential arms (a document citing its own `doc_id`, or an element it hosts
+itself) are retained defensively, but no fixture exercises them and none could
+be constructed — treat single-file runs as carrying no trace-resolution
+coverage, not partial coverage.
+
+Applied to all **three** tracked copies of the linter — `tools/sdd_doc_lint/`,
+the plugin bundle's `platforms/claude-code-plugin/sdd_doc_lint/`, and
+`platforms/hermes/sdd_doc_lint/` — byte-identical before and after.
+
 ### Fixed — the version-sync fanout can no longer silently rewrite historical "shipped in vX" claims (2026-08-15)
 
 Closes [#405](https://github.com/vladm3105/aidoc-flow-framework/issues/405)
@@ -140,24 +167,6 @@ stages 5d/5e.
 - **Framework spec unchanged** at `0.40.0`;
   `platforms/claude-code-plugin/FRAMEWORK_SPEC_VERSION` still matches it. Hermes
   is untouched (founder decision O2 — no Hermes version bump in this initiative).
-
-### Fixed — single-file lint runs no longer report every upstream trace tag as an ERROR (2026-08-15)
-
-Closes [#412](https://github.com/vladm3105/aidoc-flow-framework/issues/412)
-(`LINT-TRACE-RES-SINGLE-FILE`). `sdd_doc_lint` resolves `@<layer>:` tags
-against a `doc_index` built from **the paths passed on the invocation**, so
-linting one file made every upstream tag unresolvable by construction — 66
-false `TRACE-RES-001` ERRORs on the corpus's `SPEC-01` alone, and 14–70 on
-every layer-02..08 document. The plugin's `PostToolUse` review hook lints
-exactly one file, so its normal operating mode spent the 4000-byte findings
-budget drowning real findings. The fix gates the cross-document arm on the
-invocation shape: `whole_corpus=target.is_dir()` — directory runs (`pre_merge`,
-pre-commit, CI) are byte-for-byte unaffected, and single-file runs still check
-everything resolvable within the edited document itself. A same-corpus
-directory run still fires (asserted by test), so the skip is invocation-shaped,
-not a blanket disable. Applied to both tracked copies of the linter
-(`tools/sdd_doc_lint/` and the plugin bundle's `platforms/claude-code-plugin/sdd_doc_lint/`,
-which were byte-identical before and after).
 
 ### Fixed — `SECURITY.md` described a security posture the repository does not have (2026-08-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,24 @@ stages 5d/5e.
   `platforms/claude-code-plugin/FRAMEWORK_SPEC_VERSION` still matches it. Hermes
   is untouched (founder decision O2 — no Hermes version bump in this initiative).
 
+### Fixed — single-file lint runs no longer report every upstream trace tag as an ERROR (2026-08-15)
+
+Closes [#412](https://github.com/vladm3105/aidoc-flow-framework/issues/412)
+(`LINT-TRACE-RES-SINGLE-FILE`). `sdd_doc_lint` resolves `@<layer>:` tags
+against a `doc_index` built from **the paths passed on the invocation**, so
+linting one file made every upstream tag unresolvable by construction — 66
+false `TRACE-RES-001` ERRORs on the corpus's `SPEC-01` alone, and 14–70 on
+every layer-02..08 document. The plugin's `PostToolUse` review hook lints
+exactly one file, so its normal operating mode spent the 4000-byte findings
+budget drowning real findings. The fix gates the cross-document arm on the
+invocation shape: `whole_corpus=target.is_dir()` — directory runs (`pre_merge`,
+pre-commit, CI) are byte-for-byte unaffected, and single-file runs still check
+everything resolvable within the edited document itself. A same-corpus
+directory run still fires (asserted by test), so the skip is invocation-shaped,
+not a blanket disable. Applied to both tracked copies of the linter
+(`tools/sdd_doc_lint/` and the plugin bundle's `platforms/claude-code-plugin/sdd_doc_lint/`,
+which were byte-identical before and after).
+
 ### Fixed — `SECURITY.md` described a security posture the repository does not have (2026-08-02)
 
 **PLUGIN-PREPROD-001 PR 5, stage b.** Closes finding **M7**. No version bump on

--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -343,7 +343,7 @@
 - *Stage:* not a PLUGIN-PREPROD-001 blocker — the `0.25.0` cut runs the tier by
   hand. Genuinely open work after that.
 
-### `[lint]` `LINT-TRACE-RES-SINGLE-FILE` — linting one file reports every cross-document trace tag as an ERROR → [#412](https://github.com/vladm3105/aidoc-flow-framework/issues/412)
+### `[lint]` `LINT-TRACE-RES-SINGLE-FILE` — linting one file reports every cross-document trace tag as an ERROR — ⏳ FIX IN REVIEW ([#412](https://github.com/vladm3105/aidoc-flow-framework/issues/412), PR [#456](https://github.com/vladm3105/aidoc-flow-framework/pull/456): cross-document arm gated on the invocation shape, `whole_corpus=target.is_dir()`; both vendored copies synced)
 
 - *Context:* found 2026-07-31 by review during PLUGIN-PREPROD-001 PR 2, in the
   plugin's own `verbose` hook path. `_check_trace_resolution`

--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -343,7 +343,7 @@
 - *Stage:* not a PLUGIN-PREPROD-001 blocker — the `0.25.0` cut runs the tier by
   hand. Genuinely open work after that.
 
-### `[lint]` `LINT-TRACE-RES-SINGLE-FILE` — linting one file reports every cross-document trace tag as an ERROR — ⏳ FIX IN REVIEW ([#412](https://github.com/vladm3105/aidoc-flow-framework/issues/412), PR [#456](https://github.com/vladm3105/aidoc-flow-framework/pull/456): cross-document arm gated on the invocation shape, `whole_corpus=target.is_dir()`; both vendored copies synced)
+### `[lint]` `LINT-TRACE-RES-SINGLE-FILE` — linting one file reports every cross-document trace tag as an ERROR → [#412](https://github.com/vladm3105/aidoc-flow-framework/issues/412)
 
 - *Context:* found 2026-07-31 by review during PLUGIN-PREPROD-001 PR 2, in the
   plugin's own `verbose` hook path. `_check_trace_resolution`

--- a/platforms/claude-code-plugin/sdd_doc_lint/__init__.py
+++ b/platforms/claude-code-plugin/sdd_doc_lint/__init__.py
@@ -1800,10 +1800,18 @@ def _check_trace_resolution(
         edited document alone, so every upstream tag it emits is
         unresolvable by construction and a wall of TRACE-RES-001 ERRORs
         about correctly-cited documents would drown the real findings
-        (LINT-TRACE-RES-SINGLE-FILE). Only citations resolvable within
-        the linted document itself (self doc-tags, elements hosted by
-        this document) are still checked. Directory runs — ``pre_merge``,
-        pre-commit, CI — pass ``whole_corpus=True`` and are unaffected.
+        (LINT-TRACE-RES-SINGLE-FILE). Treat a single-file run as
+        carrying NO trace-resolution coverage. The self-referential
+        arms below (a document citing its own ``doc_id``, or an element
+        it hosts itself) are retained defensively, but no fixture
+        exercises them and none could be constructed — do not read them
+        as partial coverage. Directory runs — ``pre_merge``, pre-commit,
+        CI — pass ``whole_corpus=True`` and are unaffected.
+
+        NOTE the gate is per ``lint_path`` TARGET, not per file:
+        ``__main__`` calls ``lint_path`` once per CLI argument, so
+        ``sdd_doc_lint a.md b.md`` disables the rule for both. No
+        current caller does this; see the follow-up issue.
       * Index documents (frontmatter ``artifact_type: <X>-INDEX``) — they
         intentionally carry no trace tags.
       * Placeholder / malformed tag values — covered by PH01 / ID01.

--- a/platforms/claude-code-plugin/sdd_doc_lint/__init__.py
+++ b/platforms/claude-code-plugin/sdd_doc_lint/__init__.py
@@ -1782,6 +1782,8 @@ def _check_trace_resolution(
     layers: dict,
     doc_re: re.Pattern,
     elem_re: re.Pattern,
+    *,
+    whole_corpus: bool = True,
 ) -> list[Finding]:
     """TRACE-RES-001 — every emitted UPSTREAM ``@<layer>: <ID>`` tag in
     the corpus resolves on disk (the target document exists AND the cited
@@ -1793,6 +1795,15 @@ def _check_trace_resolution(
     auditor lens.
 
     Skipped:
+      * Cross-document citations on single-file (``on_author``) runs —
+        ``whole_corpus=False``. The corpus of a single-file run is the
+        edited document alone, so every upstream tag it emits is
+        unresolvable by construction and a wall of TRACE-RES-001 ERRORs
+        about correctly-cited documents would drown the real findings
+        (LINT-TRACE-RES-SINGLE-FILE). Only citations resolvable within
+        the linted document itself (self doc-tags, elements hosted by
+        this document) are still checked. Directory runs — ``pre_merge``,
+        pre-commit, CI — pass ``whole_corpus=True`` and are unaffected.
       * Index documents (frontmatter ``artifact_type: <X>-INDEX``) — they
         intentionally carry no trace tags.
       * Placeholder / malformed tag values — covered by PH01 / ID01.
@@ -1847,6 +1858,11 @@ def _check_trace_resolution(
             if m_pfx:
                 artifact_code = m_pfx.group(1)
         my_layer_n = layer_number.get(artifact_code, 0)
+        # This artifact's own doc_id — the one citation target that IS
+        # present in a single-file (on_author) corpus.
+        own_doc_id = ""
+        if fm:
+            own_doc_id = str(fm.get("doc_id") or "").strip().strip('"').strip("'")
 
         for i, line in enumerate(text.splitlines(), 1):
             for m in _TAG.finditer(line):
@@ -1859,6 +1875,21 @@ def _check_trace_resolution(
                 value = m.group(2)
                 if not (doc_re.match(value) or elem_re.match(value)):
                     continue
+                # LINT-TRACE-RES-SINGLE-FILE: on a single-file run, only
+                # citations of this document itself can resolve — skip
+                # everything cross-document (it is unresolvable by
+                # construction, not evidence of a defect).
+                if not whole_corpus:
+                    if doc_re.match(value):
+                        if value != own_doc_id:
+                            continue
+                    else:
+                        head = value.split(".", 2)
+                        host = (
+                            f"{head[0]}-{head[1]}" if len(head) >= 2 and head[1].isdigit() else ""
+                        )
+                        if host != own_doc_id:
+                            continue
                 if doc_re.match(value):
                     if value not in doc_index:
                         findings.append(
@@ -1895,7 +1926,9 @@ def _check_trace_resolution(
                             )
                         )
         # BDD YAML dual-mode: resolve scenario `ears` tokens (no @-tags to scan).
-        if artifact_code == "BDD":
+        # Skipped on single-file runs — scenario `ears` tokens are upstream
+        # EARS citations, cross-document by construction (see gate above).
+        if artifact_code == "BDD" and whole_corpus:
             scenarios, _ = _bdd_yaml_scenarios(text)
             if scenarios is not None:
                 for tok in _bdd_ears_tokens(scenarios):
@@ -2692,7 +2725,12 @@ def lint_path(
     findings.extend(_check_seed_disposition(corpus))
     findings.extend(_check_cascade(corpus))
     findings.extend(_check_staleness(corpus, _framework_version(registry or find_registry())))
-    findings.extend(_check_trace_resolution(corpus, layers, doc_re, elem_re))
+    # LINT-TRACE-RES-SINGLE-FILE: cross-document resolution is evidence only
+    # when the invocation covered a corpus — a single-file (on_author) run
+    # cannot resolve upstream tags by construction.
+    findings.extend(
+        _check_trace_resolution(corpus, layers, doc_re, elem_re, whole_corpus=target.is_dir())
+    )
     # REFGRAN01 is a form rule (GD-03), not the corpus coverage gate — it runs
     # unconditionally (not behind --skip-coverage-gate), with run-mode severity.
     findings.extend(_check_ref_granularity(corpus, mode))

--- a/platforms/hermes/sdd_doc_lint/__init__.py
+++ b/platforms/hermes/sdd_doc_lint/__init__.py
@@ -1800,10 +1800,18 @@ def _check_trace_resolution(
         edited document alone, so every upstream tag it emits is
         unresolvable by construction and a wall of TRACE-RES-001 ERRORs
         about correctly-cited documents would drown the real findings
-        (LINT-TRACE-RES-SINGLE-FILE). Only citations resolvable within
-        the linted document itself (self doc-tags, elements hosted by
-        this document) are still checked. Directory runs — ``pre_merge``,
-        pre-commit, CI — pass ``whole_corpus=True`` and are unaffected.
+        (LINT-TRACE-RES-SINGLE-FILE). Treat a single-file run as
+        carrying NO trace-resolution coverage. The self-referential
+        arms below (a document citing its own ``doc_id``, or an element
+        it hosts itself) are retained defensively, but no fixture
+        exercises them and none could be constructed — do not read them
+        as partial coverage. Directory runs — ``pre_merge``, pre-commit,
+        CI — pass ``whole_corpus=True`` and are unaffected.
+
+        NOTE the gate is per ``lint_path`` TARGET, not per file:
+        ``__main__`` calls ``lint_path`` once per CLI argument, so
+        ``sdd_doc_lint a.md b.md`` disables the rule for both. No
+        current caller does this; see the follow-up issue.
       * Index documents (frontmatter ``artifact_type: <X>-INDEX``) — they
         intentionally carry no trace tags.
       * Placeholder / malformed tag values — covered by PH01 / ID01.

--- a/platforms/hermes/sdd_doc_lint/__init__.py
+++ b/platforms/hermes/sdd_doc_lint/__init__.py
@@ -1782,6 +1782,8 @@ def _check_trace_resolution(
     layers: dict,
     doc_re: re.Pattern,
     elem_re: re.Pattern,
+    *,
+    whole_corpus: bool = True,
 ) -> list[Finding]:
     """TRACE-RES-001 — every emitted UPSTREAM ``@<layer>: <ID>`` tag in
     the corpus resolves on disk (the target document exists AND the cited
@@ -1793,6 +1795,15 @@ def _check_trace_resolution(
     auditor lens.
 
     Skipped:
+      * Cross-document citations on single-file (``on_author``) runs —
+        ``whole_corpus=False``. The corpus of a single-file run is the
+        edited document alone, so every upstream tag it emits is
+        unresolvable by construction and a wall of TRACE-RES-001 ERRORs
+        about correctly-cited documents would drown the real findings
+        (LINT-TRACE-RES-SINGLE-FILE). Only citations resolvable within
+        the linted document itself (self doc-tags, elements hosted by
+        this document) are still checked. Directory runs — ``pre_merge``,
+        pre-commit, CI — pass ``whole_corpus=True`` and are unaffected.
       * Index documents (frontmatter ``artifact_type: <X>-INDEX``) — they
         intentionally carry no trace tags.
       * Placeholder / malformed tag values — covered by PH01 / ID01.
@@ -1847,6 +1858,11 @@ def _check_trace_resolution(
             if m_pfx:
                 artifact_code = m_pfx.group(1)
         my_layer_n = layer_number.get(artifact_code, 0)
+        # This artifact's own doc_id — the one citation target that IS
+        # present in a single-file (on_author) corpus.
+        own_doc_id = ""
+        if fm:
+            own_doc_id = str(fm.get("doc_id") or "").strip().strip('"').strip("'")
 
         for i, line in enumerate(text.splitlines(), 1):
             for m in _TAG.finditer(line):
@@ -1859,6 +1875,21 @@ def _check_trace_resolution(
                 value = m.group(2)
                 if not (doc_re.match(value) or elem_re.match(value)):
                     continue
+                # LINT-TRACE-RES-SINGLE-FILE: on a single-file run, only
+                # citations of this document itself can resolve — skip
+                # everything cross-document (it is unresolvable by
+                # construction, not evidence of a defect).
+                if not whole_corpus:
+                    if doc_re.match(value):
+                        if value != own_doc_id:
+                            continue
+                    else:
+                        head = value.split(".", 2)
+                        host = (
+                            f"{head[0]}-{head[1]}" if len(head) >= 2 and head[1].isdigit() else ""
+                        )
+                        if host != own_doc_id:
+                            continue
                 if doc_re.match(value):
                     if value not in doc_index:
                         findings.append(
@@ -1895,7 +1926,9 @@ def _check_trace_resolution(
                             )
                         )
         # BDD YAML dual-mode: resolve scenario `ears` tokens (no @-tags to scan).
-        if artifact_code == "BDD":
+        # Skipped on single-file runs — scenario `ears` tokens are upstream
+        # EARS citations, cross-document by construction (see gate above).
+        if artifact_code == "BDD" and whole_corpus:
             scenarios, _ = _bdd_yaml_scenarios(text)
             if scenarios is not None:
                 for tok in _bdd_ears_tokens(scenarios):
@@ -2692,7 +2725,12 @@ def lint_path(
     findings.extend(_check_seed_disposition(corpus))
     findings.extend(_check_cascade(corpus))
     findings.extend(_check_staleness(corpus, _framework_version(registry or find_registry())))
-    findings.extend(_check_trace_resolution(corpus, layers, doc_re, elem_re))
+    # LINT-TRACE-RES-SINGLE-FILE: cross-document resolution is evidence only
+    # when the invocation covered a corpus — a single-file (on_author) run
+    # cannot resolve upstream tags by construction.
+    findings.extend(
+        _check_trace_resolution(corpus, layers, doc_re, elem_re, whole_corpus=target.is_dir())
+    )
     # REFGRAN01 is a form rule (GD-03), not the corpus coverage gate — it runs
     # unconditionally (not behind --skip-coverage-gate), with run-mode severity.
     findings.extend(_check_ref_granularity(corpus, mode))

--- a/tests/conformance/test_repo_scripts.py
+++ b/tests/conformance/test_repo_scripts.py
@@ -28,7 +28,10 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 # Modules under tests/unit/ that must run wherever conformance runs.
-REGISTERED = ("tests.unit.test_pin_currency_reader",)
+REGISTERED = (
+    "tests.unit.test_pin_currency_reader",
+    "tests.unit.test_sdd_doc_lint_trace_resolution",
+)
 
 
 def load_tests(loader, tests, pattern):  # noqa: ARG001 — unittest protocol

--- a/tests/unit/test_sdd_doc_lint_trace_resolution.py
+++ b/tests/unit/test_sdd_doc_lint_trace_resolution.py
@@ -36,6 +36,28 @@ def _run_lint(corpus: dict[str, str]) -> list[dict]:
         return json.loads(result.stdout or "[]")
 
 
+def _run_lint_single(corpus: dict[str, str], lint_key: str) -> list[dict]:
+    """Run sdd_doc_lint on ONE file (the ``on_author`` invocation shape).
+
+    LINT-TRACE-RES-SINGLE-FILE: the corpus of such a run is the edited
+    document alone, so cross-document resolution must not fire.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        td_path = Path(td)
+        for rel, body in corpus.items():
+            target = td_path / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(body, encoding="utf-8")
+        result = subprocess.run(
+            [sys.executable, "-m", "sdd_doc_lint", td_path / lint_key, "--format=json"],
+            env={"PYTHONPATH": str(plugin_bundle_root()), "PATH": "/usr/bin:/bin"},
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return json.loads(result.stdout or "[]")
+
+
 def _brd_doc(doc_id: str = "BRD-01", body_id: str = "BRD.01.07.aaaa") -> str:
     return textwrap.dedent(
         f"""
@@ -258,6 +280,50 @@ class TraceResolutionFloor(unittest.TestCase):
             index_findings,
             f"index doc should be skipped, got {index_findings}",
         )
+
+    def test_single_file_run_skips_cross_doc_resolution(self):
+        """LINT-TRACE-RES-SINGLE-FILE (#412).
+
+        Linting one file (the plugin ``on_author`` hook's normal mode) must
+        not report upstream tags as unresolvable — the corpus is the edited
+        document alone, so cross-document citations cannot resolve by
+        construction. A wall of such ERRORs both drowns real findings and
+        teaches the model that correct trace tags are broken.
+        """
+        findings = _run_lint_single(
+            {"docs/02_PRD/PRD-01.md": _prd_doc(brd_ref="BRD-01")},
+            "docs/02_PRD/PRD-01.md",
+        )
+        trace_findings = [f for f in findings if f["code"] == "TRACE-RES-001"]
+        self.assertFalse(
+            trace_findings,
+            f"single-file run must skip cross-doc resolution, got {trace_findings}",
+        )
+
+    def test_single_file_run_skip_is_invocation_shaped(self):
+        """The single-file skip is invocation-shaped, not a blanket disable.
+
+        The SAME corpus linted as a directory must still fire TRACE-RES-001
+        for the unresolvable ``@brd: BRD-99`` — only the single-file
+        (``on_author``) invocation shape skips cross-document resolution.
+        (Own-document element citations cannot fire in either mode: an
+        element citation whose host equals the citing doc's own doc_id
+        self-registers in the element index — pre-existing behavior,
+        unchanged by the single-file gate.)
+        """
+        corpus = {"docs/02_PRD/PRD-01.md": _prd_doc(brd_ref="BRD-99")}
+        single = _run_lint_single(corpus, "docs/02_PRD/PRD-01.md")
+        self.assertFalse(
+            [f for f in single if f["code"] == "TRACE-RES-001"],
+            f"single-file run must skip cross-doc resolution, got {single}",
+        )
+        directory = _run_lint(corpus)
+        trace_findings = [f for f in directory if f["code"] == "TRACE-RES-001"]
+        self.assertTrue(
+            trace_findings,
+            f"directory run of the same corpus must still fire, got {directory}",
+        )
+        self.assertIn("BRD-99", trace_findings[0]["message"])
 
 
 if __name__ == "__main__":

--- a/tools/sdd_doc_lint/__init__.py
+++ b/tools/sdd_doc_lint/__init__.py
@@ -1800,10 +1800,18 @@ def _check_trace_resolution(
         edited document alone, so every upstream tag it emits is
         unresolvable by construction and a wall of TRACE-RES-001 ERRORs
         about correctly-cited documents would drown the real findings
-        (LINT-TRACE-RES-SINGLE-FILE). Only citations resolvable within
-        the linted document itself (self doc-tags, elements hosted by
-        this document) are still checked. Directory runs — ``pre_merge``,
-        pre-commit, CI — pass ``whole_corpus=True`` and are unaffected.
+        (LINT-TRACE-RES-SINGLE-FILE). Treat a single-file run as
+        carrying NO trace-resolution coverage. The self-referential
+        arms below (a document citing its own ``doc_id``, or an element
+        it hosts itself) are retained defensively, but no fixture
+        exercises them and none could be constructed — do not read them
+        as partial coverage. Directory runs — ``pre_merge``, pre-commit,
+        CI — pass ``whole_corpus=True`` and are unaffected.
+
+        NOTE the gate is per ``lint_path`` TARGET, not per file:
+        ``__main__`` calls ``lint_path`` once per CLI argument, so
+        ``sdd_doc_lint a.md b.md`` disables the rule for both. No
+        current caller does this; see the follow-up issue.
       * Index documents (frontmatter ``artifact_type: <X>-INDEX``) — they
         intentionally carry no trace tags.
       * Placeholder / malformed tag values — covered by PH01 / ID01.

--- a/tools/sdd_doc_lint/__init__.py
+++ b/tools/sdd_doc_lint/__init__.py
@@ -1782,6 +1782,8 @@ def _check_trace_resolution(
     layers: dict,
     doc_re: re.Pattern,
     elem_re: re.Pattern,
+    *,
+    whole_corpus: bool = True,
 ) -> list[Finding]:
     """TRACE-RES-001 — every emitted UPSTREAM ``@<layer>: <ID>`` tag in
     the corpus resolves on disk (the target document exists AND the cited
@@ -1793,6 +1795,15 @@ def _check_trace_resolution(
     auditor lens.
 
     Skipped:
+      * Cross-document citations on single-file (``on_author``) runs —
+        ``whole_corpus=False``. The corpus of a single-file run is the
+        edited document alone, so every upstream tag it emits is
+        unresolvable by construction and a wall of TRACE-RES-001 ERRORs
+        about correctly-cited documents would drown the real findings
+        (LINT-TRACE-RES-SINGLE-FILE). Only citations resolvable within
+        the linted document itself (self doc-tags, elements hosted by
+        this document) are still checked. Directory runs — ``pre_merge``,
+        pre-commit, CI — pass ``whole_corpus=True`` and are unaffected.
       * Index documents (frontmatter ``artifact_type: <X>-INDEX``) — they
         intentionally carry no trace tags.
       * Placeholder / malformed tag values — covered by PH01 / ID01.
@@ -1847,6 +1858,11 @@ def _check_trace_resolution(
             if m_pfx:
                 artifact_code = m_pfx.group(1)
         my_layer_n = layer_number.get(artifact_code, 0)
+        # This artifact's own doc_id — the one citation target that IS
+        # present in a single-file (on_author) corpus.
+        own_doc_id = ""
+        if fm:
+            own_doc_id = str(fm.get("doc_id") or "").strip().strip('"').strip("'")
 
         for i, line in enumerate(text.splitlines(), 1):
             for m in _TAG.finditer(line):
@@ -1859,6 +1875,21 @@ def _check_trace_resolution(
                 value = m.group(2)
                 if not (doc_re.match(value) or elem_re.match(value)):
                     continue
+                # LINT-TRACE-RES-SINGLE-FILE: on a single-file run, only
+                # citations of this document itself can resolve — skip
+                # everything cross-document (it is unresolvable by
+                # construction, not evidence of a defect).
+                if not whole_corpus:
+                    if doc_re.match(value):
+                        if value != own_doc_id:
+                            continue
+                    else:
+                        head = value.split(".", 2)
+                        host = (
+                            f"{head[0]}-{head[1]}" if len(head) >= 2 and head[1].isdigit() else ""
+                        )
+                        if host != own_doc_id:
+                            continue
                 if doc_re.match(value):
                     if value not in doc_index:
                         findings.append(
@@ -1895,7 +1926,9 @@ def _check_trace_resolution(
                             )
                         )
         # BDD YAML dual-mode: resolve scenario `ears` tokens (no @-tags to scan).
-        if artifact_code == "BDD":
+        # Skipped on single-file runs — scenario `ears` tokens are upstream
+        # EARS citations, cross-document by construction (see gate above).
+        if artifact_code == "BDD" and whole_corpus:
             scenarios, _ = _bdd_yaml_scenarios(text)
             if scenarios is not None:
                 for tok in _bdd_ears_tokens(scenarios):
@@ -2692,7 +2725,12 @@ def lint_path(
     findings.extend(_check_seed_disposition(corpus))
     findings.extend(_check_cascade(corpus))
     findings.extend(_check_staleness(corpus, _framework_version(registry or find_registry())))
-    findings.extend(_check_trace_resolution(corpus, layers, doc_re, elem_re))
+    # LINT-TRACE-RES-SINGLE-FILE: cross-document resolution is evidence only
+    # when the invocation covered a corpus — a single-file (on_author) run
+    # cannot resolve upstream tags by construction.
+    findings.extend(
+        _check_trace_resolution(corpus, layers, doc_re, elem_re, whole_corpus=target.is_dir())
+    )
     # REFGRAN01 is a form rule (GD-03), not the corpus coverage gate — it runs
     # unconditionally (not behind --skip-coverage-gate), with run-mode severity.
     findings.extend(_check_ref_granularity(corpus, mode))


### PR DESCRIPTION
Closes #412 (`LINT-TRACE-RES-SINGLE-FILE`)

## What

`_check_trace_resolution` resolved `@<layer>:` tags against a `doc_index` built from **the paths passed on the invocation**. Lint one file and every upstream tag is unresolvable by construction — 66 false `TRACE-RES-001` ERRORs on the corpus's `SPEC-01` alone, 14–70 on every layer-02..08 document. The plugin's `PostToolUse` review hook lints exactly one file, so this was its normal operating mode, spending the 4000-byte findings budget drowning real findings.

## Fix

Gate the cross-document arm on the **invocation shape** — `whole_corpus=target.is_dir()`:

- Directory runs (`pre_merge`, pre-commit, CI): byte-for-byte unchanged behavior.
- Single-file runs: skip citations that cannot resolve by construction; citations resolvable within the edited document itself (self doc-tags) still checked. The BDD scenario `ears` arm (upstream EARS citations, cross-document by construction) is skipped likewise.
- The gate follows the `_check_forward_coverage` / `_check_backward_coverage` precedent (corpus-scoped checks self-gating for `on_author` runs), but keyed on invocation shape rather than corpus content: a directory invocation of a one-file corpus must still fire (a citation of a document absent from the tree you linted whole IS a defect), which existing test `test_tag_referencing_missing_doc_fires_trace_res` pins.

## Verification

- Issue reproduction: single-file `SPEC-01.md` → 66 → **0** `TRACE-RES-001`; whole-corpus run unchanged at 0; `ADR-01.md`, `IPLAN-01.md` single-file → 0.
- New tests: `test_single_file_run_skips_cross_doc_resolution` and `test_single_file_run_skip_is_invocation_shaped` (same corpus: file run silent, directory run fires).
- `tests/unit` + lint guard conformance files: 259 passed. Full 379-test conformance suite green in pre-commit (vendoring test confirms byte-identical copies).
- Synced to both vendored copies via `tools/sdd_doc_lint/sync-vendored.sh` (plugin + Hermes).

## Not changed

- Whole-corpus semantics, `doc_index` construction, TAG01/ID01 intra-document checks, the hook itself.
