### PR TITLE
fix(playbooks): align PRD auditor C3 section list with PRD-TEMPLATE.yaml (#446)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — the PRD auditor's mandatory-section list was 9 of 15 positions wrong (2026-08-15)
+
+Closes [#446](https://github.com/vladm3105/aidoc-flow-framework/issues/446).
+`playbooks/02_PRD/auditor.md` C3 pinned "mandatory sections" against a PRD
+template that no longer exists — §1 Overview / §4 Non-Goals / §6 Personas /
+§12 NFRs / §14 Glossary / §15 Document Control and more, 9 of 15 positions
+wrong versus `PRD-TEMPLATE.yaml`, and the template has **no NFR section** at
+all. An auditor following it flagged valid PRDs and never checked the real §2
+Executive Summary / §6 Goals & Objectives / §10 Customer-Facing Content /
+§14 Traceability. C3 now lists the template's actual §1–§15 (naming §7b as
+optional), C4's glossary pointer moves §14→§15, C5's Document Control pointer
+§15→§1, the altitude-note's section list matches real titles, and
+`chaos_engineer.md`'s two §12 "non-functional anchor" wordings point at
+§12 Constraints & Assumptions (the section that exists). The plugin's vendored
+playbook mirror is synced.
+
 ### Changed — Claude Code plugin `0.24.0` → `0.25.0` (2026-08-02)
 
 **PLUGIN-PREPROD-001 PR 5, stage c.** The version cut that carries the

--- a/framework/playbooks/02_PRD/auditor.md
+++ b/framework/playbooks/02_PRD/auditor.md
@@ -21,8 +21,8 @@ navigational or traceability ambiguity.
 
 At BRD altitude the auditor validated BRD-specific IDs and sections. At PRD
 altitude the ID pattern changes, the required sections change (§5 Success
-Metrics, §9 Functional Requirements, §11 Acceptance Criteria, §12 NFRs, §13
-Risks replace BRD sections), and `@brd:` cross-reference tags become a new
+Metrics & KPIs, §9 Functional Requirements, §11 Acceptance Criteria, §12
+Constraints & Assumptions, §13 Risk Assessment replace BRD sections), and `@brd:` cross-reference tags become a new
 resolution requirement. At EARS altitude the auditor validates EARS-specific
 requirement IDs and conformance sections. The auditor's role — structural
 completeness, ID conformance, reference resolution — is constant across
@@ -56,19 +56,22 @@ elements to downstream EARS requirements. Missing → P1 finding citing C2.
 **C3 — Required template sections present.** The PRD template mandates a
 defined set of sections. Every mandatory section must be present, even if
 populated with "N/A — not applicable" and a rationale. Mandatory sections
-include at minimum: §1 Overview, §2 Problem Statement, §3 Goals, §4 Non-Goals,
-§5 Success Metrics, §6 Personas, §7 Scope, §8 User Stories, §9 Functional
-Requirements, §10 User-Facing Surfaces, §11 Acceptance Criteria, §12 NFRs,
-§13 Risks, §14 Glossary, §15 Document Control. Absent sections without
+include at minimum: §1 Document Control, §2 Executive Summary, §3 Problem
+Statement, §4 Target Audience & User Personas, §5 Success Metrics & KPIs,
+§6 Goals & Objectives, §7 Scope & Requirements, §8 User Stories & User Roles,
+§9 Functional Requirements, §10 Customer-Facing Content & Messaging,
+§11 Acceptance Criteria, §12 Constraints & Assumptions, §13 Risk Assessment,
+§14 Traceability, §15 Glossary (matching `PRD-TEMPLATE.yaml` §1–§15; §7b
+Component Decomposition is optional). Absent sections without
 explicit N/A are not inferrable. Missing → P1 finding citing C3.
 
 **C4 — Glossary covers PRD-introduced terms.** Every domain-specific or
-PRD-specific term introduced in the document body must appear in §14 Glossary
+PRD-specific term introduced in the document body must appear in §15 Glossary
 with a definition scoped to this document's usage. Terms that appeared in the
 BRD and carry the same meaning may be cross-referenced rather than redefined.
 Missing → P3 finding citing C4.
 
-**C5 — Self-claimed score not used as audit verdict.** If the PRD's §15
+**C5 — Self-claimed score not used as audit verdict.** If the PRD's §1
 Document Control contains a self-assessed quality score, the auditor must flag
 that this score must not be used as the synthesizer's verdict. The synthesizer
 determines the audit verdict from the aggregated lens findings in `verdict.json`,

--- a/framework/playbooks/02_PRD/chaos_engineer.md
+++ b/framework/playbooks/02_PRD/chaos_engineer.md
@@ -36,9 +36,10 @@ Every finding MUST cite which check fired. Findings without a check citation
 are out-of-scope and discarded by the synthesizer.
 
 **C1 — §13 risk-row symmetry (CE-1 calibration).** Every risk row in §13
-must have three anchors: (a) a §10 user-facing surface that exposes this risk
+must have three anchors: (a) a §10 customer-facing surface that exposes this risk
 to users, (b) a §11 AC gate that verifies the mitigation is in place, and (c)
-a §12 non-functional anchor (NFR, SLO, or ADR deferral). A risk row that
+a §12 constraints & assumptions anchor (NFR, SLO, constraint, or ADR
+deferral). A risk row that
 names a mitigation but lacks any of the three anchors is structurally
 incomplete — the PRD-01 pool-exhaustion risk had §13 text and §10 surface but
 no §11 gate, which let the risk pass review undetected. Missing → P2 finding

--- a/platforms/claude-code-plugin/framework/playbooks/02_PRD/auditor.md
+++ b/platforms/claude-code-plugin/framework/playbooks/02_PRD/auditor.md
@@ -21,8 +21,8 @@ navigational or traceability ambiguity.
 
 At BRD altitude the auditor validated BRD-specific IDs and sections. At PRD
 altitude the ID pattern changes, the required sections change (§5 Success
-Metrics, §9 Functional Requirements, §11 Acceptance Criteria, §12 NFRs, §13
-Risks replace BRD sections), and `@brd:` cross-reference tags become a new
+Metrics & KPIs, §9 Functional Requirements, §11 Acceptance Criteria, §12
+Constraints & Assumptions, §13 Risk Assessment replace BRD sections), and `@brd:` cross-reference tags become a new
 resolution requirement. At EARS altitude the auditor validates EARS-specific
 requirement IDs and conformance sections. The auditor's role — structural
 completeness, ID conformance, reference resolution — is constant across
@@ -56,19 +56,22 @@ elements to downstream EARS requirements. Missing → P1 finding citing C2.
 **C3 — Required template sections present.** The PRD template mandates a
 defined set of sections. Every mandatory section must be present, even if
 populated with "N/A — not applicable" and a rationale. Mandatory sections
-include at minimum: §1 Overview, §2 Problem Statement, §3 Goals, §4 Non-Goals,
-§5 Success Metrics, §6 Personas, §7 Scope, §8 User Stories, §9 Functional
-Requirements, §10 User-Facing Surfaces, §11 Acceptance Criteria, §12 NFRs,
-§13 Risks, §14 Glossary, §15 Document Control. Absent sections without
+include at minimum: §1 Document Control, §2 Executive Summary, §3 Problem
+Statement, §4 Target Audience & User Personas, §5 Success Metrics & KPIs,
+§6 Goals & Objectives, §7 Scope & Requirements, §8 User Stories & User Roles,
+§9 Functional Requirements, §10 Customer-Facing Content & Messaging,
+§11 Acceptance Criteria, §12 Constraints & Assumptions, §13 Risk Assessment,
+§14 Traceability, §15 Glossary (matching `PRD-TEMPLATE.yaml` §1–§15; §7b
+Component Decomposition is optional). Absent sections without
 explicit N/A are not inferrable. Missing → P1 finding citing C3.
 
 **C4 — Glossary covers PRD-introduced terms.** Every domain-specific or
-PRD-specific term introduced in the document body must appear in §14 Glossary
+PRD-specific term introduced in the document body must appear in §15 Glossary
 with a definition scoped to this document's usage. Terms that appeared in the
 BRD and carry the same meaning may be cross-referenced rather than redefined.
 Missing → P3 finding citing C4.
 
-**C5 — Self-claimed score not used as audit verdict.** If the PRD's §15
+**C5 — Self-claimed score not used as audit verdict.** If the PRD's §1
 Document Control contains a self-assessed quality score, the auditor must flag
 that this score must not be used as the synthesizer's verdict. The synthesizer
 determines the audit verdict from the aggregated lens findings in `verdict.json`,

--- a/platforms/claude-code-plugin/framework/playbooks/02_PRD/chaos_engineer.md
+++ b/platforms/claude-code-plugin/framework/playbooks/02_PRD/chaos_engineer.md
@@ -36,9 +36,10 @@ Every finding MUST cite which check fired. Findings without a check citation
 are out-of-scope and discarded by the synthesizer.
 
 **C1 — §13 risk-row symmetry (CE-1 calibration).** Every risk row in §13
-must have three anchors: (a) a §10 user-facing surface that exposes this risk
+must have three anchors: (a) a §10 customer-facing surface that exposes this risk
 to users, (b) a §11 AC gate that verifies the mitigation is in place, and (c)
-a §12 non-functional anchor (NFR, SLO, or ADR deferral). A risk row that
+a §12 constraints & assumptions anchor (NFR, SLO, constraint, or ADR
+deferral). A risk row that
 names a mitigation but lacks any of the three anchors is structurally
 incomplete — the PRD-01 pool-exhaustion risk had §13 text and §10 surface but
 no §11 gate, which let the risk pass review undetected. Missing → P2 finding


### PR DESCRIPTION
Closes #446

## What

`framework/playbooks/02_PRD/auditor.md:59-62` (check C3, P1) listed "mandatory PRD sections" from a template that no longer exists. Versus `framework/layers/02_PRD/PRD-TEMPLATE.yaml`, 9 of 15 positions were wrong, and the template has **no NFR section**. An auditor applying it flagged every valid PRD (missing "§1 Overview", "§4 Non-Goals", "§6 Personas", "§12 NFRs") and never checked the real §2 Executive Summary, §6 Goals & Objectives, §10 Customer-Facing Content & Messaging, §14 Traceability.

## Changes

| Location | Was | Now |
|---|---|---|
| C3 (`:59-62`) | 15-section list, 9 positions wrong | the template's actual §1–§15, with §7b noted optional |
| C4 (`:66`) | §14 Glossary | §15 Glossary (§14 is Traceability) |
| C5 (`:71`) | §15 Document Control | §1 Document Control |
| altitude note (`:23-24`) | "§12 NFRs, §13 Risks" | "§12 Constraints & Assumptions, §13 Risk Assessment" |
| `chaos_engineer.md` C1 (`:41`) | "§12 non-functional anchor (NFR, SLO…)" | "§12 constraints & assumptions anchor (NFR, SLO, constraint, or ADR deferral)" |
| `chaos_engineer.md` C1 (`:39`) | "§10 user-facing surface" | "§10 customer-facing surface" (matches §10's title) |

Section numbers re-derived from `PRD-TEMPLATE.yaml` `# Section N:` headers directly, not from the issue text.

## Verification

- Playbook coverage/frontmatter conformance green (4 passed, 153 subtests); full suite green in pre-commit.
- Remaining `§N` references in both files re-checked one by one against the template map — all positions now valid.

## Not broken (per the issue, re-verified)

§5/§9/§11/§13 references were already correct; the template itself is internally consistent; `chaos_engineer`'s §13/§10/§11 positional references were right (only wording updated).

Vendored plugin playbook mirror synced byte-identical.
