### PR TITLE
fix(build): re-sync the plugin framework bundle after the IPLAN status edit

### DIFF
--- a/platforms/claude-code-plugin/framework/layers/08_IPLAN/IPLAN-TEMPLATE.yaml
+++ b/platforms/claude-code-plugin/framework/layers/08_IPLAN/IPLAN-TEMPLATE.yaml
@@ -297,7 +297,7 @@ traceability:
       Verified = tests pass + lint clean. Populated by each session.
     files:
       - path: "<implementation file, per the @spec language>"
-        status: created  # created | modified
+        status: created  # created | modified | planned
         session: 1
         verified: false  # true after tests pass + lint clean
 


### PR DESCRIPTION
Unbreaks `main`. **One file, generated, no hand edits.**

## What broke

`2943bf3b` ("Update status options in IPLAN-TEMPLATE.yaml") edited
`framework/layers/08_IPLAN/IPLAN-TEMPLATE.yaml` — adding `planned` to the
`code_inventory` status comment — without re-running
`tools/sync-plugin-framework.sh`. The vendored copy under
`platforms/claude-code-plugin/framework/` therefore drifted from canonical
`framework/`.

Three contexts went red on `main`, all the same single cause:

| Context | How it surfaces |
| --- | --- |
| Framework + platform conformance | `test_bundle_is_byte_identical` |
| Framework-spec change gate | its *"Conformance suite"* step — note the diff-aware **E001–E008 checks passed** |
| call / Lint / format / security hooks | pre-commit runs the same conformance hook |

## The fix

`tools/sync-plugin-framework.sh`, and nothing else. It re-vendors the one drifted
file, reproducing the identical one-line change in the bundle:

```diff
-        status: created  # created | modified
+        status: created  # created | modified | planned
```

**Blast radius measured before committing**, in a throwaway clone checked out at
`2943bf3b` (per this repo's standing rule never to run a sync script in the working
tree): the script touches **exactly 1 file**, and conformance then reports
**457 passed, 943 subtests passed**.

## Deliberately not included

Both belong to a founder decision, not to an unbreak-`main` PR. Tracked in the
follow-up issue:

1. **Whether the edit owes a framework version bump + GD entry** per
   `GATE-SPEC-E005`. That gate never evaluated `2943bf3b` — a **direct push to
   `main` bypasses PR checks entirely**, which is why nothing caught the drift
   either. Deferred by explicit founder decision.
2. **`IPLAN-TEMPLATE.yaml:163` now contradicts `:300`.** That line documents this
   exact carrier's vocabulary as *"§8 `traceability.code_inventory.files[].status`
   (a different vocabulary — `created | modified` — with its own `verified:`)"*,
   which the edit at `:300` falsifies. Reconciling it means editing `framework/**`
   again, which would itself trip `GATE-SPEC-E005`.

## Verification

- `pre-commit run --all-files` — 19 hooks green, rc=0
- `python3 -m pytest tests/conformance -q` — 457 passed, 943 subtests passed
- The changed file is generator output; `git diff` confirms it matches canonical
  `framework/` byte-for-byte.
