### PR TITLE
fix(tests): forward coverage was exercised by nothing — 15 fixtures now author §7 in the normative form (#577)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,36 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — forward coverage was exercised by nothing; 15 acceptance fixtures now author §7 in the normative form (#577) (2026-08-29)
+
+`COV01` — *every in-scope BRD functional requirement must reach a SPEC and an IPLAN*, an error
+in `gate-code` — **fired on zero acceptance targets**. Not "passed": it graded nothing, because
+every fixture authored §7 as `### <ID> <Title>` level-3 headings while
+`BRD-TEMPLATE.yaml` `functional_requirements._authored_form` normatively prescribes
+`- **<ID> — <Title>** (<band>): …`. Of 27 fixture files with an FR heading, **none** yielded a
+single requirement, and no manifest pinned a `COV01`.
+
+**The scanner was right; the fixtures were not.** 15 files re-authored into the normative form,
+including the `(P1)` band and the `Acceptance criteria:` boundary that bounds the gated set.
+
+`COV01` is now **live** on `fullpath/golden_chain` — the one target with a complete
+BRD→…→IPLAN graph — and it is quiet there because it is *satisfied*, not because it is blind.
+Proven both ways: injecting an uncovered `(P1)` FR produces a `COV01` error; the unmodified
+chain produces none.
+
+The per-layer targets remain unexercised for a **different**, already-recorded reason: their
+`.yaml` downstreams carry an unterminated `---` fence, so `_extract_frontmatter` returns `None`,
+they are invisible to `build_edge_graph`, and their BRD's forward reach never includes SPEC.
+That repair is #478's, and it is measured there as adding findings and moving the manifest.
+
+`tests/conformance/test_forward_coverage_is_exercised.py` asserts **liveness, not silence** —
+the fixtures must yield FRs *and* an uncovered FR must actually produce a finding. Asserting
+only that the corpus is clean is what let the blind state persist, because a blind gate and a
+satisfied gate are both quiet. Mutation-tested: reverting one fixture to the heading form
+fails it.
+
+**No manifest changed and no corpus finding moved** — verified.
+
 ### Fixed — three acceptance goldens were invisible to the trace graph; the fence repair makes 14 hidden warnings visible (#478) (2026-08-29)
 
 `layer_06_spec/valid/SPEC-01_golden.yaml`, `layer_07_tdd/valid/TDD-01_golden.yaml` and

--- a/tests/acceptance/fixtures/fullpath/golden_chain/01_BRD/BRD-01_golden.md
+++ b/tests/acceptance/fixtures/fullpath/golden_chain/01_BRD/BRD-01_golden.md
@@ -39,9 +39,11 @@ Decision makers and key contributors for the MVP cycle.
 
 Business-level capabilities the MVP must support.
 
-### BRD.01.07.aaaa Authenticated session
+- **BRD.01.07.aaaa — Authenticated session** (P1): the MVP must let registered users sign in and maintain an authenticated session for the duration of their workflow, with response budgets the downstream EARS requirement codifies.
 
-The MVP must let registered users sign in and maintain an authenticated session for the duration of their workflow, with response budgets the downstream EARS requirement codifies.
+Acceptance criteria:
+
+- **BRD.01.07.b2c4 — Session persists across the workflow**: a signed-in user's session remains valid for the duration of one uninterrupted workflow without re-authentication.
 
 ## ADR Topics
 

--- a/tests/acceptance/fixtures/fullpath/golden_chain/02_PRD/PRD-01_golden.md
+++ b/tests/acceptance/fixtures/fullpath/golden_chain/02_PRD/PRD-01_golden.md
@@ -43,11 +43,7 @@ Role definitions and product-level story summaries for the MVP cycle.
 
 Product-level capabilities elaborating the upstream BRD business requirements.
 
-### PRD.01.09.aaaa Sign-in capability
-
-The product provides a sign-in surface that elaborates the upstream BRD authenticated-session requirement; the downstream EARS atomic requirement codifies the response budget.
-
-- @brd: BRD.01.07.aaaa
+- **PRD.01.09.aaaa — Sign-in capability** (P1): the product provides a sign-in surface that elaborates the upstream BRD authenticated-session requirement; the downstream EARS atomic requirement codifies the response budget. @brd: BRD.01.07.aaaa
 
 ## Customer-Facing Content
 

--- a/tests/acceptance/fixtures/layer_02_prd/valid/BRD-01_golden.md
+++ b/tests/acceptance/fixtures/layer_02_prd/valid/BRD-01_golden.md
@@ -39,9 +39,11 @@ Decision makers and key contributors for the MVP cycle.
 
 Business-level capabilities the MVP must support.
 
-### BRD.01.07.aaaa Authenticated session
+- **BRD.01.07.aaaa — Authenticated session** (P1): the MVP must let registered users sign in and maintain an authenticated session for the duration of their workflow, with response budgets the downstream EARS requirement codifies.
 
-The MVP must let registered users sign in and maintain an authenticated session for the duration of their workflow, with response budgets the downstream EARS requirement codifies.
+Acceptance criteria:
+
+- **BRD.01.07.b2c4 — Session persists across the workflow**: a signed-in user's session remains valid for the duration of one uninterrupted workflow without re-authentication.
 
 ## ADR Topics
 

--- a/tests/acceptance/fixtures/layer_03_ears/valid/BRD-01_golden.md
+++ b/tests/acceptance/fixtures/layer_03_ears/valid/BRD-01_golden.md
@@ -39,9 +39,11 @@ Decision makers and key contributors for the MVP cycle.
 
 Business-level capabilities the MVP must support.
 
-### BRD.01.07.aaaa Authenticated session
+- **BRD.01.07.aaaa — Authenticated session** (P1): the MVP must let registered users sign in and maintain an authenticated session for the duration of their workflow, with response budgets the downstream EARS requirement codifies.
 
-The MVP must let registered users sign in and maintain an authenticated session for the duration of their workflow, with response budgets the downstream EARS requirement codifies.
+Acceptance criteria:
+
+- **BRD.01.07.b2c4 — Session persists across the workflow**: a signed-in user's session remains valid for the duration of one uninterrupted workflow without re-authentication.
 
 ## ADR Topics
 

--- a/tests/acceptance/fixtures/layer_03_ears/valid/PRD-01_golden.md
+++ b/tests/acceptance/fixtures/layer_03_ears/valid/PRD-01_golden.md
@@ -43,11 +43,7 @@ Role definitions and product-level story summaries for the MVP cycle.
 
 Product-level capabilities elaborating the upstream BRD business requirements.
 
-### PRD.01.09.aaaa Sign-in capability
-
-The product provides a sign-in surface that elaborates the upstream BRD authenticated-session requirement; the downstream EARS atomic requirement codifies the response budget.
-
-- @brd: BRD.01.07.aaaa
+- **PRD.01.09.aaaa — Sign-in capability** (P1): the product provides a sign-in surface that elaborates the upstream BRD authenticated-session requirement; the downstream EARS atomic requirement codifies the response budget. @brd: BRD.01.07.aaaa
 
 ## Customer-Facing Content
 

--- a/tests/acceptance/fixtures/layer_04_bdd/valid/BRD-01_golden.md
+++ b/tests/acceptance/fixtures/layer_04_bdd/valid/BRD-01_golden.md
@@ -39,9 +39,11 @@ Decision makers and key contributors for the MVP cycle.
 
 Business-level capabilities the MVP must support.
 
-### BRD.01.07.aaaa Authenticated session
+- **BRD.01.07.aaaa — Authenticated session** (P1): the MVP must let registered users sign in and maintain an authenticated session for the duration of their workflow, with response budgets the downstream EARS requirement codifies.
 
-The MVP must let registered users sign in and maintain an authenticated session for the duration of their workflow, with response budgets the downstream EARS requirement codifies.
+Acceptance criteria:
+
+- **BRD.01.07.b2c4 — Session persists across the workflow**: a signed-in user's session remains valid for the duration of one uninterrupted workflow without re-authentication.
 
 ## ADR Topics
 

--- a/tests/acceptance/fixtures/layer_04_bdd/valid/PRD-01_golden.md
+++ b/tests/acceptance/fixtures/layer_04_bdd/valid/PRD-01_golden.md
@@ -43,11 +43,7 @@ Role definitions and product-level story summaries for the MVP cycle.
 
 Product-level capabilities elaborating the upstream BRD business requirements.
 
-### PRD.01.09.aaaa Sign-in capability
-
-The product provides a sign-in surface that elaborates the upstream BRD authenticated-session requirement; the downstream EARS atomic requirement codifies the response budget.
-
-- @brd: BRD.01.07.aaaa
+- **PRD.01.09.aaaa — Sign-in capability** (P1): the product provides a sign-in surface that elaborates the upstream BRD authenticated-session requirement; the downstream EARS atomic requirement codifies the response budget. @brd: BRD.01.07.aaaa
 
 ## Customer-Facing Content
 

--- a/tests/acceptance/fixtures/layer_05_adr/valid/BRD-01_golden.md
+++ b/tests/acceptance/fixtures/layer_05_adr/valid/BRD-01_golden.md
@@ -39,9 +39,11 @@ Decision makers and key contributors for the MVP cycle.
 
 Business-level capabilities the MVP must support.
 
-### BRD.01.07.aaaa Authenticated session
+- **BRD.01.07.aaaa — Authenticated session** (P1): the MVP must let registered users sign in and maintain an authenticated session for the duration of their workflow, with response budgets the downstream EARS requirement codifies.
 
-The MVP must let registered users sign in and maintain an authenticated session for the duration of their workflow, with response budgets the downstream EARS requirement codifies.
+Acceptance criteria:
+
+- **BRD.01.07.b2c4 — Session persists across the workflow**: a signed-in user's session remains valid for the duration of one uninterrupted workflow without re-authentication.
 
 ## ADR Topics
 

--- a/tests/acceptance/fixtures/layer_05_adr/valid/PRD-01_golden.md
+++ b/tests/acceptance/fixtures/layer_05_adr/valid/PRD-01_golden.md
@@ -43,11 +43,7 @@ Role definitions and product-level story summaries for the MVP cycle.
 
 Product-level capabilities elaborating the upstream BRD business requirements.
 
-### PRD.01.09.aaaa Sign-in capability
-
-The product provides a sign-in surface that elaborates the upstream BRD authenticated-session requirement; the downstream EARS atomic requirement codifies the response budget.
-
-- @brd: BRD.01.07.aaaa
+- **PRD.01.09.aaaa — Sign-in capability** (P1): the product provides a sign-in surface that elaborates the upstream BRD authenticated-session requirement; the downstream EARS atomic requirement codifies the response budget. @brd: BRD.01.07.aaaa
 
 ## Customer-Facing Content
 

--- a/tests/acceptance/fixtures/layer_06_spec/valid/BRD-01_golden.md
+++ b/tests/acceptance/fixtures/layer_06_spec/valid/BRD-01_golden.md
@@ -39,9 +39,11 @@ Decision makers and key contributors for the MVP cycle.
 
 Business-level capabilities the MVP must support.
 
-### BRD.01.07.aaaa Authenticated session
+- **BRD.01.07.aaaa — Authenticated session** (P1): the MVP must let registered users sign in and maintain an authenticated session for the duration of their workflow, with response budgets the downstream EARS requirement codifies.
 
-The MVP must let registered users sign in and maintain an authenticated session for the duration of their workflow, with response budgets the downstream EARS requirement codifies.
+Acceptance criteria:
+
+- **BRD.01.07.b2c4 — Session persists across the workflow**: a signed-in user's session remains valid for the duration of one uninterrupted workflow without re-authentication.
 
 ## ADR Topics
 

--- a/tests/acceptance/fixtures/layer_06_spec/valid/PRD-01_golden.md
+++ b/tests/acceptance/fixtures/layer_06_spec/valid/PRD-01_golden.md
@@ -43,11 +43,7 @@ Role definitions and product-level story summaries for the MVP cycle.
 
 Product-level capabilities elaborating the upstream BRD business requirements.
 
-### PRD.01.09.aaaa Sign-in capability
-
-The product provides a sign-in surface that elaborates the upstream BRD authenticated-session requirement; the downstream EARS atomic requirement codifies the response budget.
-
-- @brd: BRD.01.07.aaaa
+- **PRD.01.09.aaaa — Sign-in capability** (P1): the product provides a sign-in surface that elaborates the upstream BRD authenticated-session requirement; the downstream EARS atomic requirement codifies the response budget. @brd: BRD.01.07.aaaa
 
 ## Customer-Facing Content
 

--- a/tests/acceptance/fixtures/layer_07_tdd/valid/BRD-01_golden.md
+++ b/tests/acceptance/fixtures/layer_07_tdd/valid/BRD-01_golden.md
@@ -39,9 +39,11 @@ Decision makers and key contributors for the MVP cycle.
 
 Business-level capabilities the MVP must support.
 
-### BRD.01.07.aaaa Authenticated session
+- **BRD.01.07.aaaa — Authenticated session** (P1): the MVP must let registered users sign in and maintain an authenticated session for the duration of their workflow, with response budgets the downstream EARS requirement codifies.
 
-The MVP must let registered users sign in and maintain an authenticated session for the duration of their workflow, with response budgets the downstream EARS requirement codifies.
+Acceptance criteria:
+
+- **BRD.01.07.b2c4 — Session persists across the workflow**: a signed-in user's session remains valid for the duration of one uninterrupted workflow without re-authentication.
 
 ## ADR Topics
 

--- a/tests/acceptance/fixtures/layer_07_tdd/valid/PRD-01_golden.md
+++ b/tests/acceptance/fixtures/layer_07_tdd/valid/PRD-01_golden.md
@@ -43,11 +43,7 @@ Role definitions and product-level story summaries for the MVP cycle.
 
 Product-level capabilities elaborating the upstream BRD business requirements.
 
-### PRD.01.09.aaaa Sign-in capability
-
-The product provides a sign-in surface that elaborates the upstream BRD authenticated-session requirement; the downstream EARS atomic requirement codifies the response budget.
-
-- @brd: BRD.01.07.aaaa
+- **PRD.01.09.aaaa — Sign-in capability** (P1): the product provides a sign-in surface that elaborates the upstream BRD authenticated-session requirement; the downstream EARS atomic requirement codifies the response budget. @brd: BRD.01.07.aaaa
 
 ## Customer-Facing Content
 

--- a/tests/acceptance/fixtures/layer_08_iplan/valid/BRD-01_golden.md
+++ b/tests/acceptance/fixtures/layer_08_iplan/valid/BRD-01_golden.md
@@ -39,9 +39,11 @@ Decision makers and key contributors for the MVP cycle.
 
 Business-level capabilities the MVP must support.
 
-### BRD.01.07.aaaa Authenticated session
+- **BRD.01.07.aaaa — Authenticated session** (P1): the MVP must let registered users sign in and maintain an authenticated session for the duration of their workflow, with response budgets the downstream EARS requirement codifies.
 
-The MVP must let registered users sign in and maintain an authenticated session for the duration of their workflow, with response budgets the downstream EARS requirement codifies.
+Acceptance criteria:
+
+- **BRD.01.07.b2c4 — Session persists across the workflow**: a signed-in user's session remains valid for the duration of one uninterrupted workflow without re-authentication.
 
 ## ADR Topics
 

--- a/tests/acceptance/fixtures/layer_08_iplan/valid/PRD-01_golden.md
+++ b/tests/acceptance/fixtures/layer_08_iplan/valid/PRD-01_golden.md
@@ -43,11 +43,7 @@ Role definitions and product-level story summaries for the MVP cycle.
 
 Product-level capabilities elaborating the upstream BRD business requirements.
 
-### PRD.01.09.aaaa Sign-in capability
-
-The product provides a sign-in surface that elaborates the upstream BRD authenticated-session requirement; the downstream EARS atomic requirement codifies the response budget.
-
-- @brd: BRD.01.07.aaaa
+- **PRD.01.09.aaaa — Sign-in capability** (P1): the product provides a sign-in surface that elaborates the upstream BRD authenticated-session requirement; the downstream EARS atomic requirement codifies the response budget. @brd: BRD.01.07.aaaa
 
 ## Customer-Facing Content
 

--- a/tests/conformance/test_forward_coverage_is_exercised.py
+++ b/tests/conformance/test_forward_coverage_is_exercised.py
@@ -1,0 +1,108 @@
+"""Conformance: at least one acceptance target actually exercises ``COV01``.
+
+`COV01` is the framework's **forward-coverage** gate — every in-scope BRD
+functional requirement must reach a SPEC and an IPLAN, an error in ``gate-code``.
+A gate that grades zero requirements passes silently and forever, and that is
+indistinguishable from a gate that passes because the corpus is correct.
+
+**Regression cover: #577.** Every acceptance fixture authored its §7 as
+``### <ID> <Title>`` level-3 headings. `scan_fr_elements` requires the bullet
+form `BRD-TEMPLATE.yaml` `functional_requirements._authored_form` prescribes
+normatively — ``- **<ID> — <Title>** (<band>): …`` — so **not one fixture yielded
+a single functional requirement**, `COV01` fired on no target, and no manifest
+pinned one. The scanner was right; the fixtures were not.
+
+**This asserts liveness, not silence.** Both halves matter and the second is the
+one that was missing: the fixtures must yield FRs *and* an uncovered FR must
+actually produce a finding. Asserting only that the corpus is clean is what let
+the blind state persist — a blind gate and a satisfied gate are both quiet.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+from _spec import REPO_ROOT
+
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+from sdd_doc_lint import lint_path, scan_fr_elements  # noqa: E402
+
+FIXTURES = REPO_ROOT / "tests" / "acceptance" / "fixtures"
+
+# The one target with a complete BRD→…→IPLAN graph, and therefore the only place
+# forward coverage is meaningful. The per-layer targets stage upstreams as
+# context and their `.yaml` downstreams carry an unterminated `---` fence, so
+# they are invisible to `build_edge_graph` and their BRD never reaches SPEC —
+# a separate defect, tracked on #478, with a measured manifest cost.
+CHAIN = FIXTURES / "fullpath" / "golden_chain"
+CHAIN_BRD = CHAIN / "01_BRD" / "BRD-01_golden.md"
+
+
+class ForwardCoverageIsExercised(unittest.TestCase):
+    def test_the_chain_brd_yields_functional_requirements(self):
+        frs = scan_fr_elements(CHAIN_BRD.read_text(encoding="utf-8"))
+        self.assertTrue(
+            frs,
+            f"{CHAIN_BRD.relative_to(REPO_ROOT)} yields no FR to scan_fr_elements — "
+            "§7 must use the normative bullet form from BRD-TEMPLATE.yaml "
+            "`functional_requirements._authored_form`, or COV01 grades nothing (#577)",
+        )
+
+    def test_every_yielded_fr_carries_a_band(self):
+        """The band is the machine-readable phase signal.
+
+        Without it an FR classifies as in-scope by default, so the fixture would
+        still exercise COV01 — but by accident. `_authored_form` calls the band
+        normative; assert it rather than rely on the default.
+        """
+        for fr in scan_fr_elements(CHAIN_BRD.read_text(encoding="utf-8")):
+            with self.subTest(fr=fr.elem_id):
+                self.assertIn(fr.band, ("P1", "P2", "Future"), f"{fr.elem_id} has band {fr.band!r}")
+
+    def test_an_uncovered_requirement_actually_produces_cov01(self):
+        """Liveness. Injects an FR nothing realizes and asserts COV01 fires.
+
+        Adding an FR rather than renaming an existing one is deliberate: renaming
+        makes every downstream ``@brd:`` citation unresolvable, so TRACE-RES-001
+        fires first and COV01's absence proves nothing. That faulty probe is how
+        this test's first draft concluded the gate was dead on targets where it
+        is merely inapplicable.
+        """
+        import shutil
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            work = Path(tmp) / "chain"
+            shutil.copytree(CHAIN, work)
+            brd = work / "01_BRD" / "BRD-01_golden.md"
+            text = brd.read_text(encoding="utf-8")
+            anchor = "\n\nAcceptance criteria:"
+            self.assertIn(anchor, text, "the fixture lost its acceptance-criteria boundary")
+            brd.write_text(
+                text.replace(
+                    anchor,
+                    "\n- **BRD.01.07.c0de — Uncovered capability** (P1): "
+                    "a requirement nothing downstream picks up." + anchor,
+                    1,
+                ),
+                encoding="utf-8",
+            )
+            codes = [f.code for f in lint_path(work)]
+            self.assertIn(
+                "COV01",
+                codes,
+                "an uncovered in-scope FR produced no COV01 — forward coverage is "
+                f"not being evaluated on {CHAIN.relative_to(REPO_ROOT)}. Codes seen: "
+                f"{sorted(set(codes))}",
+            )
+
+    def test_the_unmodified_chain_is_cov01_clean(self):
+        """The control: quiet because satisfied, which the test above distinguishes."""
+        codes = [f.code for f in lint_path(CHAIN)]
+        self.assertNotIn("COV01", codes, "the golden chain should satisfy forward coverage")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`COV01` — *every in-scope BRD functional requirement must reach a SPEC and an
IPLAN*, an **error** in `gate-code` — **fired on zero acceptance targets**.

Not "passed". It graded nothing. Every fixture authored §7 as
`### <ID> <Title>` level-3 headings, while `BRD-TEMPLATE.yaml`
`functional_requirements._authored_form` normatively prescribes
`- **<ID> — <Title>** (<band>): …`. Of **27** fixture files with an FR heading,
**none** yielded a single requirement, and no manifest pinned a `COV01`.

**The scanner is right; the fixtures were not.** I checked the template before
concluding the opposite — "the scanner is incomplete" was the intuitive read and
would have been the wrong fix.

## What changed

15 files re-authored into the normative form, including the `(P1)` band (the
machine-readable phase signal) and the `Acceptance criteria:` line that bounds
the gated set.

**`COV01` is now live on `fullpath/golden_chain`** — the one target with a
complete BRD→…→IPLAN graph — and it is quiet there because **satisfied**, not
blind. Proven both ways:

| Probe | Result |
|---|---|
| inject an uncovered `(P1)` FR | `[ERROR COV01] in-scope FR 'BRD.01.07.c0de' (band P1) is cited by no PRD` |
| unmodified chain | no `COV01` |

## Why the per-layer targets are still unexercised — a different, recorded defect

Their `.yaml` downstreams carry an **unterminated** `---` fence (document-start
marker only), so `_extract_frontmatter` returns `None`, they are invisible to
`build_edge_graph`, and the BRD's forward reach never includes SPEC. Measured:

```
layer_06_spec/valid  BRD-01 forward reach = ['ADR', 'BDD', 'EARS', 'PRD']
```

That repair belongs to **#478**, where it is already recorded as adding findings
and moving the manifest. Deliberately out of scope here.

## The guard asserts liveness, not silence

`tests/conformance/test_forward_coverage_is_exercised.py`: the fixtures must
yield FRs **and** an uncovered FR must actually produce a finding. Asserting
only that the corpus is clean is precisely what let the blind state persist —
**a blind gate and a satisfied gate are both quiet**. Mutation-tested: reverting
one fixture to the heading form fails it.

## Two probe corrections, recorded because both were mine

- **Orphaning an existing FR id is a faulty probe.** It makes every downstream
  `@brd:` citation unresolvable, so `TRACE-RES-001` fires first and `COV01`'s
  absence proves nothing. My first liveness run used it and wrongly concluded the
  gate was dead on targets where it is merely inapplicable. The test **adds** an
  uncovered FR instead.
- **`zzzz` is not a valid element-id suffix** — `ID03` requires hex. Caught by
  the linter on the first run.

## Verification

conformance **418** · acceptance-deterministic **64** · unit **196**.
**No manifest changed and no corpus finding moved** — both verified, not assumed.
`pre-commit run --all-files` green on two consecutive runs.

Closes #577

Multi-agent self-review per OPS-0065 (self-review + bidirectional liveness probe + mutation test): APPROVE
