### PR TITLE
fix(build): repoint tracked .mcp.json off the retired ucx_framework (#437)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,9 +1,9 @@
 {
   "mcpServers": {
     "sdd-lifecycle": {
-      "command": "/opt/data/ucx_framework/.venv/bin/python",
+      "command": "/path/to/python",
       "args": ["-m", "mcp_server.server"],
-      "cwd": "/opt/data/ucx_framework/platforms/hermes/src"
+      "cwd": "/path/to/aidoc-flow-framework/platforms/hermes/src"
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — the tracked `.mcp.json` pointed at the retired ucx_framework checkout (2026-08-15)
+
+Closes [#437](https://github.com/vladm3105/aidoc-flow-framework/issues/437).
+The repo-root `.mcp.json` — tracked, so shipped to every clone — configured the
+`sdd-lifecycle` MCP server entirely inside `/opt/data/ucx_framework`, the
+retired pre-migration predecessor (`cwd` never resolved post-migration; the
+checkout itself is now deleted, so `command` dangles too). Both keys now carry
+the portable placeholder form that `platforms/hermes/README.md` §"Install"
+already documents for this exact file ("/path/to/python" +
+"/path/to/aidoc-flow-framework/platforms/hermes/src"), restoring the file's
+documented role as a reference config instead of a machine-specific dead one.
+A previous changelog-recorded sweep rewrote stale `/opt/data/ucx_framework/.venv`
+MCP paths to that placeholder but missed this file — the class was declared
+fixed while the live instance survived.
+
 ### Changed — Claude Code plugin `0.24.0` → `0.25.0` (2026-08-02)
 
 **PLUGIN-PREPROD-001 PR 5, stage c.** The version cut that carries the

--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -15,8 +15,9 @@
 >   resolve it). ≤ 3 lines per entry.
 > - Tags: `[lint]` / `[harness]` / `[skill]` / `[template]` / `[sync]` /
 >   `[plan-review]` / `[docs]` / `[hermes-parity]` / `[example-corpus]` /
->   `[ci]` / `[hermes]` / `[plugin]`. The last three were added by use before
->   they were declared here; a new tag belongs in this list when it is coined.
+>   `[ci]` / `[hermes]` / `[plugin]` / `[build]`. The last four were added by use
+>   before they were declared here; a new tag belongs in this list when it is
+>   coined.
 > - Once an item is large enough to design, promote to a formal plan
 >   and link from the TODO entry as `→ <NAME>-PLAN.md`. The TODO entry
 >   stays open until the plan ships, then moves to **Closed** with the
@@ -82,7 +83,16 @@
   against current `framework/**` before trusting any of the nine tasks.
 - *Stage:* unscheduled. Blocks nothing; the cost is silent loss, not breakage.
 
-### `[build]` `MCP-CONFIG-DEAD-PATHS` — tracked root `.mcp.json` configured the sdd-lifecycle server inside the retired `/opt/data/ucx_framework` — ⏳ FIX IN REVIEW ([#437](https://github.com/vladm3105/aidoc-flow-framework/issues/437), PR [#459](https://github.com/vladm3105/aidoc-flow-framework/pull/459): both keys moved to the portable placeholder form `platforms/hermes/README.md` §"Install" documents for this file)
+### `[build]` `MCP-CONFIG-DEAD-PATHS` — tracked root `.mcp.json` pointed the sdd-lifecycle server at the retired `ucx_framework` → #437
+
+- *Context:* the tracked root `.mcp.json` set both `command` and `cwd` inside
+  `/opt/data/ucx_framework`, the retired pre-migration predecessor. That
+  checkout is deleted from this machine, and `cwd` had never resolved since the
+  migration (the retired repo carried no `platforms/` layout). Claude Code
+  auto-loads this file at project root, so it shipped broken to every clone.
+- *Fix shape:* move both keys to the portable placeholder form
+  `platforms/hermes/README.md` §"Install" already documents for this exact file,
+  keeping that README's "set up as a reference" claim true.
 
 ### `[build]` `SYNC-WEBSITE-SILENT-NOOP` — the version sync writes a sibling repo, misses, and says nothing → #423
 
@@ -409,7 +419,7 @@
   shape, user-visible), but it is one repo's linter and not on the PLUGIN-PREPROD
   critical path.
 
-### `[hermes]` `HERMES-MCP-FLOATING-DEP` — `Hermes pytest` is red on an unpinned SDK floor, and a path filter hid it for days
+### `[hermes]` `HERMES-MCP-FLOATING-DEP` — `Hermes pytest` is red on an unpinned SDK floor, and a path filter hid it for days → #465
 
 - *Context:* surfaced 2026-07-31 on PR #406, which is the first PR to touch
   `platforms/hermes/**` since 2026-07-27 — the workflow is path-filtered, so the

--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -82,7 +82,7 @@
   against current `framework/**` before trusting any of the nine tasks.
 - *Stage:* unscheduled. Blocks nothing; the cost is silent loss, not breakage.
 
-### `[build]` `MCP-CONFIG-DEAD-PATHS` — tracked root `.mcp.json` configured the sdd-lifecycle server inside the retired `/opt/data/ucx_framework` — ⏳ FIX IN REVIEW ([#437](https://github.com/vladm3105/aidoc-flow-framework/issues/437): both keys moved to the portable placeholder form `platforms/hermes/README.md` §"Install" documents for this file)
+### `[build]` `MCP-CONFIG-DEAD-PATHS` — tracked root `.mcp.json` configured the sdd-lifecycle server inside the retired `/opt/data/ucx_framework` — ⏳ FIX IN REVIEW ([#437](https://github.com/vladm3105/aidoc-flow-framework/issues/437), PR [#459](https://github.com/vladm3105/aidoc-flow-framework/pull/459): both keys moved to the portable placeholder form `platforms/hermes/README.md` §"Install" documents for this file)
 
 ### `[build]` `SYNC-WEBSITE-SILENT-NOOP` — the version sync writes a sibling repo, misses, and says nothing → #423
 

--- a/plans/FRAMEWORK-TODO.md
+++ b/plans/FRAMEWORK-TODO.md
@@ -82,6 +82,8 @@
   against current `framework/**` before trusting any of the nine tasks.
 - *Stage:* unscheduled. Blocks nothing; the cost is silent loss, not breakage.
 
+### `[build]` `MCP-CONFIG-DEAD-PATHS` — tracked root `.mcp.json` configured the sdd-lifecycle server inside the retired `/opt/data/ucx_framework` — ⏳ FIX IN REVIEW ([#437](https://github.com/vladm3105/aidoc-flow-framework/issues/437): both keys moved to the portable placeholder form `platforms/hermes/README.md` §"Install" documents for this file)
+
 ### `[build]` `SYNC-WEBSITE-SILENT-NOOP` — the version sync writes a sibling repo, misses, and says nothing → #423
 
 - *Context:* found 2026-08-02 while measuring the plugin `VERSION` fanout for


### PR DESCRIPTION
Closes #437

## What

The tracked repo-root `.mcp.json` configured the `sdd-lifecycle` MCP server entirely inside `/opt/data/ucx_framework` — the retired pre-migration predecessor. Verified: the checkout is now **deleted** from this machine (per the issue's prediction), so both `command` and `cwd` are dead; `cwd` had likely never resolved since the migration (the retired repo never had a `platforms/` layout).

## Fix

Both keys moved to the portable placeholder form that `platforms/hermes/README.md` §"Install" already documents **for this exact file**:

```json
"command": "/path/to/python",
"cwd": "/path/to/aidoc-flow-framework/platforms/hermes/src"
```

This restores the file's documented role — the README calls the root `.mcp.json` "set up as a reference" — instead of a machine-specific dead config that ships broken to every clone. Chosen over untracking: the README's reference claim stays true, and the alternative (a per-machine venv path or plain `python3`) cannot be correct for two machines at once either.

Notable from the issue: a changelog-recorded sweep had already rewritten this exact class of `/opt/data/ucx_framework/.venv` MCP path to the placeholder form — and missed the root file, so the record asserted the class fixed while the live instance survived.

## Verification

- Valid JSON; conformance suite green in pre-commit; no test or workflow references `.mcp.json`.
- Alternative rejected on the merits, not unnoticed: untracking would have required rewording `platforms/hermes/README.md:30` ("root-level `.mcp.json` in this repo is set up as a reference"), which this PR keeps true.

## Not changed

- Hermes packaging, the plugin platform (unaffected — the `doc-*` skills do not read `.mcp.json`), the spec.
