### PR TITLE
fix(spec): align AI_ASSISTANT_RULES generation-order from-clauses with required_tags (#450)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — AI_ASSISTANT_RULES generation-order `from` clauses contradicted the registry (2026-08-15)
+
+Closes [#450](https://github.com/vladm3105/aidoc-flow-framework/issues/450).
+The file a consuming project points its assistants at "before authoring"
+taught exactly the wrong upstream citations: ADR "(from BDD + PRD topics)"
+omitted EARS and added out-of-set PRD; SPEC "(from ADR + BDD)" and TDD
+"(from SPEC + BDD)" omitted EARS (and ADR for TDD); IPLAN "(from TDD)" omitted
+SPEC — each contradicting both the same file's own necessary-upstream doctrine
+(line 12) and `LAYER_REGISTRY.yaml` `required_tags`. The four clauses now
+match the registry exactly: ADR (from EARS + BDD), SPEC (from EARS + BDD +
+ADR), TDD (from EARS + BDD + ADR + SPEC), IPLAN (from SPEC + TDD). This is the
+trace-fabrication/omission class the doctrine exists to prevent: an assistant
+following the old text would emit a `@prd` tag on an ADR the linter's TAG01
+rejects, and omit the `@ears` tag it demands.
+
 ### Changed — Claude Code plugin `0.24.0` → `0.25.0` (2026-08-02)
 
 **PLUGIN-PREPROD-001 PR 5, stage c.** The version cut that carries the

--- a/framework/AI_ASSISTANT_RULES.md
+++ b/framework/AI_ASSISTANT_RULES.md
@@ -20,10 +20,10 @@
 2. PRD — product features, user stories (from BRD)
 3. EARS — formal WHEN-THE-SHALL-WITHIN requirements (from PRD)
 4. BDD — Given-When-Then scenarios with spec_trace to SPEC (from EARS)
-5. ADR — architecture decisions (from BDD + PRD topics)
-6. SPEC — component interfaces, data models, behavior contracts (from ADR + BDD)
-7. TDD — test case definitions with inputs/outputs/edge cases (from SPEC + BDD)
-8. IPLAN — file manifest, bash commands, session handoff (from TDD)
+5. ADR — architecture decisions (from EARS + BDD)
+6. SPEC — component interfaces, data models, behavior contracts (from EARS + BDD + ADR)
+7. TDD — test case definitions with inputs/outputs/edge cases (from EARS + BDD + ADR + SPEC)
+8. IPLAN — file manifest, bash commands, session handoff (from SPEC + TDD)
 9. Code — implementation from IPLAN
 ```
 


### PR DESCRIPTION
Closes #450

## What

`framework/AI_ASSISTANT_RULES.md:23-26` (Layer Generation Order) stated `from` clauses contradicting both the file's own necessary-upstream doctrine (`:12`: "Cite only the layer's **necessary upstream** (its `required_tags`)") and `LAYER_REGISTRY.yaml`:

| Layer | Was | Registry `required_tags` | Now |
|---|---|---|---|
| ADR | BDD + PRD topics | `[ears, bdd]` | EARS + BDD |
| SPEC | ADR + BDD | `[ears, bdd, adr]` | EARS + BDD + ADR |
| TDD | SPEC + BDD | `[ears, bdd, adr, spec]` | EARS + BDD + ADR + SPEC |
| IPLAN | TDD | `[spec, tdd]` | SPEC + TDD |

Rows 1–4 (BRD/PRD/EARS/BDD) were already correct and are untouched.

## Why it matters

This is the AI entry document consuming projects point assistants at before authoring. Following the old text, an assistant emits a `@prd` tag on an ADR (out-of-set — linter TAG01 rejects it) and omits the `@ears` tag TAG01 demands — the exact trace-fabrication/omission class the doctrine exists to prevent.

## Verification

- Each new clause diffed against `LAYER_REGISTRY.yaml` `required_tags` (lines 84/97/110/123) — exact set equality, same order as the registry.
- Full conformance suite green.

## Not changed

- Layer ordering (1–9), the doctrine text, the registry (correct as-is), layer READMEs (`framework/layers/04_BDD/README.md:49` has a related-but-distinct stale phrase tracked by #439).
