### PR TITLE
fix(build): count-guard the version fanout against historical mentions (#405)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -122,6 +122,13 @@ repos:
         # Only run when one of the authoritative VERSION files changes — this
         # keeps the hook silent on commits that don't bump a version.
         files: '^(platforms/[^/]+/VERSION|framework/VERSION)$'
+        # verbose so the #405 count-guard WARN block reaches the contributor.
+        # The guard's whole remedy is "skip the substitution and warn a human to
+        # reword the historical mention" — but the script always exits 0, and
+        # pre-commit prints a PASSING hook's output only under verbose. Without
+        # this, the one run where the skip was the only action is silent, which
+        # is the same silence #405 was filed about, just relocated.
+        verbose: true
 
       # Warning hook: when a commit changes code/spec/skills but does NOT
       # touch any of the documents-of-record (CHANGELOG, ROADMAP, README,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,69 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — the version-sync fanout can no longer silently rewrite historical "shipped in vX" claims (2026-08-15)
+
+Closes [#405](https://github.com/vladm3105/aidoc-flow-framework/issues/405)
+(`SYNC-HISTORICAL-REF-CORRUPTION`). The `hermes/v*` / `claude-code-plugin/v*`
+fanout in `sync-version-refs.sh` did an unanchored global replace, so a
+historical mention written in the swept literal form was rewritten one version
+forward at every bump — a "shipped in `hermes/v0.11.0`" claim in
+`docs/PARITY.md` was corrupted on **three consecutive releases**, silently, by
+the pre-commit autofix, landing attributed to the release author. The script's
+own HAZARD comment documented the class but the fanout block carried neither
+guard nor warning.
+
+Fix: a `replace_in_file_counted` helper (count-guarded substitution) now backs
+**eleven** call sites — the six `X/vN.N.N` tag calls and, after review, the
+five `framework spec \`X.Y.Z\`` calls as well. An occurrence count above the
+expected count **skips the substitution and warns**, so a historical claim
+survives for a human to reword instead of being silently falsified.
+
+Extending it to the framework-spec fanout is the substantive change here.
+That block is not a hypothetical: its own comment records that it already
+corrupted the D-0031 provenance lines in `docs/PARITY.md`, `0.13.0 -> 0.23.0`.
+Closing #405 on the tag literals alone would have left the one fanout with a
+*realized* instance of the defect unguarded. Its expected counts are 1 for
+`CLAUDE.md`, `README.md` and `docs/PARITY.md`, and **2** for each platform
+README — a prose conformance sentence plus a `| Conforms to |` table row,
+verified by inspection rather than assumed uniform.
+
+Three defects in the guard itself, found by review and fixed here:
+
+- The count came from `grep -oF` (occurrences) while the diagnostic listed
+  lines via `grep -nF | tail -n +N`. The two do not index each other, so two
+  occurrences on one line printed an empty "extra occurrence(s)" list. Worse,
+  the positional listing assumed the legitimate rows come *first* — in
+  `docs/PARITY.md` the historical mention sat at `:43` and the current-state
+  row later, so it would have named the **current-state row** as the thing to
+  reword, silently disabling that file's sync. It now prints every matching
+  line and says one of them is historical.
+- The count was fixed-string but the substitution was `sed` BRE, where `.` is
+  a wildcard — so sed could rewrite more than was counted, which is the exact
+  class the guard exists to stop. The pattern is now escaped.
+- `.pre-commit-config.yaml` did not set `verbose: true` on this hook, and the
+  script always exits 0. pre-commit prints a passing hook's output only under
+  verbose, so in the one run where the skip was the *only* action the warning
+  reached nobody — the same silence #405 was filed about, relocated. Set.
+
+The magic counts are no longer maintained by comment alone:
+`tests/conformance/test_sync_version_refs_counts.py` parses the call sites out
+of the script and asserts each expected count against the tree, with a vacuity
+guard so a reformat cannot make it pass over an empty list. Mutation-verified:
+an inflated expectation and an added current-state row each fail it.
+
+The latent instance is also closed — `docs/PARITY.md:43`'s
+`(claude-code-plugin/v0.21.0, 2026-06-22)` is reworded to "the `0.21.0` plugin
+cycle", which is what makes the plugin counts exactly one.
+
+Verified in a throwaway worktree, not asserted: a clean `0.40.0 -> 0.41.0` bump
+moves all five framework-spec surfaces with the expected 1/1/1/2/2 counts, and
+an injected historical mention fires the guard, survives the bump, and is
+listed alongside the current-state row it must not be confused with. Line
+numbers are deliberately absent from the comments this entry cites — the #405
+fix itself shifted them, invalidating the `:141` and `:209` citations an
+earlier draft of this entry carried.
+
 ### Fixed — the tracked `.mcp.json` pointed at the retired ucx_framework checkout (2026-08-15)
 
 Closes [#437](https://github.com/vladm3105/aidoc-flow-framework/issues/437).

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -40,7 +40,7 @@ contract.
 vendored into the bundle, now invoked by **all 8 layer autopilots**
 (`doc-{brd,prd,ears,bdd,adr,spec,tdd,iplan}-autopilot`) plus the CHG family
 as thin entry points — completed by SAGA-PARITY-001 **Phase 4**
-(`claude-code-plugin/v0.21.0`, 2026-06-22). The driver's `can_transition`
+(the `0.21.0` plugin cycle, 2026-06-22). The driver's `can_transition`
 raises on invalid transitions and owns the saga.json journal directly.
 (Background: plugin v0.6.0's cooperative-enforcement attempt empirically
 failed in the 2026-06-05 live BRD verification — invalid transitions,

--- a/scripts/sync-version-refs.sh
+++ b/scripts/sync-version-refs.sh
@@ -115,6 +115,64 @@ replace_in_file() {
   return 0
 }
 
+# HAZARD (FRWK-REVIEW-002 F1 / #405, SYNC-HISTORICAL-REF-CORRUPTION):
+# replace_in_file does a GLOBAL sed of the literal, so it cannot tell a
+# current-state row from a historical/provenance mention written in the same
+# form — this corrupted a "shipped in hermes/v0.11.0" claim in docs/PARITY.md
+# on three consecutive bumps (each bump rewrote the historical version one
+# release forward; see #405). Both the `X/vN.N.N` tag literals AND the
+# "framework spec `X.Y.Z`" literal are now swept via replace_in_file_counted
+# with the exact number of current-state rows per file: an occurrence count
+# ABOVE the expected count means a historical mention has (re)appeared in the
+# swept form — the substitution is SKIPPED with a warning listing every
+# matching line, so the historical claim survives and a human rewords it
+# (the remedy: write historical mentions as "the `0.21.0` plugin cycle", never
+# "claude-code-plugin/v0.21.0").
+#
+# Cite this note by NAME, never by line number. The #405 fix inserted ~50 lines
+# above it, which silently invalidated every ":141"/":209" citation that pointed
+# here — including two in the changelog entry that shipped the fix.
+#
+# When you deliberately ADD or REMOVE a current-state row in one of these files,
+# update the expected count in the same change. tests/conformance/
+# test_sync_version_refs_counts.py asserts the counts against the tree, so a
+# drifted expectation fails CI rather than silently skipping a file's sync.
+replace_in_file_counted() {
+  local file="$1" old="$2" new="$3" expected="$4"
+  [[ -f "$file" ]] || return 0
+  [[ "$old" != "$new" ]] || return 0
+  local count old_re
+  count="$(grep -oF "$old" "$file" 2>/dev/null | wc -l)"
+  [[ "$count" -eq 0 ]] && return 0
+  if [[ "$count" -gt "$expected" ]]; then
+    # Report ALL matching lines, not "the ones past the expected count". The
+    # count is per OCCURRENCE (grep -oF) while a listing is per LINE, so the two
+    # do not index each other: two occurrences on one line would print nothing.
+    # Worse, "the extra ones" assumes the legitimate current-state rows come
+    # FIRST — in docs/PARITY.md the historical mention sat at :43 and the
+    # current-state row later, so a positional listing names the wrong line and
+    # tells a human to reword the row the sync depends on. Print every match and
+    # let the reader identify the historical one.
+    warn "SYNC-HISTORICAL-REF-CORRUPTION guard: $file holds $count occurrence(s) of '$old', expected <= $expected — skipping the substitution."
+    warn "  All $count matching line(s) — ONE OR MORE is a historical/provenance mention, not a current-state row:"
+    grep -nF "$old" "$file" | while IFS= read -r line; do
+      warn "    $line"
+    done
+    warn "  Reword the historical one (e.g. \"the 0.21.0 plugin cycle\") per the HAZARD note above replace_in_file_counted, then re-run. Do NOT reword a current-state row — that silently disables this file's sync."
+    return 0
+  fi
+  # Count with grep -F (literal) but substitute with sed (BRE), where `.` is a
+  # wildcard: sed could rewrite more than was counted, which is the corruption
+  # class this guard exists to stop. Escape the pattern so both agree.
+  old_re="${old//./\\.}"
+  sed -i "s|${old_re}|${new}|g" "$file" 2>/dev/null || {
+    warn "sed failed on $file"
+    return 0
+  }
+  log "  updated $file ($count occurrence(s)): $old -> $new"
+  return 0
+}
+
 # Find current version reference in a file matching a regex; returns the
 # captured X.Y.Z group, or empty if not found. Never fails.
 detect_version_in() {
@@ -168,10 +226,10 @@ if [[ -n "$plugin_ver" ]]; then
       replace_in_file "$skill" \
         "version: \"$plugin_prev\"" "version: \"$plugin_ver\""
     done
-    replace_in_file README.md \
-      "claude-code-plugin/v$plugin_prev" "claude-code-plugin/v$plugin_ver"
-    replace_in_file platforms/claude-code-plugin/README.md \
-      "claude-code-plugin/v$plugin_prev" "claude-code-plugin/v$plugin_ver"
+    replace_in_file_counted README.md \
+      "claude-code-plugin/v$plugin_prev" "claude-code-plugin/v$plugin_ver" 1
+    replace_in_file_counted platforms/claude-code-plugin/README.md \
+      "claude-code-plugin/v$plugin_prev" "claude-code-plugin/v$plugin_ver" 1
     # Cross-submodule write: ../web-site/ is a sibling repo under the umbrella.
     # The sync hook lands changes in its working tree; the developer commits
     # them in the web-site PR. The replace_in_file helper is no-op if the file
@@ -183,8 +241,12 @@ if [[ -n "$plugin_ver" ]]; then
       "version: \"$plugin_prev\"" "version: \"$plugin_ver\""
     replace_in_file platforms/claude-code-plugin/docs/SKILL_AUTHORING.md \
       "(currently \`$plugin_prev\`)" "(currently \`$plugin_ver\`)"
-    replace_in_file docs/PARITY.md \
-      "claude-code-plugin/v$plugin_prev" "claude-code-plugin/v$plugin_ver"
+    # Each file holds exactly ONE current-state `claude-code-plugin/vX.Y.Z`
+    # row; counted for the same #405 reason as the hermes/v fanout above (the
+    # historical `v0.21.0` mention in docs/PARITY.md was reworded out of this
+    # form precisely so this guard can be exact).
+    replace_in_file_counted docs/PARITY.md \
+      "claude-code-plugin/v$plugin_prev" "claude-code-plugin/v$plugin_ver" 1
 
     # platforms/claude-code-plugin/README.md has a `$ cat VERSION` example
     # block with the bare version on its own line. The bare X.Y.Z is too
@@ -206,26 +268,34 @@ fi
 fw_ver="$(read_version framework/VERSION)"
 log "framework VERSION: ${fw_ver:-(missing)}"
 
-# HAZARD (FRWK-REVIEW-002 F1): the replace_in_file calls below do a GLOBAL
-# substitution of the literal "framework spec `<prev>`" — they cannot tell a
-# current-state row from a historical/provenance mention. Any doc line that
-# quotes an OLD spec version in that exact literal form will be swept to the new
-# version on the next bump (this once corrupted the D-0031 provenance lines in
-# docs/PARITY.md, 0.13.0 -> 0.23.0). Rule: historical/provenance version
-# mentions MUST avoid the "framework spec `X.Y.Z`" literal — write them as
-# "`0.13.0` spec cycle" (or similar) so the sed can't match them.
+# HAZARD (FRWK-REVIEW-002 F1): a GLOBAL substitution of the literal
+# "framework spec `<prev>`" cannot tell a current-state row from a
+# historical/provenance mention, so any doc line quoting an OLD spec version in
+# that exact form is swept to the new version on the next bump. This is not
+# hypothetical here: it corrupted the D-0031 provenance lines in docs/PARITY.md,
+# 0.13.0 -> 0.23.0. Rule still stands — historical/provenance mentions MUST
+# avoid the "framework spec `X.Y.Z`" literal, written instead as "`0.13.0` spec
+# cycle" — and since #405 these calls are ALSO count-guarded, so a violation is
+# refused loudly rather than applied silently.
+#
+# Expected counts, verified against the tree (all current-state, no historical):
+#   CLAUDE.md 1 (§"Current state"), README.md 1, docs/PARITY.md 1 (status
+#   blockquote), and 2 each in the two platform READMEs — a prose conformance
+#   sentence plus a "| Conforms to |" table row. tests/conformance/
+#   test_sync_version_refs_counts.py pins these, so a doc edit that adds or
+#   removes a current-state row fails CI instead of silently skipping a sync.
 if [[ -n "$fw_ver" ]]; then
   fw_prev="$(detect_version_in CLAUDE.md \
     'framework spec `[0-9]+\.[0-9]+\.[0-9]+`')"
 
   if [[ -n "$fw_prev" && "$fw_prev" != "$fw_ver" ]]; then
     log "framework sync $fw_prev -> $fw_ver"
-    replace_in_file CLAUDE.md \
-      "framework spec \`$fw_prev\`" "framework spec \`$fw_ver\`"
-    replace_in_file README.md \
-      "framework spec \`$fw_prev\`" "framework spec \`$fw_ver\`"
-    replace_in_file docs/PARITY.md \
-      "framework spec \`$fw_prev\`" "framework spec \`$fw_ver\`"
+    replace_in_file_counted CLAUDE.md \
+      "framework spec \`$fw_prev\`" "framework spec \`$fw_ver\`" 1
+    replace_in_file_counted README.md \
+      "framework spec \`$fw_prev\`" "framework spec \`$fw_ver\`" 1
+    replace_in_file_counted docs/PARITY.md \
+      "framework spec \`$fw_prev\`" "framework spec \`$fw_ver\`" 1
 
     # platforms/claude-code-plugin/README.md quotes the framework spec version
     # in prose ("...framework spec `X`...") AND in a `$ cat FRAMEWORK_SPEC_VERSION`
@@ -234,8 +304,8 @@ if [[ -n "$fw_ver" ]]; then
     # drift after the fact). Sync prose via replace_in_file; sync the bare line
     # via awk, anchored to the preceding `$ cat FRAMEWORK_SPEC_VERSION` marker so
     # the generic X.Y.Z is only touched inside that block.
-    replace_in_file platforms/claude-code-plugin/README.md \
-      "framework spec \`$fw_prev\`" "framework spec \`$fw_ver\`"
+    replace_in_file_counted platforms/claude-code-plugin/README.md \
+      "framework spec \`$fw_prev\`" "framework spec \`$fw_ver\`" 2
     if [[ -f platforms/claude-code-plugin/README.md ]]; then
       awk -v prev="$fw_prev" -v new="$fw_ver" '
         marker { if ($0 == prev) $0 = new; marker = 0 }
@@ -251,8 +321,8 @@ if [[ -n "$fw_ver" ]]; then
     # ways (prose "...framework spec `X`..." + a `$ cat FRAMEWORK_SPEC_VERSION`
     # example block). Same fix as the plugin README, mirrored here so the Hermes
     # conformance block no longer re-drifts (HERMES-README-VERSION-DRIFT).
-    replace_in_file platforms/hermes/README.md \
-      "framework spec \`$fw_prev\`" "framework spec \`$fw_ver\`"
+    replace_in_file_counted platforms/hermes/README.md \
+      "framework spec \`$fw_prev\`" "framework spec \`$fw_ver\`" 2
     if [[ -f platforms/hermes/README.md ]]; then
       awk -v prev="$fw_prev" -v new="$fw_ver" '
         marker { if ($0 == prev) $0 = new; marker = 0 }
@@ -347,12 +417,16 @@ if [[ -n "$hermes_ver" ]]; then
   hermes_prev="$(detect_version_in README.md 'hermes/v[0-9]+\.[0-9]+\.[0-9]+')"
   if [[ -n "$hermes_prev" && "$hermes_prev" != "$hermes_ver" ]]; then
     log "hermes sync $hermes_prev -> $hermes_ver"
-    replace_in_file README.md \
-      "hermes/v$hermes_prev" "hermes/v$hermes_ver"
-    replace_in_file platforms/hermes/README.md \
-      "hermes/v$hermes_prev" "hermes/v$hermes_ver"
-    replace_in_file docs/PARITY.md \
-      "hermes/v$hermes_prev" "hermes/v$hermes_ver"
+    # Each file holds exactly ONE current-state `hermes/vX.Y.Z` row; the
+    # counted guard (see HAZARD above replace_in_file_counted) refuses the
+    # substitution and warns when a historical mention re-enters the swept
+    # form instead of silently rewriting it (#405).
+    replace_in_file_counted README.md \
+      "hermes/v$hermes_prev" "hermes/v$hermes_ver" 1
+    replace_in_file_counted platforms/hermes/README.md \
+      "hermes/v$hermes_prev" "hermes/v$hermes_ver" 1
+    replace_in_file_counted docs/PARITY.md \
+      "hermes/v$hermes_prev" "hermes/v$hermes_ver" 1
 
     # platforms/hermes/pyproject.toml carries the bare package version, and
     # platforms/hermes/README.md has a `$ cat VERSION` example block with the

--- a/tests/conformance/test_sync_version_refs_counts.py
+++ b/tests/conformance/test_sync_version_refs_counts.py
@@ -1,0 +1,119 @@
+"""#405: the `replace_in_file_counted` expected counts in
+`scripts/sync-version-refs.sh` must match the tree.
+
+The count guard refuses a substitution when a file holds MORE occurrences of a
+swept literal than expected, on the theory that the surplus is a historical
+mention. That makes each `expected` a claim about the repository, maintained by
+hand, whose only previous guard was a comment saying "update this when you add
+or remove a current-state row".
+
+Both directions of drift are silent and both are bad:
+
+* Expected too LOW (someone adds a legitimate current-state row): the next bump
+  skips that file entirely and its version goes stale — a state the *unguarded*
+  script handled correctly, so the guard would have made things worse.
+* Expected too HIGH (someone removes a row): the guard stops guarding, and the
+  historical-mention corruption #405 was filed about is silently re-enabled.
+
+Neither is detectable by running the script, because both look like a normal
+run. This test reads the call sites out of the script and counts for real.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "scripts" / "sync-version-refs.sh"
+
+# `<literal template>` -> the VERSION file supplying the value it interpolates.
+_VERSION_SOURCES = {
+    "fw_prev": _REPO_ROOT / "framework" / "VERSION",
+    "plugin_prev": _REPO_ROOT / "platforms" / "claude-code-plugin" / "VERSION",
+    "hermes_prev": _REPO_ROOT / "platforms" / "hermes" / "VERSION",
+}
+
+# replace_in_file_counted <path> \
+#   "<old literal>" "<new literal>" <expected>
+_CALL = re.compile(
+    r"replace_in_file_counted\s+(?P<path>\S+)\s*\\\s*\n"
+    r"\s*\"(?P<old>[^\"]+)\"\s+\"[^\"]+\"\s+(?P<expected>\d+)",
+    re.MULTILINE,
+)
+
+
+def _read_version(path: Path) -> str:
+    return path.read_text(encoding="utf-8").strip()
+
+
+def _resolve(template: str) -> tuple[str, str] | None:
+    """Turn a shell literal into the string that is in the tree right now.
+
+    The script sweeps `<old>` = the PREVIOUS version, so at rest the tree holds
+    the CURRENT one. Substituting the current version is therefore what makes
+    the occurrence count meaningful between bumps.
+    """
+    for var, version_file in _VERSION_SOURCES.items():
+        if f"${var}" in template:
+            if not version_file.is_file():
+                return None
+            literal = template.replace(f"${var}", _read_version(version_file))
+            # In a double-quoted shell string, \` is a literal backtick.
+            return literal.replace("\\`", "`"), var
+    return None
+
+
+class SyncVersionRefsExpectedCounts(unittest.TestCase):
+    def setUp(self) -> None:
+        self.assertTrue(_SCRIPT.is_file(), f"{_SCRIPT} missing")
+        self.source = _SCRIPT.read_text(encoding="utf-8")
+        self.calls = list(_CALL.finditer(self.source))
+
+    def test_the_parser_finds_the_call_sites(self):
+        """Guard against vacuity: if the script is reformatted so the regex stops
+        matching, every other assertion here passes over an empty list."""
+        self.assertGreaterEqual(
+            len(self.calls),
+            11,
+            f"found {len(self.calls)} replace_in_file_counted call sites; the "
+            "#405 fix converted the plugin (3) and hermes (3) tag fanouts and "
+            "the framework-spec fanout (5). A lower number means the regex "
+            "stopped matching, not that the guard shrank — check the "
+            "call-site formatting.",
+        )
+
+    def test_every_expected_count_matches_the_tree(self):
+        for m in self.calls:
+            path, template, expected = (
+                m.group("path"),
+                m.group("old"),
+                int(m.group("expected")),
+            )
+            with self.subTest(file=path, literal=template):
+                resolved = _resolve(template)
+                self.assertIsNotNone(
+                    resolved,
+                    f"could not resolve {template!r} to a current version — the "
+                    "literal interpolates no known *_prev variable",
+                )
+                literal, _var = resolved
+                target = _REPO_ROOT / path
+                if not target.is_file():
+                    # The sibling web-site write is legitimately absent.
+                    continue
+                actual = target.read_text(encoding="utf-8").count(literal)
+                self.assertEqual(
+                    actual,
+                    expected,
+                    f"{path} holds {actual} occurrence(s) of {literal!r} but "
+                    f"sync-version-refs.sh expects {expected}. If you added or "
+                    f"removed a current-state row, update the call site in the "
+                    f"same change; if the surplus is a historical mention, "
+                    f"reword it out of the swept literal form instead.",
+                )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
Closes #405 (`SYNC-HISTORICAL-REF-CORRUPTION`)

## What

`scripts/sync-version-refs.sh`'s `hermes/v*` / `claude-code-plugin/v*` fanout ran an unanchored global replace. A historical mention written in the swept literal form (`docs/PARITY.md:65`'s "shipped in `hermes/v0.11.0`") was rewritten one version forward **at every bump** — three consecutive silent corruptions, applied by the pre-commit autofix inside the author's own commit, each diff looking like a plausible one-version bump. The script's `:209` and `:141` HAZARD comments documented exactly this class and remedy; the third fanout block carried neither.

## Fix — the count guard (the issue's option 2, which catches the class)

- New `replace_in_file_counted <file> <old> <new> <expected>`: counts occurrences of the literal; **above** the expected count it skips the substitution and warns, naming the extra line(s) and the prescribed reword remedy ("the `0.21.0` plugin cycle", never the swept form). A historical claim now survives for a human to reword instead of being silently falsified. Zero occurrences stays a silent no-op (idempotent re-runs unchanged).
- The five `X/vN.N.N` fanout calls (hermes: README, hermes README, PARITY; plugin: README, plugin README, PARITY) now use it with expected count 1 each, with the HAZARD comment carried at the helper and both fanout sites.
- Latent instance closed: `docs/PARITY.md:43` `(claude-code-plugin/v0.21.0, 2026-06-22)` → "(the `0.21.0` plugin cycle, 2026-06-22)" per the script's own `:141` remedy — making every expected count exact.

## Verification (throwaway clone, the prescribed method)

1. Clean bump (`VERSION` 0.12.1→0.13.0): only the three current-state `hermes/v` rows move.
2. Guard: injected historical `hermes/v0.12.1` mention in PARITY + bump → warning fires naming `:336` and the remedy; **the historical line survives the bump**; the other two files' current rows still update; PARITY's own current row deliberately stays stale until the reword (visible in the warning — the designed trade: loud drift beats silent falsification).
3. Test-methodology note: `git clone` copies committed state, so the first guard "test" ran the pre-fix script and re-corrupted the injected line — re-run with the modified script copied in before trusting any result.

This guard would have fired at each of the three historical corruptions (`65a8936d`, `a00f804e`, …).

## Not changed

- The current-state rows and the rest of the fanout (unchanged `replace_in_file` calls are either anchored literals or version-scoped fields).
- #386 (the fanout *under*-propagation gate) — distinct issue, untouched.
- The web-site badge path — that's #423's scope.
