### PR TITLE
fix(governance): define the @chg provenance tag the CHG auditor requires (#448)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,25 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — the CHG auditor's P1 `@chg: CHG-NN` requirement cited a tag defined nowhere (2026-08-15)
+
+Closes [#448](https://github.com/vladm3105/aidoc-flow-framework/issues/448).
+`playbooks/09_CHG/auditor.md` made the `@chg: CHG-NN` back-reference a **P1**
+requirement (check C1), but the form appeared in no other spec surface — not
+`TAG_SYNTAX.md`, not the registry, not the CHG template — so an auditor demanded
+a citation whose syntax, carriers, and placement no document specified, and a
+corrected artifact could not know the required shape. `TAG_SYNTAX.md` now
+defines it in a new §"Provenance tag": document-level form matching the CHG
+record's `chg_id`, carried by every artifact in the CHG's
+`implementation.artifacts_modified[]` with `change_type: modified`, placed in
+the artifact's traceability section (or Document Control where the template has
+none), pipe-delimited cardinality unchanged — and explicitly **not** a trace
+citation (CHG is a governance overlay in no layer's `required_tags`, so the
+linter's `_TAG` correctly ignores it). The auditor playbook's two references now
+cite the definition, and C1 names the real template field
+(`artifacts_modified[]`, not a nonexistent `impact_assessment` propagated-diff
+list). The plugin's vendored framework mirror is synced.
+
 ### Changed — Claude Code plugin `0.24.0` → `0.25.0` (2026-08-02)
 
 **PLUGIN-PREPROD-001 PR 5, stage c.** The version cut that carries the

--- a/framework/governance/TAG_SYNTAX.md
+++ b/framework/governance/TAG_SYNTAX.md
@@ -52,6 +52,28 @@ These use the document form and are **exempt** from `REFGRAN01`:
   navigation (`@tdd: TDD-01` as a "Downstream" hint on a SPEC): informational,
   points at a not-yet-or-elsewhere-realized layer.
 
+## Provenance tag — `@chg: CHG-NN` (change back-reference)
+
+`@chg:` is **not a trace tag**: it carries no lineage (CHG is a governance
+overlay, not one of the 8 registry layers, and appears in no layer's
+`required_tags` or `can_reference`). It is a **provenance back-reference** from
+a modified artifact to the change record that authorized the edit:
+
+- **Form:** `@chg: CHG-NN` — always document-level (`CHG-NN` matches the CHG
+  record's `chg_id` in `CHG-TEMPLATE.yaml`; CHG declares no elements).
+- **Carrier:** every artifact listed in the CHG's
+  `implementation.artifacts_modified[]` with `change_type: modified` (created
+  artifacts cite the CHG in their own Document Control origin; deleted
+  artifacts obviously carry nothing).
+- **Placement:** in the modified artifact's traceability section, or its
+  Document Control where the layer template has no traceability section —
+  anywhere the tag is discoverable by a reader diffing the artifact.
+- **Semantics:** without it, a modified artifact is an unsourced edit
+  indistinguishable from a hand-edit. The CHG auditor check **C1** (P1)
+  enforces it on every modified artifact; this section is the definition C1
+  cites. Pipe-delimited cardinality (above) applies unchanged when one
+  artifact was touched by several CHGs.
+
 ## Per-layer necessary-upstream tags
 
 Each layer's `required_tags` (its direct upstream — see `TRACEABILITY.md`) use

--- a/framework/playbooks/09_CHG/auditor.md
+++ b/framework/playbooks/09_CHG/auditor.md
@@ -21,7 +21,10 @@ survive contact with the next CHG that touches the same artifacts.
 Back-references are the central concept. Every artifact the CHG
 modified must carry a `@chg: CHG-NN` tag pointing back to this CHG,
 so that a future reader looking at a BRD / PRD / EARS / etc. update
-can trace it to the governing change record. Without that
+can trace it to the governing change record. The tag's syntax,
+carriers, and placement are defined in
+`governance/TAG_SYNTAX.md` §"Provenance tag" — a document-level
+provenance back-reference, not a trace citation. Without that
 back-reference, the modified artifact looks like an unsourced edit,
 indistinguishable from a hand-edit. The auditor lens also verifies
 that the change-level classification (C1 / C2 / C3 / Emergency)
@@ -53,9 +56,10 @@ Every finding MUST cite which check fired. Findings without a check
 citation are out-of-scope and discarded by the synthesizer.
 
 **C1 — Every modified artifact carries `@chg: CHG-NN` back-reference.**
-Each artifact the CHG modifies (named in `impact_assessment` with a
-propagated diff) must include a `@chg: CHG-NN` back-reference
-pointing to this CHG, so future readers can trace the edit. A
+Each artifact the CHG modifies (named in `implementation.artifacts_modified[]`
+with `change_type: modified`) must include a `@chg: CHG-NN` back-reference
+pointing to this CHG, in the form and placement `governance/TAG_SYNTAX.md`
+§"Provenance tag" defines. A
 modified artifact without the back-reference is indistinguishable
 from an unsourced hand-edit. Missing on any modified artifact → P1
 citing C1.

--- a/platforms/claude-code-plugin/framework/governance/TAG_SYNTAX.md
+++ b/platforms/claude-code-plugin/framework/governance/TAG_SYNTAX.md
@@ -52,6 +52,28 @@ These use the document form and are **exempt** from `REFGRAN01`:
   navigation (`@tdd: TDD-01` as a "Downstream" hint on a SPEC): informational,
   points at a not-yet-or-elsewhere-realized layer.
 
+## Provenance tag — `@chg: CHG-NN` (change back-reference)
+
+`@chg:` is **not a trace tag**: it carries no lineage (CHG is a governance
+overlay, not one of the 8 registry layers, and appears in no layer's
+`required_tags` or `can_reference`). It is a **provenance back-reference** from
+a modified artifact to the change record that authorized the edit:
+
+- **Form:** `@chg: CHG-NN` — always document-level (`CHG-NN` matches the CHG
+  record's `chg_id` in `CHG-TEMPLATE.yaml`; CHG declares no elements).
+- **Carrier:** every artifact listed in the CHG's
+  `implementation.artifacts_modified[]` with `change_type: modified` (created
+  artifacts cite the CHG in their own Document Control origin; deleted
+  artifacts obviously carry nothing).
+- **Placement:** in the modified artifact's traceability section, or its
+  Document Control where the layer template has no traceability section —
+  anywhere the tag is discoverable by a reader diffing the artifact.
+- **Semantics:** without it, a modified artifact is an unsourced edit
+  indistinguishable from a hand-edit. The CHG auditor check **C1** (P1)
+  enforces it on every modified artifact; this section is the definition C1
+  cites. Pipe-delimited cardinality (above) applies unchanged when one
+  artifact was touched by several CHGs.
+
 ## Per-layer necessary-upstream tags
 
 Each layer's `required_tags` (its direct upstream — see `TRACEABILITY.md`) use

--- a/platforms/claude-code-plugin/framework/playbooks/09_CHG/auditor.md
+++ b/platforms/claude-code-plugin/framework/playbooks/09_CHG/auditor.md
@@ -21,7 +21,10 @@ survive contact with the next CHG that touches the same artifacts.
 Back-references are the central concept. Every artifact the CHG
 modified must carry a `@chg: CHG-NN` tag pointing back to this CHG,
 so that a future reader looking at a BRD / PRD / EARS / etc. update
-can trace it to the governing change record. Without that
+can trace it to the governing change record. The tag's syntax,
+carriers, and placement are defined in
+`governance/TAG_SYNTAX.md` §"Provenance tag" — a document-level
+provenance back-reference, not a trace citation. Without that
 back-reference, the modified artifact looks like an unsourced edit,
 indistinguishable from a hand-edit. The auditor lens also verifies
 that the change-level classification (C1 / C2 / C3 / Emergency)
@@ -53,9 +56,10 @@ Every finding MUST cite which check fired. Findings without a check
 citation are out-of-scope and discarded by the synthesizer.
 
 **C1 — Every modified artifact carries `@chg: CHG-NN` back-reference.**
-Each artifact the CHG modifies (named in `impact_assessment` with a
-propagated diff) must include a `@chg: CHG-NN` back-reference
-pointing to this CHG, so future readers can trace the edit. A
+Each artifact the CHG modifies (named in `implementation.artifacts_modified[]`
+with `change_type: modified`) must include a `@chg: CHG-NN` back-reference
+pointing to this CHG, in the form and placement `governance/TAG_SYNTAX.md`
+§"Provenance tag" defines. A
 modified artifact without the back-reference is indistinguishable
 from an unsourced hand-edit. Missing on any modified artifact → P1
 citing C1.


### PR DESCRIPTION
Closes #448

## What

`framework/playbooks/09_CHG/auditor.md:22` and `:55-57` make `@chg: CHG-NN` a **P1** requirement (check C1), but the tag form appeared in exactly those three lines and nowhere else in the spec — not `TAG_SYNTAX.md` (which defines the full `@`-tag vocabulary and the BDD exception), not the registry, not `CHG-TEMPLATE.yaml`. An auditor enforcing C1 demanded a citation whose format no document specified; a corrected artifact could not know the required shape. Nothing validates playbook tag references against `TAG_SYNTAX.md`, and CHG is an overlay outside the 8 registry layers, so `test_layer_registry_necessary_upstream` never checked it — which is why the gap survived.

## Fix (option (a) — define the tag)

New `TAG_SYNTAX.md` §"Provenance tag — `@chg: CHG-NN`":

- **Form:** document-level, matching the CHG record's `chg_id` (CHG declares no elements).
- **Carrier:** every artifact in the CHG's `implementation.artifacts_modified[]` with `change_type: modified`; created artifacts cite origin in their own Document Control; deleted carry nothing.
- **Placement:** the modified artifact's traceability section, or Document Control where the layer template has none.
- **Class distinction:** explicitly NOT a trace citation — no lineage, in no layer's `required_tags`/`can_reference`. This is not just doctrinal: the linter's `_TAG` regex is built from registry layer tags only, so `@chg:` is correctly invisible to TAG01/TRACE-RES — the definition now says why that is correct rather than accidental.

The auditor playbook's two references now cite the definition, and C1 names the real template field — `implementation.artifacts_modified[]` — instead of an `impact_assessment` "propagated diff" list the template doesn't have. Plugin's vendored framework mirror synced byte-identical.

## Verification

- Governance + playbook conformance files: 11 passed, 188 subtests.
- Full conformance suite green in pre-commit.
- The doc-path the playbook cites (`governance/TAG_SYNTAX.md` §"Provenance tag") verified to exist by reading the file back.

## Not changed

- The existing `@`-tag vocabulary, registry `required_tags`, CHG gate routing (GATE-01/03/06/08/CODE/SPEC), `CHG-TEMPLATE.yaml`.
- The C5 re-gate field gap class the issue notes — separate issue if pursued.
