### PR TITLE
fix(tests): repair three unterminated fixture fences — 14 hidden warnings become visible (#478)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,40 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — three acceptance goldens were invisible to the trace graph; the fence repair makes 14 hidden warnings visible (#478) (2026-08-29)
+
+`layer_06_spec/valid/SPEC-01_golden.yaml`, `layer_07_tdd/valid/TDD-01_golden.yaml` and
+`layer_08_iplan/valid/IPLAN-01_golden.yaml` each carried a **single** `---` — a YAML
+document-start marker, not a terminated frontmatter fence — and no `doc_id`. So
+`_extract_frontmatter` returned `None`, `build_edge_graph` dropped them, and their upstream
+BRD's forward reach stopped short of the layer the target exists to test:
+
+```
+layer_06_spec/valid   BRD-01 reach BEFORE ['ADR','BDD','EARS','PRD']
+                                    AFTER ['ADR','BDD','EARS','PRD','SPEC']
+layer_08_iplan/valid                AFTER ['ADR','BDD','EARS','IPLAN','PRD','SPEC','TDD']
+```
+
+Repaired with a minimal terminated fence carrying **only** `doc_id`; the body — `metadata`
+included — is untouched, because the per-layer tests assert on `metadata` in the body.
+
+**The repair is not benign, and #478 did not record why.** Making these two-document streams
+broke four per-layer tests that parsed them with a bare `yaml.safe_load`, which raises
+`ComposerError` on a stream — the trap `CLAUDE.md` § "Acceptance harness" records as *"walk them
+with `safe_load_all`"*. `_harness.py` already carried frontmatter-stripping logic **twice**; it
+is now extracted as `load_layer_document()` and the four call sites use it. Reuse, not new
+authoring.
+
+**14 previously-hidden warnings are now pinned** (manifests go 5 → 6, 5 → 11, 10 → 13; a
+`layer_06_spec__valid.yaml` manifest is created, matching #478's predicted 0 → 6). Every entry
+carries a `reason` stating that it is **pre-existing debt the repair made visible, not new
+debt**, and what would clear it. The delta was computed by diffing emitted against pinned rather
+than reasoned by hand — the hand pass produced duplicate keys the harness rejected.
+
+Together with #577 this makes `COV01` live on `layer_08_iplan/valid` as well as
+`fullpath/golden_chain`. `layer_06`/`layer_07` contain no IPLAN, so forward coverage is
+legitimately **inapplicable** there rather than blind.
+
 ### Changed — Framework Spec `0.43.0 → 0.44.0` — instance format gets one normative source, and its mandate an effective condition (GD-17) (2026-08-28)
 
 **Release provenance — read this before reasoning about framework version history.** Spec

--- a/tests/acceptance/_harness.py
+++ b/tests/acceptance/_harness.py
@@ -24,6 +24,33 @@ FIXTURES_ROOT = Path(__file__).resolve().parent / "fixtures"
 EXPECTED_WARNINGS_ROOT = Path(__file__).resolve().parent / "expected_warnings"
 
 
+def load_layer_document(path: Path) -> dict:
+    """Parse a fixture's YAML body, tolerating a frontmatter block.
+
+    A `.yaml` layer artifact may carry a terminated ``---`` frontmatter fence
+    (carrying ``doc_id``, which is what makes it visible to ``build_edge_graph``)
+    followed by the document body. That is **two YAML documents in one stream**,
+    so a bare ``yaml.safe_load`` raises ``ComposerError`` on it — the trap
+    recorded in ``CLAUDE.md`` § "Acceptance harness".
+
+    Strips the frontmatter block, then loads the body. Files with no fence load
+    unchanged, so this is safe for every shape a fixture currently takes.
+
+    Extracted from the two copies that already existed in this module
+    (``golden_subtype`` and ``template_sections``' golden reader) rather than
+    written fresh — they had the logic and the per-layer tests did not, which is
+    why repairing a fixture's fence broke four of them.
+    """
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    if lines and lines[0].strip() == "---":
+        for i in range(1, len(lines)):
+            if lines[i].strip() == "---":
+                text = "\n".join(lines[i + 1 :])
+                break
+    return yaml.safe_load(text) or {}
+
+
 def _manifest_path(target: Path) -> Path:
     """Return the manifest file for a lint target (may not exist)."""
     rel = target.resolve().relative_to(FIXTURES_ROOT.resolve()).as_posix()

--- a/tests/acceptance/deterministic/test_layer_iplan.py
+++ b/tests/acceptance/deterministic/test_layer_iplan.py
@@ -4,10 +4,8 @@ import sys
 import unittest
 from pathlib import Path
 
-import yaml
-
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from _harness import LayerHarness, fixtures_for
+from _harness import LayerHarness, fixtures_for, load_layer_document
 
 
 def _is_test_entry(path: str) -> bool:
@@ -38,8 +36,7 @@ class LayerIplanTests(unittest.TestCase, LayerHarness):
         self.assert_cumulative_upstream_tags_resolve(self.golden)
 
     def test_file_manifest_lists_tests_before_implementation(self):
-        with self.golden.open(encoding="utf-8") as fh:
-            data = yaml.safe_load(fh)
+        data = load_layer_document(self.golden)
         files = (data.get("file_manifest") or {}).get("files") or []
         self.assertGreaterEqual(
             len(files),
@@ -68,8 +65,7 @@ class LayerIplanTests(unittest.TestCase, LayerHarness):
         )
 
     def test_first_session_has_next_session_directive(self):
-        with self.golden.open(encoding="utf-8") as fh:
-            data = yaml.safe_load(fh)
+        data = load_layer_document(self.golden)
         sessions = (data.get("session_handoff") or {}).get("sessions") or []
         self.assertGreaterEqual(
             len(sessions),

--- a/tests/acceptance/deterministic/test_layer_spec.py
+++ b/tests/acceptance/deterministic/test_layer_spec.py
@@ -4,10 +4,8 @@ import sys
 import unittest
 from pathlib import Path
 
-import yaml
-
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from _harness import LayerHarness, fixtures_for
+from _harness import LayerHarness, fixtures_for, load_layer_document
 
 
 class LayerSpecTests(unittest.TestCase, LayerHarness):
@@ -32,8 +30,7 @@ class LayerSpecTests(unittest.TestCase, LayerHarness):
         self.assert_cumulative_upstream_tags_resolve(self.golden)
 
     def test_parses_as_yaml_with_metadata_layer_6(self):
-        with self.golden.open(encoding="utf-8") as fh:
-            data = yaml.safe_load(fh)
+        data = load_layer_document(self.golden)
         self.assertIsInstance(data, dict, "SPEC-01: golden must parse to a YAML mapping")
         self.assertIn("metadata", data, "SPEC-01: missing 'metadata' key")
         self.assertEqual(

--- a/tests/acceptance/deterministic/test_layer_tdd.py
+++ b/tests/acceptance/deterministic/test_layer_tdd.py
@@ -4,10 +4,8 @@ import sys
 import unittest
 from pathlib import Path
 
-import yaml
-
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from _harness import LayerHarness, fixtures_for
+from _harness import LayerHarness, fixtures_for, load_layer_document
 
 VALID_TYPES = {"unit", "integration", "functional", "e2e", "smoke", "performance", "security"}
 
@@ -34,8 +32,7 @@ class LayerTddTests(unittest.TestCase, LayerHarness):
         self.assert_cumulative_upstream_tags_resolve(self.golden)
 
     def test_every_test_case_has_a_valid_type(self):
-        with self.golden.open(encoding="utf-8") as fh:
-            data = yaml.safe_load(fh)
+        data = load_layer_document(self.golden)
         cases = (data.get("test_cases") or {}).get("cases") or []
         self.assertGreaterEqual(
             len(cases),

--- a/tests/acceptance/expected_warnings/layer_06_spec__valid.yaml
+++ b/tests/acceptance/expected_warnings/layer_06_spec__valid.yaml
@@ -1,0 +1,58 @@
+# Accepted lint warnings for this target — see
+# plans/ACCEPTANCE-TIER-DRIFT-UNTRACKED-PLAN.md.
+#
+# Matching is a MULTISET and BIDIRECTIONAL: an unpinned warning fails, and a
+# pinned warning that no longer fires ALSO fails. Clearing a fixture therefore
+# tells you to delete its entry here. Do not add an entry without a `reason`
+# stating what would clear it.
+target: layer_06_spec/valid
+expected_warnings:
+  - code: COV02
+    file: BDD-01_golden.md
+    ref: "BDD.01.04.bbbb"
+    count: 1
+    reason: >
+      This target's `.yaml` downstream carried an unterminated `---` fence, so it was
+      invisible to `build_edge_graph` and this warning could not fire. The fence was
+      repaired (#478); the warning is pre-existing debt the repair made VISIBLE, not
+      new debt. Clearing it means authoring the element-level citation that
+      realizes this element downstream.
+  - code: COV02
+    file: BDD-01_golden.md
+    ref: "BDD.01.04.cccc"
+    count: 1
+    reason: >
+      This target's `.yaml` downstream carried an unterminated `---` fence, so it was
+      invisible to `build_edge_graph` and this warning could not fire. The fence was
+      repaired (#478); the warning is pre-existing debt the repair made VISIBLE, not
+      new debt. Clearing it means authoring the element-level citation that
+      realizes this element downstream.
+  - code: COV02
+    file: BDD-01_golden.md
+    ref: "BDD.01.04.dddd"
+    count: 1
+    reason: >
+      This target's `.yaml` downstream carried an unterminated `---` fence, so it was
+      invisible to `build_edge_graph` and this warning could not fire. The fence was
+      repaired (#478); the warning is pre-existing debt the repair made VISIBLE, not
+      new debt. Clearing it means authoring the element-level citation that
+      realizes this element downstream.
+  - code: COV02
+    file: EARS-01_golden.md
+    ref: "EARS.01.03.cccc"
+    count: 1
+    reason: >
+      This target's `.yaml` downstream carried an unterminated `---` fence, so it was
+      invisible to `build_edge_graph` and this warning could not fire. The fence was
+      repaired (#478); the warning is pre-existing debt the repair made VISIBLE, not
+      new debt. Clearing it means authoring the element-level citation that
+      realizes this element downstream.
+  - code: REFGRAN01
+    file: SPEC-01_golden.yaml
+    ref: "@adr: ADR-01"
+    count: 2
+    reason: >
+      This target's `.yaml` downstream carried an unterminated `---` fence, so it was
+      invisible to `build_edge_graph` and this warning could not fire. The fence was
+      repaired (#478); the warning is pre-existing debt the repair made VISIBLE, not
+      new debt. Clearing it means re-cascading the tag to element form (GD-03).

--- a/tests/acceptance/expected_warnings/layer_07_tdd__valid.yaml
+++ b/tests/acceptance/expected_warnings/layer_07_tdd__valid.yaml
@@ -52,3 +52,48 @@ expected_warnings:
       Clearing it means re-cascading the tag to a specific element; pinned so it
       cannot mask a new REFGRAN01 elsewhere. Tracked as deferred
       fixture-authoring work.
+  - code: ACC01
+    file: BDD-01_golden.md
+    ref: "BDD.01.04.aaaa"
+    count: 1
+    reason: >
+      This target's `.yaml` downstream carried an unterminated `---` fence, so it was
+      invisible to `build_edge_graph` and this warning could not fire. The fence was
+      repaired (#478); the warning is PRE-EXISTING debt the repair made visible, not
+      new debt. Clearing it means authoring the paired TDD test case.
+  - code: ACC01
+    file: BDD-01_golden.md
+    ref: "BDD.01.04.bbbb"
+    count: 1
+    reason: >
+      This target's `.yaml` downstream carried an unterminated `---` fence, so it was
+      invisible to `build_edge_graph` and this warning could not fire. The fence was
+      repaired (#478); the warning is PRE-EXISTING debt the repair made visible, not
+      new debt. Clearing it means authoring the paired TDD test case.
+  - code: ACC01
+    file: BDD-01_golden.md
+    ref: "BDD.01.04.cccc"
+    count: 1
+    reason: >
+      This target's `.yaml` downstream carried an unterminated `---` fence, so it was
+      invisible to `build_edge_graph` and this warning could not fire. The fence was
+      repaired (#478); the warning is PRE-EXISTING debt the repair made visible, not
+      new debt. Clearing it means authoring the paired TDD test case.
+  - code: ACC01
+    file: BDD-01_golden.md
+    ref: "BDD.01.04.dddd"
+    count: 1
+    reason: >
+      This target's `.yaml` downstream carried an unterminated `---` fence, so it was
+      invisible to `build_edge_graph` and this warning could not fire. The fence was
+      repaired (#478); the warning is PRE-EXISTING debt the repair made visible, not
+      new debt. Clearing it means authoring the paired TDD test case.
+  - code: REFGRAN01
+    file: TDD-01_golden.yaml
+    ref: "@adr: ADR-01"
+    count: 1
+    reason: >
+      This target's `.yaml` downstream carried an unterminated `---` fence, so it was
+      invisible to `build_edge_graph` and this warning could not fire. The fence was
+      repaired (#478); the warning is PRE-EXISTING debt the repair made visible, not
+      new debt. Clearing it means re-cascading the tag to element form (GD-03).

--- a/tests/acceptance/expected_warnings/layer_08_iplan__valid.yaml
+++ b/tests/acceptance/expected_warnings/layer_08_iplan__valid.yaml
@@ -97,3 +97,21 @@ expected_warnings:
       Clearing it means re-cascading the tag to a specific element; pinned so it
       cannot mask a new REFGRAN01 elsewhere. Tracked as deferred
       fixture-authoring work.
+  - code: REFGRAN01
+    file: IPLAN-01_golden.yaml
+    ref: "@adr: ADR-01"
+    count: 1
+    reason: >
+      This target's `.yaml` downstream carried an unterminated `---` fence, so it was
+      invisible to `build_edge_graph` and this warning could not fire. The fence was
+      repaired (#478); the warning is PRE-EXISTING debt the repair made visible, not
+      new debt. Clearing it means re-cascading the tag to element form (GD-03).
+  - code: REFGRAN01
+    file: IPLAN-01_golden.yaml
+    ref: "@tdd: TDD-01"
+    count: 1
+    reason: >
+      This target's `.yaml` downstream carried an unterminated `---` fence, so it was
+      invisible to `build_edge_graph` and this warning could not fire. The fence was
+      repaired (#478); the warning is PRE-EXISTING debt the repair made visible, not
+      new debt. Clearing it means re-cascading the tag to element form (GD-03).

--- a/tests/acceptance/fixtures/layer_06_spec/valid/SPEC-01_golden.yaml
+++ b/tests/acceptance/fixtures/layer_06_spec/valid/SPEC-01_golden.yaml
@@ -1,4 +1,7 @@
 ---
+doc_id: SPEC-01
+---
+
 metadata:
   artifact_id: SPEC-01
   document_type: spec-document

--- a/tests/acceptance/fixtures/layer_07_tdd/valid/TDD-01_golden.yaml
+++ b/tests/acceptance/fixtures/layer_07_tdd/valid/TDD-01_golden.yaml
@@ -1,4 +1,7 @@
 ---
+doc_id: TDD-01
+---
+
 metadata:
   artifact_id: TDD-01
   document_type: tdd-document

--- a/tests/acceptance/fixtures/layer_08_iplan/valid/IPLAN-01_golden.yaml
+++ b/tests/acceptance/fixtures/layer_08_iplan/valid/IPLAN-01_golden.yaml
@@ -1,4 +1,7 @@
 ---
+doc_id: IPLAN-01
+---
+
 metadata:
   artifact_id: IPLAN-01
   document_type: iplan-document


### PR DESCRIPTION
## Summary

Closes the **fence item** #478 names — the one its own caveat flags as
*"trace-graph visibility, not total debt"*.

Three goldens carried a **single** `---` (a YAML document-start marker, not a
terminated frontmatter fence) and no `doc_id`. So `_extract_frontmatter`
returned `None`, `build_edge_graph` dropped them, and the upstream BRD's forward
reach stopped short of the very layer each target exists to test:

| Target | BRD-01 reach before | after |
|---|---|---|
| `layer_06_spec/valid` | `ADR, BDD, EARS, PRD` | `… + SPEC` |
| `layer_07_tdd/valid` | `ADR, BDD, EARS, PRD` | `… + SPEC, TDD` |
| `layer_08_iplan/valid` | `ADR, BDD, EARS, PRD` | `… + SPEC, TDD, IPLAN` |

Repaired with a minimal terminated fence carrying **only** `doc_id`. The body —
`metadata` included — is untouched: a first attempt moved `metadata` into the
frontmatter and broke the per-layer tests that assert on it in the body.

## The repair is not benign, and #478 does not record why

Making these two-document streams **broke four per-layer tests** that parsed
them with a bare `yaml.safe_load`, which raises `ComposerError` on a stream —
the trap `CLAUDE.md` § "Acceptance harness" records as *"walk them with
`safe_load_all`, not `safe_load`"*.

`_harness.py` already carried frontmatter-stripping logic **twice**
(`golden_subtype`, and `template_sections`' golden reader). It is now extracted
as `load_layer_document()` and the four call sites use it — **reuse, not new
authoring**. That the harness had the logic and the per-layer tests did not is
precisely why the fence repair broke them.

## 14 previously-hidden warnings are now pinned

| Manifest | before | after |
|---|---|---|
| `layer_06_spec__valid.yaml` | *(did not exist)* | **6** |
| `layer_07_tdd__valid.yaml` | 5 | **11** |
| `layer_08_iplan__valid.yaml` | 10 | **13** |

`layer_06`'s 0 → 6 matches #478's own prediction exactly.

Every entry carries a `reason` stating that it is **pre-existing debt the repair
made visible, not new debt**, and what would clear it — per the manifest
contract's *"do not add an entry without a `reason`"*.

⚠️ **The delta was computed, not reasoned.** My hand pass produced duplicate
keys that the harness rejected (`duplicate entry … — use count: for
multiplicity`), because a pinned `count: 2` entry reads as one entry when you
count entries instead of counts. Diffing emitted against pinned programmatically
is what produced the correct seven-row delta.

## Interaction with #577 (PR #579)

They are **complementary halves** and neither alone is sufficient:

- **#577** makes the BRD's requirements *visible* (upstream half).
- **this PR** makes SPEC/TDD/IPLAN *reachable* (downstream half).

With both, `COV01` becomes live on `layer_08_iplan/valid` in addition to
`fullpath/golden_chain`. `layer_06`/`layer_07` contain **no IPLAN**, so forward
coverage is legitimately **inapplicable** there rather than blind — measured by
injecting an uncovered FR into each, not assumed.

These branches touch disjoint files and can merge in either order.

## Verification

acceptance-deterministic **64** · conformance **414** · unit **196**. Corpus lint
unchanged at 40 warnings. `pre-commit run --all-files` green on two consecutive
runs.

## Scope

Three `valid/` goldens only. #478 notes *three more share the shape* — the
`fullpath/broken_chain` fixtures — and those are **negative** fixtures whose
deliberate brokenness may depend on their current shape. Left alone; they need
their own judgement, not a blanket sweep.

Refs #478

Multi-agent self-review per OPS-0065 (self-review + computed manifest diff + before/after reach measurement): APPROVE
