### PR TITLE
docs(handoff): record the 0.41.3 release and the branch cleanup

### DIFF
--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -5,13 +5,19 @@
 restore prior states here. Settled traps live in `CLAUDE.md` § "Durable traps" and are
 never repeated here.
 
-**State:** last deployable commit is the `main` tip carrying PR **#530** — verify with
-`git log --oneline -1 origin/main` (it was `8dccc315` at the wrap; assert the PR, not the
-hash). Framework spec **`0.41.3`**, plugin `0.25.0`, Hermes `0.12.1`; both platform
-`FRAMEWORK_SPEC_VERSION` pins read `0.41.3`. **Merged, not released** — no tag cut (only
-`framework/v0.41.2` exists), no consumer has run against `0.41.3`. No open PRs. Working
-tree clean once this wrap commit lands — while you are reading the uncommitted draft,
-`plans/HANDOFF.md` is itself modified.
+**State:** framework spec **`0.41.3`**, plugin `0.25.0`, Hermes `0.12.1`; both platform
+`FRAMEWORK_SPEC_VERSION` pins read `0.41.3`. **RELEASED** — `framework/v0.41.3` is an
+annotated tag on `8dccc315` (PR #530), published as the **Latest** GitHub release on
+2026-08-24. Conformance was verified green *at that commit*, not inferred from `main`, per
+`docs/TAGGING.md`. No consumer has yet run against it. No open PRs, working tree clean.
+
+The last **deployable** commit is `8dccc315` (PR #530); everything on `main` after it is
+docs-only. Re-derive with **two** commands — `git rev-list -n1 framework/v0.41.3` for the
+commit, and `gh release view framework/v0.41.3 --json tagName,isPrerelease,isDraft` for the
+publication state. Do **not** use `git log -1 origin/main` (returns whatever docs commit
+landed last, and shows no PR number) and do **not** use `--json targetCommitish`: that field
+is the release's target branch, so it returns the literal string `main` and no SHA at all.
+`gh release view` exposes no field carrying the tag's commit.
 
 **Verified this session on `main` at `8dccc315`** (run, not asserted): conformance
 371 passed / 795 subtests · acceptance-deterministic 64 passed / 56 subtests ·
@@ -133,5 +139,18 @@ cost a wrong prediction this session. **The root cause was fixed, not merely def
 `platforms/hermes/pyproject.toml:7` now reads `mcp[cli]>=1.0.0,<2`, so the resolver can no
 longer pull `mcp 2.0.0`. Do not describe this dependency as an open failure class.
 
-**What did NOT change:** no release, no tag, neither platform version moved, the example
-corpus was not touched, and no `plans/` document other than this one was written.
+**Repo hygiene done 2026-08-24:** stale branches pruned (local 14 → 2, remote 10 → 3, plus
+whatever branch carries the change you are reading) and two abandoned worktrees removed. The
+two survivor sets differ, so read them separately: **locally** `main` and
+`fix/423-site-badge-selfheal`; **on origin** those two plus `legacy-ucx-v3.2-read-only`,
+which is the protected read-only pre-migration branch and has no local counterpart. Kept
+deliberately: `fix/423-site-badge-selfheal` carries live work for #423.
+
+⚠️ When judging whether a branch is dead, **check its PR state, not
+`git merge-base --is-ancestor`.** Everything here is squash-merged, and a squashed branch's
+tip is never an ancestor of `main` — so the ancestor test called all thirteen "unmerged"
+when twelve had fully landed. (It is a reliable test only for branches that were
+fast-forwarded or rebase-merged; this repo has none.)
+
+**What did NOT change:** neither platform version moved, no platform release was cut, the
+example corpus was not touched, and no `plans/` document other than this one was written.


### PR DESCRIPTION
## Summary

The handoff merged in #533 said **"Merged, not released — no tag cut (only `framework/v0.41.2` exists)"**. Cutting `framework/v0.41.3` falsified that about an hour later, so the file on `main` was describing a state that no longer existed. This corrects it and records the repo cleanup done alongside.

## What changed

1. **The release is cut.** `framework/v0.41.3` is an annotated tag on `8dccc315` (PR #530), published as the **Latest** GitHub release. Two details are stated because they were decisions, not defaults: the tag targets the `VERSION`-bump commit rather than the `main` tip (matching how `framework/v0.41.2` was cut), and conformance was verified green **at that commit** in a throwaway worktree rather than inferred from `main`, which is what `docs/TAGGING.md` actually requires.

2. **A self-defeating verify instruction, removed.** The old state block said *"verify with `git log --oneline -1 origin/main`"* and named PR #530. That command returns whatever docs commit landed last — #533 at the time of writing — and shows no PR number at all, so it could not confirm the fact it was attached to. Replaced with a `gh release view` query. This is the structural artifact of a handoff that ships as its own commit: merging it changes the tip it points at.

3. **Cleanup recorded**, with the trap that made it non-obvious: local branches 14 → 2, remote 10 → 3, two abandoned worktrees removed. `fix/423-site-badge-selfheal` (live work for #423) and the protected `legacy-ucx-v3.2-read-only` were kept deliberately.

## The trap worth reading

`git merge-base --is-ancestor <branch> main` reported **all thirteen** local branches as unmerged, when twelve were fully landed. Everything in this repo is squash-merged, so a branch tip is *never* an ancestor of `main` — the test always says "unmerged" and is useless here. PR state is the only reliable signal. Acting on the ancestor check would have meant either keeping twelve dead branches or, worse, trusting it in the other direction.

## Files touched (OPS-0061 Rule 1 self-check)

| Surface | Change |
| --- | --- |
| `plans/HANDOFF.md` | state block corrected; cleanup recorded |

**Governance tier:** 🟢 non-governance — `plans/HANDOFF.md` is not on the governance-PR surface list. One surface. No `CHANGELOG.md` entry: no code, no CI, and the release itself is already in the `0.41.3` entry.

## Multi-agent self-review (OPS-0065 / OPS-0069)

**Agents dispatched:** none — recorded in the commit as a skip with its reason. This is a single-surface factual correction to a docs file with no logic, where each corrected claim was verified directly against `git` and `gh` (tag object type, tag target, release `isPrerelease`, branch and worktree counts) rather than reasoned about. Dispatching reviewers to re-read three verified facts would be ceremony.

## Test plan

`pre-commit run --files plans/HANDOFF.md` clean, including the conformance hook. No code changed.
