### PR TITLE
fix(docs): correct the fw_prev trap in CLAUDE.md and the sync script's own header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — the `fw_prev` doc-currency trap named the wrong file in two places (2026-08-28)
+
+`scripts/sync-version-refs.sh` derives `fw_prev` from `docs/PARITY.md`, a change made by issue #386. `fw_prev` gates one block of the framework-spec fanout — `CLAUDE.md`, `README.md`, `docs/PARITY.md` itself, both platform READMEs and a conformance literal. It does **not** gate the three loops below it (`FRAMEWORK_SPEC_VERSION`, the 52 SKILL frontmatters, the playbooks), each of which has its own detector. Two narrative surfaces went on describing the pre-#386 behaviour and named `CLAUDE.md` as the source: the script's own header comment and `CLAUDE.md` § "Durable traps".
+
+The wording misled in both directions at once. It warned readers off hand-editing `CLAUDE.md`, which #386 made harmless, and said nothing about `docs/PARITY.md` — which, being both the detector's source and one of its targets, makes the gate compare equal and skip that whole block when pre-edited. Silently: the ungated loops still run, so the script prints `version-reference sync applied` and exits 0. Because `CLAUDE.md` is auto-loaded every session and its § "Durable traps" preamble tells readers not to re-derive its entries, the stale claim was carried into a plan draft before an independent review opened the script.
+
+Corrected in both surfaces, with the superseded wording marked rather than silently replaced, and **cited by name rather than by line number** — the first draft of this very fix shipped a line citation that its own edit invalidated, which is the precedent the script already records at its `#405` note. Comment-and-prose only; no behaviour change. Issue #556.
+
 ### Changed — Framework Spec `0.42.0 → 0.43.0` — YAML is the normative artifact format (GD-15); IPLAN gains a `tdd_ref` TDD-case carrier (GD-16) (2026-08-26)
 
 Two spec decisions ship together, plus the linter defect that blocked the second.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -748,12 +748,23 @@ fresh to have settled, and never repeats one that is already here.
   fixed even when every other surface is current — the state that had let `CLAUDE.md`
   sit at Hermes `0.11.1` against a `0.12.0` `VERSION` for four days, and that the
   plugin token had carried latently since `SYNC-CLAUDE-PLUGIN-VERSION-GAP`.
-  `fw_prev` is different: it is read
-  from `CLAUDE.md` **and** gates propagation to `README.md`, `docs/PARITY.md`, both
-  platform READMEs and a conformance-test literal — so **hand-editing the
-  framework-spec token in `CLAUDE.md` before running the sync strands those five
-  files, silently, at exit 0.** Measured, not inferred; filed as
-  [#386](https://github.com/vladm3105/aidoc-flow-framework/issues/386). The 52 SKILL
+  `fw_prev` is different: it is detected **from `docs/PARITY.md`** (the `fw_prev`
+  assignment in `scripts/sync-version-refs.sh` — cite it by name, never by line) and
+  gates propagation to `CLAUDE.md`, `README.md`, **`docs/PARITY.md` itself**, both
+  platform READMEs and a conformance-test literal — so **hand-editing the framework-spec
+  token in `docs/PARITY.md` before running the sync strands every one of those except
+  `docs/PARITY.md` itself, silently, at exit 0.** It is both the detector's source and
+  one of its targets, which is exactly why editing it first is the destructive case: the
+  gate compares it against the new `VERSION`, finds them equal, and skips the whole
+  block. Worse, the run still *looks* successful — the three ungated loops below rewrite
+  their files and the script prints `version-reference sync applied`. ⚠️ **This bullet used to name `CLAUDE.md` as the
+  `fw_prev` source. That was true when
+  [#386](https://github.com/vladm3105/aidoc-flow-framework/issues/386) was filed and is
+  false now — #386 is **fixed and closed**, and the fix moved the detector to
+  `docs/PARITY.md` precisely so a hand-edited `CLAUDE.md` could no longer strand the
+  fanout. Editing `CLAUDE.md`'s framework token first is now harmless; editing
+  `docs/PARITY.md`'s is not.** The stale wording misled in both directions for weeks and
+  reached a plan draft before review caught it (#556). The 52 SKILL
   frontmatters, the playbooks and `platforms/*/FRAMEWORK_SPEC_VERSION` are **not** in
   that blast radius — each has its own detector.
 - **Run a sync-script reproduction in a throwaway clone, never in the working tree.**

--- a/plans/TEMPLATE-COMPLETENESS-001-PLAN.md
+++ b/plans/TEMPLATE-COMPLETENESS-001-PLAN.md
@@ -46,7 +46,7 @@ Bundling converts that into one.
 - **#554**, **#555**, **#486**, **#487** — no bump, or absorbed by the corpus regen.
 - All ⏸ PARKED issues (#438, #483, #543–#548).
 - **Two defects discovered during this plan's review, filed separately rather than fixed
-  here:** the stale `fw_prev` trap (Claim 19/20), filed as **#556**, and EARS's `glossary:` being
+  here:** the stale `fw_prev` trap (Claim 19/20), filed as **#556** and since **fixed**, and EARS's `glossary:` being
   admitted to STRUCT01's required set while the template numbers five sections (Claim 18),
   filed as **#557**.
 
@@ -177,8 +177,9 @@ correct (Claim 10) and is the target shape.
 - **Do not hand-edit the framework-spec token in `docs/PARITY.md` before running the
   sync.** `fw_prev` is detected from `docs/PARITY.md` (Claim 19) and gates propagation to
   `CLAUDE.md`, `README.md`, both platform READMEs and a conformance literal. ⚠️ Both
-  `CLAUDE.md` § "Durable traps" and the script's own header comment (Claim 20) still name
-  `CLAUDE.md` as the source — they are stale; `:288` is the operative code.
+  *(Both `CLAUDE.md` § "Durable traps" and the script's own header comment used to name
+  `CLAUDE.md` as the source. **Fixed 2026-08-28 by #556** — Claim 20. Cite the `fw_prev`
+  assignment by name, not by line: correcting that header moved it.)*
 - Write `GD-17` in `framework/governance/DECISIONS.md` covering the three changes.
 - Record the founder's per-bump grant as an audit-trail line in the commit message.
 
@@ -218,7 +219,7 @@ correct (Claim 10) and is the target shape.
 | R2 | An addition creates a new required section and reddens every existing instance of that layer | Medium | D1 nests both additions; **V4 and V3 catch the STRUCT01 and header-count derivations, V6 catches the acceptance-harness derivation (Claim 27) that both are blind to** |
 | R3 | Implementing #551 from the issue body produces a third threshold shape | Medium | D2; copy `EARS-TEMPLATE.yaml:384`, not the issue's snippet |
 | R4 | The fanout runs in the wrong order and lands drifted playbooks | Medium | Task 4 fixes the order; V9 detects it |
-| R5 | An implementer follows the stale `CLAUDE.md` trap, hand-edits `CLAUDE.md`, and believes they have broken the fanout — or pre-edits `docs/PARITY.md` and actually does | Medium | Task 4 names `docs/PARITY.md` as the real source and flags both stale surfaces (Claims 19, 20) |
+| R5 | An implementer pre-edits `docs/PARITY.md` and silently strands the gated block | **Low since #556** | Both narrative surfaces now name `docs/PARITY.md` (Claim 20). Task 4 restates it; the failure is still silent at exit 0, so the warning stays |
 | R6 | #550's fix is scoped to one marker and leaves survivors — six under other **path** keys, or seven under the **function** keys one field over | **High** | D3 counts both classes; **V2a covers paths, V2b covers functions**. This plan's first draft made the path error and its second made the function error |
 | R7 | Adding template keys reddens the acceptance tier | Medium | The fixtures are linted against the **live** templates, so "templates are not instances" does not decouple them; V6 is the check and the tier matches warnings as a bidirectional multiset, so any movement is visible |
 
@@ -239,13 +240,13 @@ correct (Claim 10) and is the target shape.
 | 11 | Two sync scripts perform the fanout | `sync-version-refs.sh` | scripts/sync-version-refs.sh:10 |
 | 12 | `TESTING_STRATEGY_TDD.md` names no language or runner — blocks Task 1 | (absence) | PROBE: `grep -in -e python -e pytest -e jest framework/TESTING_STRATEGY_TDD.md` exits 1 |
 | 13 | GD-13's title says "Two governance documents" while its body says six | `GD-13` | framework/governance/DECISIONS.md:202 |
-| 14 | The `0.41.3` CHANGELOG entry is the block to extend | `0.41.2 → 0.41.3` | CHANGELOG.md:38 |
+| 14 | The `0.41.3` CHANGELOG entry is the block to extend | `0.41.2 → 0.41.3` | CHANGELOG.md:46 |
 | 15 | `total_sections` has exactly one consumer and it is BRD-only | `test_total_sections_bumped` | tests/conformance/test_seed_contract.py:80 |
 | 16 | STRUCT01's required-section set is derived from top-level keys carrying `_size_target` | `_size_target` | `tools/sdd_doc_lint/__init__.py:531` |
 | 17 | The section-count gate counts `# Section N:` comment headers | `_template_numbered_count` | tests/conformance/platforms/test_skill_template_alignment.py:78 |
 | 18 | EARS's `glossary:` carries `_size_target` and no `_required: false`, so STRUCT01 requires a section the template does not number | `glossary` | framework/layers/03_EARS/EARS-TEMPLATE.yaml:401 |
-| 19 | `fw_prev` is detected from `docs/PARITY.md`, not `CLAUDE.md` — #386 is fixed | `fw_prev` | scripts/sync-version-refs.sh:288 |
-| 20 | The script's own header comment still claims `CLAUDE.md` is the `fw_prev` source | `deliberately NOT` | scripts/sync-version-refs.sh:52 |
+| 19 | `fw_prev` is detected from `docs/PARITY.md`, not `CLAUDE.md` — #386 is fixed | `fw_prev="$(detect_version_in docs/PARITY.md` | scripts/sync-version-refs.sh:298 |
+| 20 | **RESOLVED 2026-08-28 by #556.** The script header and `CLAUDE.md` both named `CLAUDE.md` as the `fw_prev` source; both now name `docs/PARITY.md` | `Corrected per #556` | scripts/sync-version-refs.sh:62 |
 | 21 | SPEC's declared diagram-tag vocabulary is two values | `diagram_tags` | framework/registry/LAYER_REGISTRY.yaml:204 |
 | 22 | EARS's diagram allowlist is empty, so any EARS `@diagram:` tag is a DG02 error | `_DIAGRAM_ALLOWED` | `tools/sdd_doc_lint/__init__.py:820` |
 | 23 | R8 places IPLAN `title` in `metadata:` and is founder-gated on OKF D1 — line cited as of `docs/a2-discard-d0077`, which restores two void R-rows above it | `R8` | plans/IPLAN-LAYER-REVIEW-001-DESIGN.md:340 |
@@ -294,7 +295,7 @@ more findings than Pass 1, so scope was cut rather than folded** (fold disciplin
   not number (Claim 18) — is filed separately, not fixed here.
 - **Task 4's fanout guardrail protected the wrong file.** `fw_prev` is detected from
   `docs/PARITY.md` (Claim 19); #386 is fixed. `CLAUDE.md`'s durable trap and the script's
-  own header (Claim 20) are both stale. Rewritten, and filed separately.
+  own header (Claim 20) were both stale — filed as #556 and fixed on 2026-08-28.
 - **Minor, folded:** Task 3 edits a historical CHANGELOG entry in place; permissible only
   because it is still under `## [Unreleased]` (Claim 24). Now stated.
 - **Confirmed, no action:** D2 is correct and #551's snippet genuinely is wrong; blast

--- a/scripts/sync-version-refs.sh
+++ b/scripts/sync-version-refs.sh
@@ -49,9 +49,17 @@
 #
 # The two CLAUDE.md current-state tokens (plugin, hermes) are detected from
 # CLAUDE.md itself, so they self-heal even when every other surface is already
-# current. The framework-spec token is deliberately NOT: fw_prev detected from
-# CLAUDE.md is what gates propagation to README / PARITY / both platform READMEs,
-# so hand-editing CLAUDE.md before a framework bump still silently skips them.
+# current. The framework-spec token is detected from docs/PARITY.md instead (see
+# the fw_prev assignment below) -- that is what gates propagation to CLAUDE.md,
+# README.md, docs/PARITY.md ITSELF, both platform READMEs, and the conformance
+# literal in tests/conformance/platforms/test_plugin_release_metadata.py. So it
+# is docs/PARITY.md that must not be hand-edited before a framework bump: it is
+# both the detector's source and one of its targets, so pre-editing it makes the
+# gate compare equal and skip every one of them. Editing CLAUDE.md first is
+# harmless. NOTE the three framework loops BELOW this gate (FRAMEWORK_SPEC_VERSION,
+# SKILL frontmatter, playbooks) each have their own detector and are NOT affected.
+# (This comment previously said fw_prev came from CLAUDE.md; #386 fixed that and
+# the comment was not updated. Corrected per #556.)
 #
 # What it does NOT do (semantic / human-authored content):
 #   - CHANGELOG entries (text)


### PR DESCRIPTION
## What

`scripts/sync-version-refs.sh` derives `fw_prev` — the token gating one block of the framework-spec fanout — from **`docs/PARITY.md`**, a change made by #386. Two narrative surfaces went on describing the pre-#386 behaviour and named `CLAUDE.md` as the source: the script's own header comment, and `CLAUDE.md` § "Durable traps".

## Why it mattered

It misled in **both** directions at once:

- It warned readers off hand-editing `CLAUDE.md`, which #386 made **harmless** — `replace_in_file_counted` finds count 0 and returns without warning or early exit, so the rest of the block still runs.
- It said nothing about **`docs/PARITY.md`**, which is both the detector's source *and* one of its targets. Pre-editing it makes the gate compare equal and skip the whole block — **silently, at exit 0**. Worse, the three loops *below* the gate still rewrite their files, so the run prints `version-reference sync applied` and looks successful.

`CLAUDE.md` is auto-loaded every session, and its § "Durable traps" preamble explicitly tells readers these are facts not to re-derive. The stale claim was carried into a plan draft in this repo before an independent review opened the script.

## The first draft of this fix repeated the defect

Worth recording, because it is the same class:

- It cited the `fw_prev` assignment as `:288`. **Its own edit to the header above moved that line to `:298`.** The script already documents this precedent in its `#405` note — *"Cite this note by NAME, never by line number"* — and the fix ignored it.
- Its CHANGELOG citation `:50-54` pointed at the range the fix had just **replaced**, where the new text says the opposite.

Everything is now cited by name. Two further review findings folded: the script header's propagation list omitted `docs/PARITY.md` itself and the conformance literal, and the CHANGELOG over-claimed "the entire fanout" when the three loops below the gate (`FRAMEWORK_SPEC_VERSION`, 52 SKILL frontmatters, playbooks) each have their own detector and are unaffected — which `CLAUDE.md`'s own text said correctly in the same commit.

## Ledger maintenance

`plans/TEMPLATE-COMPLETENESS-001-PLAN.md` rows 19 and 20 cite this script. Row 20's anchor token (`deliberately NOT`) is **deleted by this fix**, and its claim — that the header "still" names `CLAUDE.md` — is now false. Both rows updated; the citation gate passes on 28 citations.

## Verification

- Conformance **375 passed / 796 subtests**; acceptance-deterministic **64 / 56**; `pre-commit` 19 hooks green.
- `git diff -- scripts/sync-version-refs.sh | grep -vE '^[-+]\s*#'` → empty. **Comment-only; no behaviour change.**
- The propagation list was re-derived from the gate block itself, not carried forward.

## Scope

Three doc surfaces (`CHANGELOG.md`, `CLAUDE.md`, the plan) plus one comment-only code file. The `CHANGELOG.md` entry is owed here — unlike #559, this PR touches `scripts/`, which **is** a trigger row in canon's doc-coverage table.

Closes #556.
