### PR TITLE
docs(handoff): regenerate for the session wrap

### DIFF
--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -5,111 +5,133 @@
 restore prior states here. Settled traps live in `CLAUDE.md` § "Durable traps" and are
 never repeated here.
 
-**State:** last deployable commit is the `main` tip carrying PR **#510** (the backlog
-retirement) — verify with `git log --oneline -1 origin/main`. Framework spec `0.40.0`,
-plugin `0.25.0`, Hermes `0.12.1` — **unchanged this session; nothing was released.**
-Five PRs merged, five open. Working tree: clean except this handoff and a `CHANGELOG.md`
-entry for #511, both landing in the wrap commit.
+**State:** last deployable commit is the `main` tip carrying PR **#516** (the framework
+`0.41.0` fold) — verify with `git log --oneline -1 origin/main`. **Framework spec moved
+this session: `0.40.0 → 0.41.0`.** Plugin `0.25.0` and Hermes `0.12.1` are **unchanged**.
+**Nothing was released and no tag was cut** — merged is not deployed. Working tree clean
+apart from this handoff.
 
-## ⚠️ The backlog moved. `plans/FRAMEWORK-TODO.md` is a tombstone
+## ⚠️ The backlog is GitHub issues. `plans/FRAMEWORK-TODO.md` is a tombstone
 
-**GitHub issues are the task surface.** `plans/FRAMEWORK-TODO.md` no longer holds work —
-it carries an entry → issue mapping table and nothing else. Do not add to it. Any
-instruction you find elsewhere telling you to append to it is stale (**#509** tracks the
-remaining pointers).
-
-**Open issues: 71.** Re-derive with `gh issue list --state open --limit 300` — never
-`--search` (tokenised and eventually consistent), and never the default `--limit 30`
-(this repo is past #500).
-
-In-progress work is labelled **`status: in progress`** (created this session; there is no
-project board, and the token was checked — `gh issue list --label "status: in progress"`).
+It carries an entry → issue mapping and nothing else. Do not add to it. Any instruction
+telling you to append to it is stale (**#508**/**#509** track the remaining pointers).
+**69 open issues.** Re-derive with `gh issue list --state open --limit 300` — never
+`--search` (tokenised, eventually consistent) and never the default `--limit 30` (this
+repo is past #500). In-progress work carries the label `status: in progress`.
 
 ## What this session did
 
-**Merged five PRs.** #459 (#437, dead `.mcp.json` paths) · #464 (#405, version-fanout
-count guard) · #456 (#412, single-file `TRACE-RES-001`) · #510 (backlog retirement) ·
-PR #511 (`AGENTS.md` routed to the tracker). Issues #405/#412/#437 closed by their
-merges; markers cleared. *(That `PR` prefix is load-bearing — markdownlint's autofix
-turns a line-initial `#511` into an H1.)*
+**Merged three PRs.** #512 (the previous wrap's handoff) · **#457** (closes **#417**,
+scoped agent dispatch) · **#516** (closes **#444/#446/#448/#450**, the `0.41.0` fold).
+In-progress markers cleared on all five closed issues — the merge does not do it.
 
-**Filed 45 issues (#465–#509).** 42 are the backlog migrated **verbatim** — moved, not
-summarised, because the entries carry `file:line` evidence worth more than their titles.
-All 42 verified to carry a Provenance section warning that some predate spec `0.40.0`.
+**#417 — the previous handoff's top item was partly wrong, and the wrong part was the
+expensive one.** It prescribed rewriting the 51 playbooks' bare `agent:` key "in the plugin
+mirror only, via `tools/sync-plugin-framework.sh`". Impossible: that script `cp -R`s
+`framework/` **over** the mirror, and `test_plugin_framework_bundle.py` asserts the mirror
+byte-identical, so a hand-edit fails a required check and is then overwritten. The premise
+was also wrong — **GD-06 ratifies that key as an engine-defined executor each platform maps
+for itself**, and the plugin resolves lens → agent from its own crew table
+(`skills/review-team/SKILL.md`), never from the key. The "51" was right; the conclusion was
+not. Now recorded in the guard's docstring, both changelogs and `docs/AGENTS.md`, so it is
+not re-derived.
 
-**Reviewed the eight queued fix PRs** with a three-lens OPS-0065 pass. That review is the
-reason four of them are not merged: they fixed their instance and left a sibling alive
-while claiming the class closed. Findings are in each PR thread.
+A scripted census found **five** real missed surfaces where the handoff listed three.
 
-**V15 is CONFIRMED and its paragraph is deleted** — a `schedule`-triggered
-`standards-drift` was followed by a `workflow_run` `pin-currency-reader` on both
-2026-08-03 and 2026-08-10, all four runs green. That is the chain V14 could only prove
-off a dispatched upstream. Do not re-open it.
+**#516 — a false blocker was caught in review, in my own GD entry.** GD-11's first draft
+said the four PRs "cannot merge independently". `tests/chg/spec_gate.py:78-88` shows E005 is
+a membership test on `framework/VERSION` that does **not** constrain the value, so
+sequential merges at `0.41.0`/`0.42.0`/… each pass. The entry's "precedent set" bullet
+rested on that premise, so merged it would have licensed batching governance work behind a
+false appeal to a gate. Rewritten to the cost argument and narrowed.
+
+**Filed 3 issues** — #513, #514, #515 — all from review of this session's own work.
+
+**#423's work is no longer at risk.** It was in `stash@{0}`, which does not survive a
+container. Now commit `f05dfc0d` on pushed branch `fix/423-site-badge-selfheal`, confirmed
+with `git branch -r --contains`. **An unreviewed WIP commit, not a PR.**
+
+## Verification — run this session, on the merged tip
+
+| Check | Result |
+|---|---|
+| `tests/conformance` | 369 passed, 783 subtests |
+| `tests/acceptance/deterministic` | 64 passed, 56 subtests |
+| `tools/sdd_doc_lint/tests` | 5 passed |
+| `tests/conformance/test_repo_scripts.py` (the `tests/unit` shim) | 1 passed, 2 subtests |
+| `pre-commit run --all-files` | clean |
+
+**0 failing.** Run them with `PYTHONPATH=tools` — without it `sdd_doc_lint` fails on import
+and reads as a regression.
 
 ## What to do next — prioritized
 
 Filter: [`is:open is:issue`](https://github.com/vladm3105/aidoc-flow-framework/issues) ·
 in-flight: `--label "status: in progress"`. Below is only the ordering.
 
-1. **[#417](https://github.com/vladm3105/aidoc-flow-framework/issues/417) — PR #457 is
-   open and does NOT close it.** Security: the plugin's read-only review gate stays
-   subvertible. The PR scoped the tables and literals, but review found three live
-   surfaces it misses — **51 playbook files carry bare `agent: <name>` frontmatter**
-   (`framework/playbooks/**`, and `REVIEW_TEAM.md:259` defines that key as the lens's
-   *executor*), the nine `doc-*-fixer` skills say "Dispatch the synthesizer" in prose with
-   no identifier, and the new guard's `TABLE_ROW_LAST_CELL` regex anchors to the **last**
-   cell so it cannot see `platforms/claude-code-plugin/README.md:213-224`, where the agent
-   is the middle cell. ⚠️ **Do not scope the playbooks in `framework/`** — the spec carries
-   no platform names. Rewrite `agent:` → `aidoc-flow:agent` in the *plugin mirror only*,
-   via `tools/sync-plugin-framework.sh`. Rebase onto `main` first.
-2. **PRs #460–#463 → fold into ONE spec PR.** All four are correct and all four are red on
-   **GATE-SPEC E005** (`framework/**` changed, `framework/VERSION` not bumped). They would
-   bump to the same version, so they cannot merge independently. Shape: `framework/VERSION`
-   `0.40.0 → 0.41.0` (MINOR — #461 adds a normative `@chg:` tag), a **GD-11** entry in
-   `framework/governance/DECISIONS.md` + its plugin mirror, both
-   `platforms/*/FRAMEWORK_SPEC_VERSION`, then the sync fanout. Precedent: the 0.40.0 bump
-   (`eb48d051`) touched **174 files** in one commit. Propagation order is load-bearing:
-   `framework/VERSION` → `scripts/sync-version-refs.sh` → `tools/sync-plugin-framework.sh`.
-3. **`plans/DECISIONS.md` — D-entry for the precedence carve-out.** #510 deferred it. It
-   records that this repo's own-gaps rule governs over the spec's Tier-2 model until #508
-   lands. A decision taken with no decision-log entry is the gap.
-4. **[#508](https://github.com/vladm3105/aidoc-flow-framework/issues/508)** — the spec
-   still names the retired file by path across **five** `framework/**` files with four
-   vendored mirrors. GATE-SPEC change; needs the 0.41.0 bump, so it can ride with item 2.
-5. **[#423](https://github.com/vladm3105/aidoc-flow-framework/issues/423)** — work in
-   progress is in **`stash@{0}`** on branch `fix/423-site-badge-selfheal`
-   (`scripts/sync-version-refs.sh`, +41/−14). ⚠️ Stashes do not survive a container, and
-   this one is **not on the remote** — recover or discard it early.
+1. **[#513](https://github.com/vladm3105/aidoc-flow-framework/issues/513) — Hermes ships a
+   stale copy of a spec file that now teaches a forbidden practice.**
+   `platforms/hermes/agent-skills/spec-driven-development/sdd-orchestrator/references/ai-assistant-rules.md:12`
+   still says *"Use the cumulative tag hierarchy `@brd` → … → `@iplan`"*, which canonical
+   `framework/AI_ASSISTANT_RULES.md:12` now calls **trace fabrication (forbidden)**; `:23-26`
+   carry all four pre-fix generation-order clauses. #516 re-pinned Hermes to `0.41.0` while
+   this copy stayed behind. `platforms/**` only — **no version bump, no GATE-SPEC.**
+   Actionable with no discovery.
+2. **[#514](https://github.com/vladm3105/aidoc-flow-framework/issues/514) — the document-ID
+   lockstep is one-sided and misses a fourth surface.** `ucx-validation-gate.sh:54` gates
+   `^BRD-[0-9]{2}$`; `saga_orchestrator.py:66` accepts 1-digit IDs neither the registry nor
+   the new schema allows. Both `platforms/hermes/**`; can ship with item 1.
+3. **[#515](https://github.com/vladm3105/aidoc-flow-framework/issues/515) — `@chg:` is
+   defined on a page scoped to trace tags**, while the other two non-trace tags live in
+   `ID_NAMING_STANDARDS.md`/`TRACEABILITY.md` *with* a `cross_links` template slot `@chg:`
+   lacks — so a P1 requirement has no key to write into. `framework/**`: needs a `VERSION`
+   bump + GD entry, so **batch with the next spec release**, not alone.
+4. **`plans/DECISIONS.md` — D-entry for the precedence carve-out.** Deferred by #510, still
+   open. Records that this repo's own-gaps rule governs over the spec's Tier-2 model until
+   #508 lands. A decision taken with no decision-log entry is the gap.
+5. **[#508](https://github.com/vladm3105/aidoc-flow-framework/issues/508)** — the spec still
+   names the retired `FRAMEWORK-TODO.md` by path across five `framework/**` files with four
+   vendored mirrors. GATE-SPEC change; rides with item 3 on the next bump.
+6. **[#423](https://github.com/vladm3105/aidoc-flow-framework/issues/423)** — still labelled
+   in progress, correctly. Review `f05dfc0d` on `fix/423-site-badge-selfheal` before opening
+   a PR; it has had none.
 
 ## Blockers and standing constraints
 
-**⚠️ This repo does not auto-merge.** `.github/ai-review/config.json:22` records it as
-deliberately omitted from the **operations-side** `auto_merge.repos` allowlist — spec/
-governance repo, `tier:spec`, human-always. ⚠️ That allowlist is read from
-`trust_config_repo` (`vladm3105/aidoc-flow-operations@main`), **not** from this repo.
-This session's five merges ran on **explicit founder authorization given in-session**
-("merge it with `--admin`"). Ask; never infer standing approval from the fact they merged.
+**⚠️ This repo does not auto-merge — ask every time.**
+`.github/ai-review/config.json:22` records it as deliberately omitted from the
+**operations-side** `auto_merge.repos` allowlist (spec/governance repo, `tier:spec`,
+human-always), and that allowlist is read from `trust_config_repo`
+(`vladm3105/aidoc-flow-operations@main`), **not** from this repo. All three merges this
+session ran on **explicit founder authorization given in-session**. Never infer standing
+approval from the fact they merged.
 
-**⚠️ Every doc PR serialises on `CHANGELOG.md`.** All of them insert at the top of
-`## [Unreleased]`, so each merge makes the next PR `DIRTY`. Four rebases this session —
-structural, not a mistake. Folding #460–#463 into one PR removes three of them.
+**⚠️ A governance PR that bumps a version cannot meet the ≤3-surface cap.**
+`sync-version-refs.sh` re-stages its own writes, so `VERSION`, `CLAUDE.md`'s token,
+`README.md`, `docs/PARITY.md`, both platform READMEs and the SKILL frontmatters move
+together or conformance goes red. #516 was 178 files. **The founder granted the Rule 1
+exception per-bump, in-session, with an audit-trail line in the commit** — ask again; it is
+not standing.
 
 **⚠️ `Hermes pytest` is RED on `main` and it is not yours.**
-`platforms/hermes/pyproject.toml:7` pins `mcp[cli]>=1.0.0` with no ceiling; pip now
-resolves **mcp 2.0.0**, which renamed the `Tool` fields, so all four unit modules fail to
-*collect*. Red on every run since **2026-07-27**. Not a required context, which is why it
-survived. Tracked as **[#465](https://github.com/vladm3105/aidoc-flow-framework/issues/465)**;
-the founder deferred the fix this session. Do not re-diagnose it.
+`platforms/hermes/pyproject.toml:7` pins `mcp[cli]>=1.0.0` with no ceiling; pip resolves
+**mcp 2.0.0**, which renamed the `Tool` fields, so all four unit modules fail to *collect*.
+Red on every run since **2026-07-27**. **Not a required context**, which is why it survives.
+Tracked as [#465](https://github.com/vladm3105/aidoc-flow-framework/issues/465); the founder
+deferred the fix. Do not re-diagnose it — it will be the only red on every PR you open.
+
+**⚠️ Every doc PR serialises on `CHANGELOG.md`.** All insert at the top of `## [Unreleased]`,
+so each merge makes the next PR `DIRTY`. Expect a rebase per PR; it is structural.
 
 **⚠️ A plugin `VERSION` bump needs a hand-authored `docs/TAGGING.md` row**, or conformance
-goes red — `tests/conformance/platforms/test_plugin_release_metadata.py:137` asserts the
-current tag string appears in the file, and `sync-version-refs.sh:56-60` deliberately does
-not write it. That assertion is a bare substring check, satisfied by the § "Release
-inventory" preamble as well as the row.
+goes red — `test_plugin_release_metadata.py:137`. A **framework-spec** bump does **not**:
+that assertion covers only the plugin tag, and no test asserts a `framework/v` row. Measured
+this session, so do not re-derive it from the plugin rule.
 
 **Phase 0 `lint-smoke` in `tests/scripts/test-acceptance.sh` is RED** — example-corpus debt
 deferred to the wholesale regen; use `--skip-lint-smoke`. That harness runs on no PR path
 here (only the umbrella's `release.yml`, on `v*` tags, against a **pinned old SHA**).
 
-**Not verified this session:** nothing was released, no tag was cut, and neither platform
-version moved. The 0.41.0 bump in item 2 has not been started.
+**Not verified this session:** nothing released, no tag cut, neither platform version moved,
+no example-corpus regen attempted. The `0.41.0` spec bump is **merged, not deployed** — no
+consumer has run against it.


### PR DESCRIPTION
Session wrap. `plans/HANDOFF.md` regenerated wholesale — the repo's governance table declares the file form, so no handoff issue is opened beside it.

**Merged this session:** #512 (previous handoff) · #457 (closes #417, scoped agent dispatch) · #516 (closes #444/#446/#448/#450, the framework `0.40.0 → 0.41.0` fold). In-progress markers cleared on all five closed issues — the merge does not clear them.

**Filed:** #513, #514, #515 — all from adversarial review of this session's own work.

## What the successor gains that a plain rewrite would have lost

- **The previous handoff's top item prescribed a structurally impossible fix.** Rewriting the 51 playbooks' `agent:` key "in the plugin mirror only, via `tools/sync-plugin-framework.sh`" cannot work: that script copies `framework/` *over* the mirror, and `test_plugin_framework_bundle.py` asserts byte-identity. The premise was also wrong — GD-06 ratifies the key as an engine-defined executor each platform maps for itself. Recorded so it is not attempted again.
- **A framework-spec bump needs no `docs/TAGGING.md` row**, unlike a plugin bump — `test_plugin_release_metadata.py:137` asserts only the plugin tag. Measured this session and stated explicitly, because the natural inference from the plugin rule is wrong.
- **A governance PR that bumps a version cannot meet the ≤3-surface cap** (`sync-version-refs.sh` re-stages its own writes; #516 was 178 files). The founder grants that exception per-bump, in-session — noted as *not standing*.

## Carried forward deliberately

The predecessor was diffed while uncommitted, so corrections it had made on purpose survive the rewrite: the no-auto-merge rule and the fact its allowlist is read from `aidoc-flow-operations`, not this repo; the `CHANGELOG.md` serialisation; the `Hermes pytest` red (#465, not a required context, founder-deferred); the Phase 0 `lint-smoke` skip; and the `gh issue list --limit 30` trap. The open-issue count was **re-derived** (71 → 69) rather than copied.

## Verification — run on the merged tip, not asserted

| Check | Result |
|---|---|
| `tests/conformance` | 369 passed, 783 subtests |
| `tests/acceptance/deterministic` | 64 passed, 56 subtests |
| `tools/sdd_doc_lint/tests` | 5 passed |
| `tests/conformance/test_repo_scripts.py` | 1 passed, 2 subtests |
| `pre-commit run --all-files` | clean |

**0 failing**, derived from an accumulated counter rather than a hardcoded summary.

Docs-only; no code, spec or version change.
