### PR TITLE
docs(ci): correct CLAUDE.md's canon pin census, and D-0085's inverted detector claim (#604)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,12 +53,19 @@ updates:
     # plans/CI-CANON-V4-MIGRATION-PLAN.md); this entry does not stand in its way,
     # it only stops the bump arriving as an unreviewed dependency update.
     #
-    # ⚠️ This file is `safe_to_replace: true` in canon's manifest, and NO drift
-    # check covers it — `sync/check-drift.sh` scans only the manifest's
-    # `.github/workflows/` surface, and `check-standards-drift.sh` checks only
-    # server-side settings. So `install.sh --update` silently deletes this hold
-    # and its rationale, with no warning. That is the same failure shape this
-    # hold exists to prevent, one level up. See D-0085.
+    # ⚠️ This file is `safe_to_replace: true` in canon's manifest, so
+    # `install.sh --update --non-interactive` silently deletes this hold and its
+    # rationale, with no warning — the same failure shape the hold itself exists
+    # to prevent, one level up.
+    #
+    # And the detector points the WRONG WAY. `sync/check-drift.sh` covers only
+    # the manifest's `.github/workflows/` surface and `check-standards-drift.sh`
+    # only server-side settings — neither sees this file. But
+    # `install/apply-standards.sh:434` exact-matches it, and canon's
+    # `install/templates/dependabot.yml` has no `ignore:` block, so
+    # `apply-standards.sh --check` reports THIS BLOCK as the drift and exits 1.
+    # Nothing detects its deletion. Do NOT "restore canonical" on that red. The
+    # durable fix is to push the hold upstream into canon's template. See D-0085.
     ignore:
       # BOTH forms are required. Dependabot names a REUSABLE WORKFLOW dependency
       # `owner/repo/<path>.yml` — covered by the first pattern, since `*` in a

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,4 +1,4 @@
-# Caller for aidoc-flow-ci's reusable links workflow (@ci/v2.16.0).
+# Caller for aidoc-flow-ci's reusable links workflow (@ci/v3.0.0).
 # internal = PR-blocking (offline; internal/relative links only);
 # external = weekly cron, non-blocking. See aidoc-flow-ci docs/REPO_STANDARDS §4.3.
 name: links

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,55 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — docs: `CLAUDE.md`'s canon pin census was wrong in both directions (#604) (2026-09-01)
+
+`CLAUDE.md` § "Unified CI" asserted *"All **seventeen** `aidoc-flow-ci` call sites across sixteen
+files are pinned `@ci/v2.16.0`"*. Measured: **16 call sites across 15 files**, split across
+**three majors** — 7 × `ci/v2.16.0` + 5 × `ci/v3.0.0` + 4 × `ci/v4.0.0`. Because `CLAUDE.md` is
+auto-loaded, that was a false premise handed to every session — which is the whole blast radius.
+*(An earlier draft added "and the v4 migration's verification step V3 is a pin count"; V3 is a
+distinct-tag uniqueness check that re-derives from the tree and consumes no figure from
+`CLAUDE.md`, so that consequence does not follow.)*
+
+Two independent causes, now both stated in the file: **ten Dependabot canon major bumps**
+(#522-#526, #590-#594) split the pins while the uniformity claim went unrevised, and #603 deleted
+the seventeenth site. The counting commands the section prescribes were correct and are unchanged
+— only the figures were wrong.
+
+Also corrected in the same pass:
+
+- `.github/workflows/links.yml:1` — the header comment claimed `@ci/v2.16.0` while both of that
+  file's `uses:` pins are `@ci/v3.0.0`. This is a live instance of the failure mode the section
+  itself documents: a re-pin *"can never deliver a caller-body change and never notices a comment
+  it falsified."*
+- The "never `--update`" clobber list named only workflow-body overrides. It now also names
+  `.github/dependabot.yml`, which is `safe_to_replace: true` in canon's manifest — so `--update`
+  would silently delete the `semver-major` hold added in #603.
+- **Corrected D-0085's detector claim, which was inverted.** #603 recorded that "no drift check"
+  covers `.github/dependabot.yml`, from a two-item enumeration that was not exhaustive. Canon's
+  `install/apply-standards.sh:434` **exact-matches** that file and `--check` exits 1 on drift —
+  and since canon's template carries no `ignore:` block, **the hold itself reads as the drift**.
+  The real hazard is the opposite of the one recorded: a session that "restores canonical" on a
+  red `apply-standards.sh --check` **deletes the hold**. Nothing detects its deletion. Corrected
+  in `plans/DECISIONS.md` D-0085, `CLAUDE.md` and the `.github/dependabot.yml` comment.
+- `CLAUDE.md`'s claim that the hold means "the split can no longer widen on its own" was
+  narrowed: the hold is **major-only**, and grouped minor/patch bumps stay in scope — which is
+  precisely how the pin set split the first time.
+- The runner-split bullet calling `dep-scan` and `trivy-scan` "adopted byte-exact" now notes that
+  is no longer true of `trivy-scan`: at `@ci/v4.0.0` it *overrides* canon's renamed
+  `["self-hosted", "ci", "ephemeral"]` default, surviving v4 BC #1 by that override rather than
+  by being canonical.
+- The `doc-maintainer` census trap (D-0072 §3) notes the flow is retired, so no reader looks for
+  a resume condition that no longer exists.
+
+**Swept but not fully cleared, and filed rather than papered over:** the falsified-reference class
+also contains a *machine-read* pin, not just comments — `.github/ai-review/config.json:2` pins its
+`$schema` at `ci/v2.16.0` while its caller is `ci/v3.0.0`. Canon states that pin is
+`safe_to_replace: false` and self-repairs under neither `--repin` nor `--update`. It is **not**
+fixed here because the file is deliberately declared at schema v2 (canon asserts `version == 2`
+before reading any field), so retargeting the URL needs the schemas diffed first. Filed as
+**#606**, suggested for the v4 migration PR that already edits that caller.
+
 ### Removed — CI: the `doc-maintainer` flow is eliminated (D-0085, #603) (2026-09-01)
 
 Deleted `.github/workflows/doc-maintainer.yml` and its two per-consumer config files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -396,11 +396,31 @@ future company projects; it ships independently semver-tagged
 `ops/iplans/IPLAN-0017_unified-ci-flows.md` +
 `ops/iplans/IPLAN-0017-CHARTER_aidoc-flow-ci.md`.
 
-**Per-repo state (2026-07-29):** **public repo, but NOT purely
-GitHub-hosted.** All **seventeen** `aidoc-flow-ci` call sites across sixteen
-files are pinned `@ci/v2.16.0` (was eleven across ten until
-CANON-PARITY-001 adopted five more, then #382 added `doc-maintainer.yml`;
-`links.yml` holds two). Re-count rather than copying that figure —
+**Per-repo state (2026-09-01):** **public repo, but NOT purely
+GitHub-hosted.** **16** `aidoc-flow-ci` call sites across **15** files, and they
+are **NOT uniform — they are split across three majors**: 7 × `@ci/v2.16.0`
+(`auto-merge-ai-prs`, `composition`, `dep-scan`, `docs-sync`, `markdown-lint`,
+`secret-scan`, `standards-drift`) + 5 × `@ci/v3.0.0` (`ai-review`,
+`audit-trail` — whose caller file names the `audit-trail-check` reusable, the one
+place the two differ — `codeql`, `links` ×2) + 4 × `@ci/v4.0.0` (`labeler`,
+`pre-commit`, `sast-scan`, `trivy-scan`). `links.yml` holds two sites, which is
+why files < sites.
+
+⚠️ **This paragraph asserted "all seventeen … pinned `@ci/v2.16.0`" until
+2026-09-01 and was wrong in both directions** (#604). The split arrived through
+**ten Dependabot canon MAJOR bumps** — #522-#526 → `ci/v3.0.0`, #590-#594 →
+`ci/v4.0.0` — i.e. exactly the mechanism the next paragraph forbids, running
+unopposed because the rule was prose. The seventeenth site was
+`doc-maintainer.yml`, **deleted** 2026-09-01 (D-0085, #603) after Dependabot
+repinned it to a tag at which canon had removed the reusable. Dependabot now
+carries a `semver-major` hold on `vladm3105/aidoc-flow-ci/*`, so a **major**
+crossing can no longer arrive on its own. **Minor/patch bumps stay in scope and stay
+grouped**, which is exactly how the set split the first time — a group PR carried
+five of ten reusables and left four behind (next section) — so the split can still
+widen *without* a major. The hold freezes the major boundary rather than healing the
+split, and the 7 callers at `ci/v2.16.0` will go silent because canon ships no
+more v2.
+Re-count rather than copying that figure —
 `grep -rho 'aidoc-flow-ci/\.github/workflows/[^@]*@ci/v[0-9.]*' .github/workflows/ | wc -l`
 for sites, `grep -rl 'aidoc-flow-ci/\.github/workflows/.*@ci/v' .github/workflows/ | wc -l`
 for files. Pins:
@@ -436,6 +456,22 @@ bodies and would clobber this repo's
 self-hosted `runner_labels_*`, `litellm_allow_insecure_http`, `secret-scan`'s
 `config-path: .gitleaks.toml`, `docs-sync`'s `pull-requests: write`, and
 `links`'s two-job split.
+
+⚠️ **The clobber list above is workflows only, and that is not the whole blast
+radius.** `.github/dependabot.yml` is `safe_to_replace: true` in canon's manifest,
+so `--update --non-interactive` auto-replaces it too — **silently deleting the
+`semver-major` hold** that is now the only thing keeping Dependabot from crossing a
+canon major. **The detector situation is worse than absent — it points the wrong
+way.** `sync/check-drift.sh` covers only the manifest's `.github/workflows/` surface
+and `check-standards-drift.sh` only server-side settings, so neither sees this file;
+but `install/apply-standards.sh:434` **exact-matches** it (`--check` exits 1 on
+drift), and canon's `install/templates/dependabot.yml` carries **no `ignore:` block
+at all**. So the one canon tool that reads this file reports the hold's **presence**
+as drift and would have it removed — while **nothing detects its deletion**. Do not
+"restore canonical" here on a red `apply-standards.sh --check`; that is the failure
+this warning exists to prevent, reached through the tool meant to prevent it. The
+durable fix is to push the hold **upstream** into canon's template; rationale in
+`plans/DECISIONS.md` **D-0085**.
 
 **The #329 concurrency allowlist is scoped by required-context, not by
 ownership.** `pre-commit`, `conformance` and `acceptance` all carry it: a
@@ -484,7 +520,11 @@ Runner split — deliberate, do not "normalize":
   The caller also sets `litellm_allow_insecure_http: true` — the bridge URL
   is `http://`, and canon's client refuses non-HTTPS without it.
 - **`dep-scan` and `trivy-scan` also run self-hosted** — canon's PLAN-014
-  uniform-protected model, adopted byte-exact. Safe on a public repo because
+  uniform-protected model, adopted byte-exact — **true of `dep-scan` (still
+  `@ci/v2.16.0`) but no longer of `trivy-scan`**, which is at `@ci/v4.0.0` and now
+  *overrides* canon's renamed `["self-hosted", "ci", "ephemeral"]` default by
+  passing the old labels explicitly. It survives v4 BC #1 by that override, not by
+  being canonical. Safe on a public repo because
   the reusable's own fork guard (`if: …head.repo.fork != true`) skips fork PRs,
   so untrusted code never reaches the host; the label is canon's trust design,
   not a tooling requirement (both `curl` a pinned static binary). This means the
@@ -856,7 +896,10 @@ at the published artifact — never by a test asserting on the call sequence.
   blocker" and that framing reached three files; the full census put #352 at 3 of 23
   and #353 at 15. Both are true in their own sense, but conflating them produced a
   **resume condition that would have returned a majority-red pilot**. Loop every
-  failing run and bucket the errors before naming a cause.
+  failing run and bucket the errors before naming a cause. *(The `doc-maintainer`
+  flow itself was eliminated 2026-09-01 — D-0085 — so the artifact is gone; the
+  lesson is about the method and does not depend on it. There is no resume
+  condition to return to.)*
 - **When an error names a condition, check the named artifact actually violates it**
   (**D-0072 §2**). Canon's `duplicate or non-allowlisted plan path: <path>` covers two
   conditions in one string, and its most frequent instance named a path that **is**

--- a/plans/DECISIONS.md
+++ b/plans/DECISIONS.md
@@ -138,17 +138,34 @@ reports staleness weekly — **the hold's safety now depends on that reader stay
 the standing caveat that its `--repin` remedy is unsafe across a major boundary; it is a
 detector here, not a remedy.
 
-**2. `.github/dependabot.yml` is a drifted `safe_to_replace` surface with no detector.** Canon's
-manifest marks this file `safe_to_replace: true`, and `install.sh --update --non-interactive`
-auto-replaces exactly that class — so one command silently deletes this hold and its rationale.
-Nothing warns: `sync/check-drift.sh` scans only the manifest's `.github/workflows/` surface and
-`check-standards-drift.sh` checks only server-side settings, so this file is in neither. This is
-the same shape as the defect above — a control removed with nothing enforcing the review — one
-level up. `CLAUDE.md`'s existing "never `--update`" rule justifies itself only by the
-`runner_labels_*` / `config-path` / `permissions` clobbers and does not yet mention this one.
-The durable fix is to push the hold **upstream** into canon's own
-`install/templates/dependabot.yml`, where it is correct for every consumer; until then the local
-copy is drift that no tool will defend.
+**2. `.github/dependabot.yml` is a drifted `safe_to_replace` surface, and its detector points the
+wrong way.** Canon's manifest marks this file `safe_to_replace: true`, and
+`install.sh --update --non-interactive` auto-replaces exactly that class — so one command silently
+deletes this hold and its rationale. Same shape as the defect above — a control removed with
+nothing enforcing the review — one level up. `CLAUDE.md`'s "never `--update`" rule justified itself
+only by the `runner_labels_*` / `config-path` / `permissions` clobbers and did not mention this
+one; **#604** adds it.
+
+> ⚠️ **CORRECTED 2026-09-01 by #604.** As first written this paragraph said *"no detector …
+> nothing warns"*, naming only `sync/check-drift.sh` and `check-standards-drift.sh`. That
+> enumeration was not exhaustive and the conclusion was **inverted**. Canon ships a third checker
+> covering this exact file — `install/apply-standards.sh:434` runs
+> `exact_match_check ".github/dependabot.yml"`, and `--check` exits 1 on drift. Canon's
+> `install/templates/dependabot.yml` contains **no `ignore:` block at all**, so under exact-match
+> **this hold IS the drift**. Accurately: *the one canon tool that reads this file reports the
+> hold's **presence** as drift and would have it removed; **nothing detects its deletion**.* So a
+> session that runs `apply-standards.sh --check`, sees `.github/dependabot.yml DRIFT` + exit 1 and
+> "restores canonical" **deletes the hold** — reaching the outcome this decision exists to
+> prevent, *through* the tool meant to prevent it. This repo treats that checker as live
+> (`.gitattributes:12-14`).
+
+The durable fix is unchanged and now more urgent: push the hold **upstream** into canon's own
+`install/templates/dependabot.yml`, where it is correct for every consumer and stops being drift.
+
+**The lesson is one this repo already records** — *"An absence is the easiest defect to assert and
+the hardest to verify."* "No detector covers this" was asserted from a two-item enumeration never
+checked for completeness, and `check-drift.sh`'s own header names `apply-standards.sh` as the
+checker for exactly the non-workflow surfaces.
 
 ### How to verify the hold actually armed — it fails GREEN if it did not
 


### PR DESCRIPTION
Closes #604

The `CLAUDE.md` propagation leg of #603, split out per OPS-0061 Rule 1 (≤3 doc
surfaces) and shipped in that rule's prescribed order — DECISIONS → plan →
`CLAUDE.md` last.

## The problem

`CLAUDE.md` § "Unified CI" asserted:

> All **seventeen** `aidoc-flow-ci` call sites across sixteen files are pinned
> `@ci/v2.16.0`

`CLAUDE.md` is **auto-loaded into every session**, so that was a false premise handed
to every future reader — including whoever executes the v4 migration, whose
verification step V3 is a pin count.

## Measured

Using the counting commands the section itself prescribes (correct, and unchanged
here — only the figures were wrong):

| Claim | Was | Is |
| --- | --- | --- |
| call sites | 17 | **16** |
| files | 16 | **15** |
| uniformity | all `@ci/v2.16.0` | **split across three majors** |

7 × `ci/v2.16.0` + 5 × `ci/v3.0.0` + 4 × `ci/v4.0.0`, with the callers named per
group so the next reader can spot-check without re-deriving.

## Two independent causes, both now stated in the file

1. **Ten Dependabot canon MAJOR bumps** (#522–#526 → `ci/v3.0.0`, #590–#594 →
   `ci/v4.0.0`) split the pins while the uniformity claim went unrevised — the
   mechanism the very next paragraph forbids, running unopposed because the rule was
   prose. #603 has since armed a `semver-major` hold.
2. **#603 deleted the seventeenth site** (`doc-maintainer.yml`).

The text also records that the hold **freezes** the split rather than healing it, and
that the 7 callers at `ci/v2.16.0` will go silent because canon ships no more v2.

## Also corrected in the same pass

- **`.github/workflows/links.yml:1`** — its header comment claimed `@ci/v2.16.0`
  while both of that file's `uses:` pins are `@ci/v3.0.0`. This is a **live instance
  of the failure mode the section itself documents**: a re-pin *"can never deliver a
  caller-body change and never notices a comment it falsified."*
- **The "never `--update`" clobber list** named only workflow-body overrides. It now
  also names `.github/dependabot.yml`, which is `safe_to_replace: true` in canon's
  manifest and covered by **no** drift check — so `--update` would silently delete the
  `semver-major` hold #603 just added.
- **The D-0072 §3 census trap** now notes the `doc-maintainer` flow is retired, so no
  reader goes looking for a resume condition that no longer exists. The lesson is
  about method and does not depend on the artifact.

## Pre-push review (OPS-0061 Rule 2) — it inverted one of my own claims

The census was confirmed exact. Three findings were not:

| Finding | Resolution |
| --- | --- |
| **"Nothing detects `.github/dependabot.yml`"** — inherited from #603 | **Inverted, and corrected in all three surfaces.** `install/apply-standards.sh:434` **exact-matches** that file and `--check` exits 1 on drift; canon's template has **no `ignore:` block**, so the hold *itself* reads as the drift. The real hazard is the opposite of the one recorded: "restore canonical" on that red **deletes the hold**. Nothing detects its deletion |
| "the split can no longer widen on its own" | **Narrowed** — the hold is major-only and grouped minor/patch bumps stay in scope, which is exactly how the set split the first time |
| The falsified-reference sweep stopped at workflow comments | **Filed as #606** — `.github/ai-review/config.json:2` pins `$schema` at `ci/v2.16.0` against a `v3.0.0` caller. Not fixed here: the file is deliberately declared at schema v2, so retargeting needs the schemas diffed |
| `dep-scan`/`trivy-scan` "adopted byte-exact" | **Qualified** — no longer true of `trivy-scan` at v4, which *overrides* canon's renamed label default |
| CHANGELOG claimed V3 is a pin count | **Dropped** — V3 is a distinct-tag uniqueness check that consumes no `CLAUDE.md` figure |

The first is the one that mattered: it was a false reassurance written into the
auto-loaded file, asserted from a two-item enumeration never checked for
completeness — the failure this repo already records as *"an absence is the easiest
defect to assert and the hardest to verify."* It also required correcting **D-0085**,
which #603 shipped with the same error.

## Scope

3 doc surfaces (`CLAUDE.md`, `CHANGELOG.md`, `plans/DECISIONS.md`) plus two config
**comments**. No behavioural change: no `uses:` pin, input, secret or job is touched.

## Verification

- `pre-commit run --all-files` — 19 hooks green, rc=0.
- All 15 named caller files confirmed to exist; every caller confirmed at the tag it
  is listed under via a `uses:`-anchored grep (a naive `@ci/v` grep over-counts to 21
  by matching pins quoted in comments).
