### PR TITLE
fix(governance): allow registry-valid 3+ digit doc IDs in saga schema (#444)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — `saga.schema.json` rejected registry-valid 3+ digit document IDs (2026-08-15)
+
+Closes [#444](https://github.com/vladm3105/aidoc-flow-framework/issues/444).
+The saga journal schema validated `artifact_id` with `^[A-Z]+-[0-9]{2}$`
+(exactly two digits) while `LAYER_REGISTRY.yaml` `id_patterns.document` and
+`ID_NAMING_STANDARDS.md` both say **two or more** (`{2,}`) — so a project past
+99 documents of a type (or using an `IPLAN-001`-style convention) wrote journal
+entries the machine contract rejected, though the registry, the linter, and the
+review-team docs all accepted them. The pattern now matches the registry, and a
+new lockstep conformance test
+(`test_saga_lifecycle_parity.py::SagaIdPatternLockstep`) asserts the schema and
+registry `document` patterns never diverge again — the schema's own description
+demanded the lockstep but nothing enforced it. The plugin's vendored governance
+copy is synced.
+
 ### Changed — Claude Code plugin `0.24.0` → `0.25.0` (2026-08-02)
 
 **PLUGIN-PREPROD-001 PR 5, stage c.** The version cut that carries the

--- a/framework/governance/saga.schema.json
+++ b/framework/governance/saga.schema.json
@@ -26,8 +26,8 @@
     },
     "artifact_id": {
       "type": "string",
-      "pattern": "^[A-Z]+-[0-9]{2}$",
-      "description": "Short artifact ID like BRD-01, PRD-02. Pattern matches the 2-digit NN format mandated by framework/governance/ID_NAMING_STANDARDS.md §'Format'. If ID_NAMING_STANDARDS is ever revised to allow 3+ digits, this pattern must change in lockstep."
+      "pattern": "^[A-Z]+-[0-9]{2,}$",
+      "description": "Short artifact ID like BRD-01, PRD-02. Pattern matches the two-or-more-digit NN format of LAYER_REGISTRY.yaml id_patterns.document and ID_NAMING_STANDARDS.md §'Format' (three-plus-digit IDs like BRD-100 are registry-valid). The three surfaces must change in lockstep."
     },
     "layer": {
       "type": "string",

--- a/platforms/claude-code-plugin/framework/governance/saga.schema.json
+++ b/platforms/claude-code-plugin/framework/governance/saga.schema.json
@@ -26,8 +26,8 @@
     },
     "artifact_id": {
       "type": "string",
-      "pattern": "^[A-Z]+-[0-9]{2}$",
-      "description": "Short artifact ID like BRD-01, PRD-02. Pattern matches the 2-digit NN format mandated by framework/governance/ID_NAMING_STANDARDS.md §'Format'. If ID_NAMING_STANDARDS is ever revised to allow 3+ digits, this pattern must change in lockstep."
+      "pattern": "^[A-Z]+-[0-9]{2,}$",
+      "description": "Short artifact ID like BRD-01, PRD-02. Pattern matches the two-or-more-digit NN format of LAYER_REGISTRY.yaml id_patterns.document and ID_NAMING_STANDARDS.md §'Format' (three-plus-digit IDs like BRD-100 are registry-valid). The three surfaces must change in lockstep."
     },
     "layer": {
       "type": "string",

--- a/tests/conformance/test_saga_lifecycle_parity.py
+++ b/tests/conformance/test_saga_lifecycle_parity.py
@@ -384,6 +384,33 @@ class SagaRealJournalConformance(unittest.TestCase):
         self.assertEqual(data2["iteration"], 2)
 
 
+class SagaIdPatternLockstep(unittest.TestCase):
+    """#444: the schema's `artifact_id` pattern must equal the registry's
+    `id_patterns.document` pattern — the schema once rejected registry-valid
+    3+ digit IDs (``{2}`` vs ``{2,}``) and nothing asserted the lockstep the
+    schema's own description demanded. REVIEW_SAGA.md quotes the registry
+    pattern verbatim as authoritative; ID_NAMING_STANDARDS.md agrees with the
+    registry; only the schema was narrower."""
+
+    def test_artifact_id_pattern_matches_registry_document_pattern(self):
+        import yaml
+
+        schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+        schema_pattern = schema["properties"]["artifact_id"]["pattern"]
+        registry = yaml.safe_load(
+            (_REPO_ROOT / "framework" / "registry" / "LAYER_REGISTRY.yaml").read_text(
+                encoding="utf-8"
+            )
+        )
+        registry_pattern = registry["id_patterns"]["document"]
+        self.assertEqual(
+            schema_pattern,
+            registry_pattern.replace("\\d", "[0-9]"),
+            "saga.schema.json artifact_id and LAYER_REGISTRY.yaml id_patterns.document "
+            "diverged — documents valid at one surface are rejected at the other",
+        )
+
+
 class SagaTransitionInvariant(unittest.TestCase):
     """The Hermes mirror of `test_saga_driver_invariants.test_invalid_transition_raises`
     (the D-0050 residual): `transition_run_status` enforces the spec table — an illegal


### PR DESCRIPTION
Closes #444

## What

`framework/governance/saga.schema.json:29` validated journal `artifact_id` with `^[A-Z]+-[0-9]{2}$` — **exactly** two digits — while `LAYER_REGISTRY.yaml:215` (`id_patterns.document`) and `ID_NAMING_STANDARDS.md` both define **two or more** (`{2,}`). A registry-valid, linter-valid `BRD-100` (or the `IPLAN-001` convention already present in the templates) wrote saga journal entries the machine contract rejected.

## Fix

- Pattern → `^[A-Z]+-[0-9]{2,}$`, matching the registry; description rewritten to name all three lockstep surfaces.
- New `SagaIdPatternLockstep` conformance test asserts the schema pattern equals the registry's `id_patterns.document` (parsed via yaml, compared after normalizing `\d` → `[0-9]`) — the lockstep the schema's own description demanded, previously enforced by nothing.
- Plugin's vendored governance copy synced byte-identical.

## Verification

- `BRD-100` valid, `BRD-01` valid, `BRD-1` / `brd-01` still rejected (regex check run directly).
- `test_saga_lifecycle_parity.py` 15 passed (incl. journal fixtures validating against the widened schema); full conformance suite green.
- Mutation note: temporarily reverting the pattern makes the lockstep test fail on the registry side — it measures the divergence, not just the schema's shape.

## Not changed

- `REVIEW_SAGA.md` (already quotes the registry pattern verbatim as authoritative), the registry, `ID_NAMING_STANDARDS.md`, the linter's `doc_re` — all already agreed; only the schema was narrower.
