### PR TITLE
docs(security): state both secret-scanning knobs and what being off costs (#467)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -109,7 +109,35 @@ exclude.
 
 **Configured in the repository's security settings**, outside any file here:
 **secret scanning with push protection**, which rejects a push containing a
-recognised provider token outright — scanning for non-provider and custom
-patterns is not enabled, so it does not catch every secret — and
-**Dependabot**, which raises security alerts and dependency-update pull
-requests.
+recognised provider token outright, and **Dependabot**, which raises security
+alerts and dependency-update pull requests.
+
+⚠️ **Two scanning knobs are OFF, and they narrow what the one merge-blocking
+control actually catches.** Push protection is presented above as the control
+that stops a change before it lands; that is true only for **recognised provider
+tokens**:
+
+| Setting | State | What being off means |
+| --- | --- | --- |
+| `secret_scanning` | enabled | — |
+| `secret_scanning_push_protection` | enabled | — |
+| `secret_scanning_non_provider_patterns` | **disabled** | Generic and custom-shaped secrets — a private key blob, an internal token format, a connection string — are not matched, so push protection does not stop them. |
+| `secret_scanning_validity_checks` | **disabled** | A detected token is not tested against its provider, so an alert cannot say whether the credential is still live. Triage has to assume every finding is active. |
+
+The gap is partly covered in-repo: `detect-secrets` and `detect-private-key` run
+as **required** pre-commit hooks, and `secret-scan.yml` scans the **full git
+history** rather than the working tree. Those catch shapes GitHub's provider
+matching does not. They are not equivalent — they run on this repository's own
+pushes, not on forks' — but they are why the disabled knobs are a narrowing
+rather than an absence.
+
+Re-derive the live state rather than trusting this table:
+
+```sh
+gh api repos/vladm3105/aidoc-flow-framework   --jq '.security_and_analysis | to_entries[] | "\(.key)=\(.value.status)"'
+```
+
+*Status:* enabling both was decided on 2026-08-29 (issue #467). The REST API
+**accepts the write and does not apply it** — a `PATCH` returns `200` with the
+values unchanged — so the change has to be made in the repository's
+Settings → Code security UI. Recorded in `plans/DECISIONS.md`.

--- a/plans/DECISIONS.md
+++ b/plans/DECISIONS.md
@@ -10,6 +10,38 @@ graduation.
 
 ---
 
+## D-0081 — Both secret-scanning knobs are to be ON; the REST API silently refuses, so it is a UI change
+
+**Date:** 2026-08-29 · **Issue:** #467 · **Decider:** founder (in session)
+
+**Decision: enable `secret_scanning_non_provider_patterns` and
+`secret_scanning_validity_checks`.** #467 framed this as a posture choice nobody had made
+explicitly rather than a defect, and the choice is now made.
+
+**It could not be executed from here, and the failure mode is worth recording.** A
+`PATCH /repos/{owner}/{repo}` carrying either knob returns **`200` with the repository object
+and the values unchanged** — no error, no warning, no `message` field. Verified by a fresh
+`GET` after each attempt, not by trusting the response. Both bracket-style `-f` parameters and a
+proper nested JSON body behave identically, so it is not a request-shape problem.
+
+The token carries `repo` scope and `permissions.admin: true` on the repository, so this is a
+feature-availability limit rather than an authorisation error — but GitHub reports it as
+success either way. **The change has to be made in Settings → Code security.**
+
+*This is the `--body -` lesson in a different API.* A write that returns 200 and does nothing is
+indistinguishable from a write that worked, unless you read the artifact back. Anyone scripting
+repository-settings changes should assume the same and verify with a separate `GET`.
+
+**Fleet note, measured while diagnosing:** the two keys are *present and disabled* on
+`aidoc-flow-framework` and `aidoc-flow-ci`, and **absent entirely** from the API response for
+`aidoc-flow-operations` and `aidoc-flow`. So the setting's availability is not uniform across
+the workspace, and a fleet-wide posture claim cannot be made from one repository's response.
+
+**Consequence.** `SECURITY.md` now states both knobs, what each being off actually costs, and
+why the in-repo scanners (`detect-secrets` + `detect-private-key` as required hooks, and
+`secret-scan.yml` over full history) make this a *narrowing* rather than an absence. #467 stays
+open until the UI toggle is made; it is no longer blocked on a decision, only on a click.
+
 ## D-0078 — Untagged spec versions are corrected forward in the next real release, never by rewriting a published record
 
 **Date:** 2026-08-28 · **Issue:** #558 · **Decider:** founder (in session)


### PR DESCRIPTION
## Summary

Founder decision 2026-08-29 on #467: **enable both knobs.** I could not execute it,
and the reason is worth more than the change.

## The REST API accepts the write and silently ignores it

```
$ echo '{"security_and_analysis":{"secret_scanning_validity_checks":{"status":"enabled"}}}' \
    | gh api -X PATCH repos/vladm3105/aidoc-flow-framework --input -
→ 200, full repository object, value unchanged

$ gh api repos/vladm3105/aidoc-flow-framework --jq '.security_and_analysis…'
  secret_scanning_non_provider_patterns=disabled
  secret_scanning_validity_checks=disabled
```

No error, no warning, no `message` field. **Verified by a fresh `GET` after each
attempt rather than by trusting the response.** Bracket-style `-f` params and a
nested JSON body behave identically, so it is not a request-shape problem; the
token carries `repo` scope and `permissions.admin: true`, so it is a
feature-availability limit that GitHub reports as success.

**It has to be done in Settings → Code security.** #467 is no longer blocked on a
decision, only on a click.

> This is the `--body -` lesson in a different API: a write that returns 200 and
> does nothing is indistinguishable from one that worked, unless you read the
> artifact back.

## What this PR does change

`SECURITY.md` previously qualified only non-provider patterns, in half a
sentence, and said nothing about validity checks — while presenting push
protection as *the* control that stops a change before it lands. It now states:

- both knobs and their live state, as a table;
- **what each being off actually costs** — generic and custom secret shapes are
  unmatched by push protection; a detected token is not tested for liveness, so
  triage must assume every finding is active;
- why this is a **narrowing rather than an absence**: `detect-secrets` and
  `detect-private-key` are *required* pre-commit hooks and `secret-scan.yml`
  scans **full history**, catching shapes GitHub's provider matching does not —
  though not on forks' pushes, which is stated too;
- the command to re-derive the live state rather than trusting the table.

## Fleet note, measured while diagnosing

The two keys are **present and disabled** on `aidoc-flow-framework` and
`aidoc-flow-ci`, and **absent entirely** from the API response for
`aidoc-flow-operations` and `aidoc-flow`. Availability is not uniform across the
workspace, so a fleet-wide posture claim cannot be made from one repository's
response.

Rationale and the API behaviour are recorded as `plans/DECISIONS.md` **D-0081**,
so the next review does not re-file this as an unmade decision.

Refs #467

Multi-agent self-review per OPS-0065 (self-review + API write verified by independent read-back + fleet comparison): APPROVE
