### PR TITLE
docs(plans): refresh HANDOFF after #615; record that #606's fix never landed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -643,6 +643,19 @@ fresh to have settled, and never repeats one that is already here.
   one of: `Multi-agent self-review per OPS-0065 (<agents>): <verdict>` or
   `Self-review skipped per founder OK — <reason>`. It is `grep -qF`; nothing else
   matches, and the phrase belongs in the **commit message**, not the PR body.
+  **It is a phrase check, not a review gate** — the skip form is self-authorizing and
+  bot authors are exempt, so a green `call / verify` is evidence that a string is
+  present and nothing more. That cuts both ways: the skip form asserts a **founder OK
+  that the gate never verifies**, so writing it without one puts a false authorization
+  claim in permanent history. Run the review and use the other form, or get the OK.
+- **A direct push to `main` bypasses every PR check, so `GATE-SPEC` never evaluates the
+  edit.** `2943bf3b` was pushed straight to `main` and changed
+  `framework/layers/08_IPLAN/IPLAN-TEMPLATE.yaml` without re-running
+  `tools/sync-plugin-framework.sh`; the vendored plugin copy drifted and took down
+  conformance, GATE-SPEC's *conformance* step and pre-commit at once (#608 repaired it
+  with the generator, one file). The gate's diff-aware `E001`–`E008` never ran at all —
+  they are PR-triggered — so **a `framework/**` edit can reach `main` owing a version
+  bump nobody assessed.** Whether that one does is still open in #609.
 - **Stacked PRs: retarget the child before merging the parent.** Merging #357 with
   `--delete-branch` deleted #358's base, which **auto-closed #358**, and GitHub
   refuses to retarget a closed PR — it had to be rebuilt by cherry-picking onto

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -10,15 +10,16 @@ never repeated here.
 of `framework/VERSION` (`plans/DECISIONS.md` D-0082). `framework/v0.44.0` is the most recent
 **tag**; `0.46.0`, `0.47.0`, `0.48.0` and `0.49.0` are untagged — see "Release provenance" below.
 
-**Verified this session** (run, not asserted, on `fix/602-adr-alternatives-cite-not-restate`,
-which branches from `dce4a1ef` and so does **not** contain the unmerged #606 work):
-conformance **473 passed / 950 subtests** via `python3 -m pytest tests/conformance -q`, and
-**509** via `python3 -m unittest discover -s tests/conformance -t tests/conformance` (CI's
-runner) — the two count subtests differently, so cite the command with the number ·
-acceptance-deterministic **64** via `python3 -m unittest discover -s tests/acceptance/deterministic -t .`
-· unit **196** via `python3 -m unittest discover -s tests/unit -t .` · `sdd_doc_lint` **6** via
-`PYTHONPATH=tools python3 -m unittest discover -s tools/sdd_doc_lint/tests` · `pre-commit run
---all-files` green, rc=0. **0 failing.**
+**Verified this session** (run, not asserted, on `main` at **`29619057`** — i.e. after
+PR #615 merged): conformance **473 passed / 950 subtests** via
+`python3 -m pytest tests/conformance -q`, and **509** via
+`python3 -m unittest discover -s tests/conformance -t tests/conformance` (CI's runner) — the
+two count subtests differently, so cite the command with the number ·
+acceptance-deterministic **64** via
+`python3 -m unittest discover -s tests/acceptance/deterministic -t .` · unit **196** via
+`python3 -m unittest discover -s tests/unit -t .` · `sdd_doc_lint` **6** via
+`PYTHONPATH=tools python3 -m unittest discover -s tools/sdd_doc_lint/tests` ·
+`pre-commit run --all-files` 19 green, rc=0. **0 failing.**
 
 Phase 0 `lint-smoke` is a separate harness and is RED — corpus debt deferred to the wholesale
 regen; use `--skip-lint-smoke`.
@@ -28,71 +29,91 @@ regen; use `--skip-lint-smoke`.
 **Founder decision 2026-08-28 (option 3):** correct forward, rewrite no published entry.
 Executed — `framework/v0.44.0` cut at `2c69a402`.
 
-⚠️ **Carried forward, and it is the sharper half of #558:** `GATE-SPEC` has **no release
-step**. E001..E008 are all diff-local, so nothing checks that a superseded version was ever
-published, and the gate is satisfied by *any* bump rather than the right one. It has **no
-tracker home of its own** — only this paragraph and the release notes' "Known gap" block.
-File it if it should have one.
+**The sharper half of #558 is now filed as #617.** `GATE-SPEC` has no release step —
+`E001..E008` are all diff-local, so nothing checks that a superseded version was ever published,
+and the gate is satisfied by *any* bump rather than the right one. It is recorded durably in
+`plans/DECISIONS.md` D-0078 ("Standing consequence") and in the **`framework/v0.44.0` GitHub
+release body** under "Known gap this tag does not close" — that string exists in **no file in
+this repo**, so grepping for it finds nothing; read it with `gh release view framework/v0.44.0`.
+It had no *tracker* home until #617, which is why it kept being re-typed into this file.
 
 ## The backlog is GitHub issues
 
-**Open issues: 34** (measured 2026-09-01). Re-derive with
-`gh issue list --state open --limit 300 --json number --jq 'length'`.
+**Open issues: 31**, of which **14** are parked (re-measured 2026-09-01 after PR #615). The
+previous handoff said 34 open and 13 parked; both were stale on arrival, so re-derive rather
+than copy:
+`gh issue list --state open --limit 300 --json number --jq 'length'` and
+`gh issue list --state open --limit 300 --json number,labels --jq '[.[]|select(.labels[].name=="parked")|.number]'`.
 In-progress work carries **`status: in progress`** — currently only **#423**.
 
-**Thirteen carry the `parked` label** and are not pickable: #438, #467, #473, #483, #484,
-and #507, #528, #543, #544, #545, #546, #547, #548. Derive that set from the label, not from
-a title scan — two of them name the gating decision only in the body.
+**The parked set** — not pickable: 438, 467, 473, 483, 484, 507,
+528, 543, 544, 545, 546, 547, 548 and **563** (numbers unprefixed deliberately — a line
+starting `#NNN` is autofixed into an H1, see `CLAUDE.md` § "Durable traps"). Derive that set
+from the label, not from a title scan — two of them name the gating decision only in the body.
 Three are blocked externally: **#484** (gated on v1.0.0), **#473** (the umbrella owns the
 submodule pointer), **#528** (product call).
 
 ## What this session did
 
-Four merges, in order: **#605** (closes #603) → **#608** (unbreak `main`) → **#607**
-(closes #604). Two issues filed and left open: **#606**, **#609**.
+**One merge: #615 (closes #602), framework spec `0.48.0 → 0.49.0`.** One issue filed and left
+open: **#614**.
 
-**`doc-maintainer` is eliminated — `plans/DECISIONS.md` D-0085, PR #605 (#603).** The caller
-was pinned `@ci/v4.0.0`, a tag at which canon had **deleted** that reusable (v4 BC #2 /
-CI-0040). Dependabot PR #591 made that repin and it **merged green**, because the workflow had
-been `disabled_manually` since 2026-08-22 — a disabled workflow never runs, so there was
-nothing to observe. Deleted the caller and its two config files; **supersedes D-0072 point 1**,
-whose manifest-parity objection had evaporated (canon removed all three surfaces from its
-manifest at v4). Discharges `CI-CANON-V4-MIGRATION-PLAN` step 2 / BC #2 early.
+**The ADR `alternatives` block stopped mandating a per-option cost.** `estimated_cost` and
+`fit` became optional, a new optional `prior_analysis` prose field lets an author cite a survey
+that already exists (typically the project's `seed/` stakeholder documents) instead of restating
+it, and `architect.md` C2 was extended to accept a compressed rationale without opening a
+citation loophole. Two adjacent defects shipped with it: the alternatives count and
+`consequences.cost_estimate`. **Read the owners, not this summary** —
+`framework/governance/DECISIONS.md` GD-24 and the `0.48.0 → 0.49.0` entry at the top of
+`CHANGELOG.md`.
 
-**Dependabot no longer proposes canon majors.** `.github/dependabot.yml` carries a
-`version-update:semver-major` hold on `vladm3105/aidoc-flow-ci/*`, in **both** name forms (the
-path form `owner/repo/<path>.yml` and the bare `owner/repo`, since a composite action would
-escape the first). **Ten** canon majors had merged unreviewed — #522–#526 → `ci/v3.0.0`,
-and #590–#594 → `ci/v4.0.0` — which is the entire explanation for the pin split.
+**#614 owns the one question GD-24 deliberately did not settle**, and carries the trap worth
+having in front of you: the reporter asked for `source: "@seed: ARCH-NN"`, and an early GD-24
+draft declined it because "a tag is lineage". **That is false** — `governance/TAG_SYNTAX.md`
+registers `@chg: CHG-NN` as an explicitly *non-lineage* **provenance** tag for an overlay that is
+likewise not one of the 8 registry layers. An `@seed:` class would be at least the **tenth**, and
+is architecturally coherent; the decline rests on scope alone. It nearly merged as precedent
+contradicting the file it cited. Not blocking anything.
 
-**Pins are now 7 × `ci/v2.16.0` + 5 × `ci/v3.0.0` + 4 × `ci/v4.0.0` = 16 sites / 15 files**
-(#607 / #604 corrected `CLAUDE.md`, which had claimed 17 sites all at `v2.16.0`). Two facts
-that must travel together with that number: the hold is **major-only**, so grouped
-minor/patch bumps can still widen the split — that is how it split the first time; and the
-7 callers at `v2.16.0` will now go **silent**, because canon ships no more v2, making
-`pin-currency-reader` / #393 the compensating detector.
+## ⚠️ #606 is closed but its fix is NOT on `main`
 
-⚠️ **Correction worth reading before trusting D-0085's first version.** #603 shipped the claim
-that "**no** drift check covers `.github/dependabot.yml`". That was an unchecked two-item
-enumeration and the conclusion was **inverted**: `install/apply-standards.sh:434` exact-matches
-that file and `--check` exits 1, and canon's template has **no `ignore:` block** — so the hold
-*is* the drift. **A session that "restores canonical" on that red deletes the hold.** Nothing
-detects its deletion. Corrected in D-0085, `CLAUDE.md` and the file's own comment by #607.
+Measured at `29619057`: `.github/ai-review/config.json:2` still pins `$schema` at
+`ci/v2.16.0` against a `ci/v3.0.0` caller, and `tests/conformance/test_ai_review_schema_pin.py`
+does not exist.
 
-## `main` was broken mid-session by a direct push — the mechanism, not the incident
+**The work is not lost, and it is already on the remote.**
+`git ls-remote origin 'refs/heads/fix/606*'` returns `cfb7b6e4` — the branch is pushed, so the
+disposition is *reopen PR #612 or open a new one*, never *push a branch*. (An earlier version of
+this paragraph and of the first comment on #606 said "never pushed"; both are corrected. PR #612
+existing was itself proof, and the negative was asserted without running the one command that
+settles it.) Tip **`cfb7b6e4`**: `25b02cdd` (retarget the pin to the caller's tag, plus
+`tests/conformance/test_ai_review_schema_pin.py`), `3f5b4dc1`, `cfb7b6e4`. PR #612 went red only
+on the `ai-review` `ResponseShapeError` flake, which no longer gates (D-0084) — verify with
+`gh pr checks 612`.
 
-`2943bf3b` ("Update status options in IPLAN-TEMPLATE.yaml") was pushed **directly to `main`**
-and edited `framework/layers/08_IPLAN/IPLAN-TEMPLATE.yaml` without re-running
-`tools/sync-plugin-framework.sh`. The vendored plugin copy drifted and took down three
-contexts at once — conformance, GATE-SPEC (its *conformance* step; the diff-aware E001–E008
-checks **passed**), and pre-commit. #608 repaired it with the generator, one file.
+⚠️ **Do not replay the branch wholesale.** `git show --stat 25b02cdd 3f5b4dc1 cfb7b6e4` shows all
+three touch `plans/HANDOFF.md` and/or `CHANGELOG.md`, and both have since moved on `main`:
+`CHANGELOG.md` gained the `0.48.0 → 0.49.0` entry, and this file was rewritten wholesale.
+Replaying `3f5b4dc1` would **resurrect the superseded issue figures** this refresh just
+re-measured. Carry forward only what is unique to #606 — the `config.json` `$schema` edit, the
+guard test, and the `CI-CANON-V4-MIGRATION-PLAN.md` step-6/V3b additions — onto a branch off
+current `main`, and re-author the changelog entry rather than replay it. The branch is also
+behind: it sits on `dce4a1ef`, `main` is `29619057`.
 
-**The durable part:** a direct push to `main` bypasses PR checks entirely, so `GATE-SPEC` never
-evaluated that `framework/**` edit. Whether it owes a version bump is **undecided and tracked
-in #609** — founder deferred it as "unblock now, decide later". #609 also records that the edit
-left `IPLAN-TEMPLATE.yaml:163` contradicting `:300` (`:163` documents that carrier's vocabulary
-as `created | modified`), and that whether **#601** is actually satisfied depends on the same
-call: if the comment *is* the contract it is, otherwise the enforced surface still needs it.
+Closure metadata (`gh issue view 606 --json state,stateReason,closedAt,closedByPullRequestsReferences`):
+closed `COMPLETED` at `06:21:36Z`, 32 seconds after PR #612 closed unmerged at `06:21:04Z`, with
+an empty `closedByPullRequestsReferences`. Evidence and dispositions are on the issue; the reopen
+call is the founder's. Nothing is failing today — `$schema` is advisory and no workflow step
+dereferences it.
+
+## The open call in #609
+
+A direct push to `main` (`2943bf3b`) bypassed `GATE-SPEC` entirely — the mechanism is now in
+`CLAUDE.md` § "Durable traps" and is not repeated here. **#609 owns the three questions that
+travel together** and is still open: does that edit owe a version bump + GD entry, is
+`IPLAN-TEMPLATE.yaml:163` reconciled with `:300` (`:163` documents that carrier's vocabulary as
+`created | modified`; `:300` declares `created | modified | planned`), and is **#601** actually
+satisfied by a comment-only edit. Founder deferred it as "unblock now, decide later".
 
 ## CI gating — `ai-review` and `composition` no longer gate (D-0084)
 
@@ -107,46 +128,52 @@ Re-derive with
 `GATE-SPEC` and `dep-scan` are **not** required — a red one leaves a PR `UNSTABLE`, not
 `BLOCKED`.
 
-**`call / verify` is NOT a review gate.** It greps the commit body for a literal phrase; the
-skip form is self-authorizing and bot authors are exempt.
-
 **`ai-review` fails intermittently** with `litellm: proxy request failed after 3 attempts:
 ResponseShapeError` (upstream `aidoc-flow-ci#543`) — observed again this session, then passing
 on a re-run of the same branch. It is **not** the 402 this proxy is otherwise known for, and
 not size-driven. Since it no longer gates, the cost is a lost verdict, not a blocked merge.
 
-## Unsettled — watch, do not yet file
+## Unsettled — watch
 
-**Intermittent DNS failure on this host.** `curl: (6) Could not resolve host: github.com`
-failed `call / dep-scan` twice (02:29Z, 02:45Z), and a local `git fetch` hit
-`ssh: Could not resolve hostname github.com` in the same window. All three self-recovered.
-`trivy-scan` runs on the same self-hosted pool at the same timestamps and **passed**, so it is
-not a blanket pool outage. Three instances is not a root cause — a fourth warrants an issue.
+**Intermittent DNS failure on this host — the previous handoff's "do not yet file" is
+discharged.** It said a fourth instance warranted an issue; **#613 was filed and closed the
+same morning** (05:49Z → 06:21Z — `gh issue view 613 --json state,createdAt,closedAt`), so do
+not re-file. A **further** instance occurred this
+session at ~13:2xZ — `gh` returned `error connecting to api.github.com` on a `pr checks` call
+and succeeded on immediate retry, matching #613's self-recovering pattern. Not re-opened:
+one self-recovering instance after closure is not yet a trend. Re-open #613 if it becomes one.
 
 ## What to do next — prioritized
 
-1. **Tag the untagged releases.** `framework/v0.44.0` is still the most recent tag while
-   `0.46.0`, `0.47.0`, `0.48.0` and `0.49.0` have all shipped to `main`. Four untagged releases is the
-   point at which "correct forward" stops being cheap, and the missing `GATE-SPEC` release
-   step still has no tracker home — file it.
-2. **#609** — the deferred founder call from this session: does `2943bf3b` owe a framework
-   version bump + GD entry, is `IPLAN-TEMPLATE.yaml:163` reconciled, and is **#601** actually
-   satisfied by a comment-only edit? All three travel together, because reconciling `:163` is
-   itself a `framework/**` edit that trips `GATE-SPEC-E005`.
-3. **#606** — `.github/ai-review/config.json:2` pins `$schema` at `ci/v2.16.0` against a
-   `ci/v3.0.0` caller, and canon says it self-repairs under neither `--repin` nor `--update`.
-   Best folded into the v4 migration PR, which already edits that caller. Not urgent: the file
-   is not load-bearing for model resolution today.
-4. **#393 / `plans/CI-CANON-V4-MIGRATION-PLAN.md`** — still **BLOCKED** on two founder /
+1. **Decide #606's disposition** — the only item where the record and `main` disagree. The
+   issue is closed `COMPLETED`, its fix is not on `main`, and the work sits unpushed on
+   `fix/606-ai-review-schema-pin` (`cfb7b6e4`). Three dispositions are laid out in the comment
+   on #606. Cheapest correct path: re-submit the branch, since the `ai-review` flake that
+   killed PR #612 no longer gates.
+2. **Tag the untagged releases.** `framework/v0.44.0` is still the most recent tag while
+   `0.46.0`, `0.47.0`, `0.48.0` and `0.49.0` have all shipped to `main`. Four untagged releases
+   is the point at which "correct forward" stops being cheap, and the missing `GATE-SPEC`
+   release step still has no tracker home — file it.
+3. **#609** — the deferred founder call: does `2943bf3b` owe a framework version bump + GD
+   entry, is `IPLAN-TEMPLATE.yaml:163` reconciled, and is **#601** actually satisfied by a
+   comment-only edit? All three travel together, because reconciling `:163` is itself a
+   `framework/**` edit that trips `GATE-SPEC-E005`.
+4. **#614** — new, unstarted: does the seed tier get a registered `@seed:` provenance tag on
+   the `@chg:` precedent? Suggested default is **no** unless a second `real-use` report
+   arrives; the point of the issue is that the *reason* must be scope, never "a tag is
+   lineage". Not blocking anything.
+5. **#393 / `plans/CI-CANON-V4-MIGRATION-PLAN.md`** — still **BLOCKED** on two founder /
    infrastructure prerequisites (runner labels `ci`/`ephemeral` do not exist; `LLM_URL` /
    `LLM_API_KEY` do not exist and the caller still forwards three `LITELLM_*` names v4
-   un-declares). ⚠️ **Its stated `--repin` remedy is unsafe** — read the plan, not the issue
-   body. The plan's exposure table and every line citation were re-measured 2026-09-01 and it
-   now carries a `## Review log`.
-5. **#588** — the identity-carrier split. Not startable alone; it is `OKF-CONFORMANCE-001`
+   un-declares). ⚠️ **Its stated `--repin` remedy is insufficient**, not unsafe — the plan
+   (`:35-37`) says `--repin` cannot deliver two of the five required changes; *unsafe* is this
+   repo's word for `--update` (risk R2). Read the plan, not the issue body. If #606 is re-submitted, its `$schema` edit and this plan's step 6 / verification V3b
+   must stay consistent.
+6. **#588** — the identity-carrier split. Not startable alone; it is `OKF-CONFORMANCE-001`
    D1's to settle.
-6. **#546** — carries a measured correction that **splits it**. The `_required: false` half of
+7. **#546** — **parked**, and splitting it is what unparks it. The `_required: false` half of
    the `STY02` defect is independently shippable and does not wait on the parked subtype
-   decision. Re-title or split before picking it up.
-7. **#423** — the only issue marked in progress. `origin/fix/423-site-badge-selfheal` carries
+   decision; the correction that establishes this is in the issue's own comments. Re-title or
+   split before picking it up, and drop `parked` from the shippable half.
+8. **#423** — the only issue marked in progress. `origin/fix/423-site-badge-selfheal` carries
    `f05dfc0d`. Needs a rebase onto current `main`, a finalized commit message and a PR.

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -8,7 +8,10 @@ never repeated here.
 **State:** framework spec **`0.49.0`**, plugin `0.25.0`, Hermes `0.12.1`; both platform
 `FRAMEWORK_SPEC_VERSION` pins read `0.49.0`. `0.45.0` was **skipped** and never became a value
 of `framework/VERSION` (`plans/DECISIONS.md` D-0082). `framework/v0.44.0` is the most recent
-**tag**; `0.46.0`, `0.47.0`, `0.48.0` and `0.49.0` are untagged — see "Release provenance" below.
+**tag** — ⚠️ **already false**: `framework/v0.46.0`–`v0.49.0` were cut and pushed 2026-09-01
+(they are tags, not a PR artifact, so they exist regardless of #618's state). The high-water
+mark is **`framework/v0.49.0`**; re-derive with `git ls-remote --tags origin 'refs/tags/framework/*'`.
+See "Release provenance" below.
 
 **Verified this session** (run, not asserted, on `main` at **`29619057`** — i.e. after
 PR #615 merged): conformance **473 passed / 950 subtests** via
@@ -150,10 +153,10 @@ one self-recovering instance after closure is not yet a trend. Re-open #613 if i
    `fix/606-ai-review-schema-pin` (`cfb7b6e4`). Three dispositions are laid out in the comment
    on #606. Cheapest correct path: re-submit the branch, since the `ai-review` flake that
    killed PR #612 no longer gates.
-2. **Tag the untagged releases.** `framework/v0.44.0` is still the most recent tag while
-   `0.46.0`, `0.47.0`, `0.48.0` and `0.49.0` have all shipped to `main`. Four untagged releases
-   is the point at which "correct forward" stops being cheap, and the missing `GATE-SPEC`
-   release step still has no tracker home — file it.
+2. **#618** — closes #617 with the phantom-version guard and records **D-0086** (the
+   `hermes/v0.1.1` tagged phantom: a cut, immutable release tag on a commit whose VERSION reads
+   `0.1.0`). The four framework tags it describes are **already pushed**; the PR carries the
+   guard, `docs/TAGGING.md` and the decision record, not the tags.
 3. **#609** — the deferred founder call: does `2943bf3b` owe a framework version bump + GD
    entry, is `IPLAN-TEMPLATE.yaml:163` reconciled, and is **#601** actually satisfied by a
    comment-only edit? All three travel together, because reconciling `:163` is itself a


### PR DESCRIPTION
Wholesale handoff refresh per the file's own rule, after #615 merged (framework spec
`0.48.0 → 0.49.0`, GD-24, closed #602). Two files: `plans/HANDOFF.md` and `CLAUDE.md`.

## Substantive

- **⚠️ #606 is closed `COMPLETED` but its fix is not on `main`.** Measured at `29619057`:
  `.github/ai-review/config.json:2` still pins `$schema` at `ci/v2.16.0` against a
  `ci/v3.0.0` caller (`ai-review.yml:93`), and `tests/conformance/test_ai_review_schema_pin.py`
  does not exist. The issue closed 32 seconds after PR #612 was closed *without* merging, with
  an empty `closedByPullRequestsReferences`. PR #612 went red only on the `ai-review`
  `ResponseShapeError` flake, which stopped gating on 2026-08-31 (D-0084). Evidence and
  dispositions are [on the issue](https://github.com/vladm3105/aidoc-flow-framework/issues/606#issuecomment-5494688517);
  the reopen call is yours.
- **The branch is on `origin`, and replaying it wholesale is a trap.**
  `git ls-remote origin 'refs/heads/fix/606*'` → `cfb7b6e4`. All three of its commits touch
  `plans/HANDOFF.md` and/or `CHANGELOG.md`, both of which have since moved — replaying
  `3f5b4dc1` would resurrect the very issue figures this PR re-measures. The handoff now says
  to carry forward only what is unique to #606.
- **Two inherited figures were stale and are re-derived, with their commands in the file.**
  Open issues is **31** (previous handoff said 34); **14** are `parked` (it said 13 and listed
  13 — #563 was absent).
- **The carried-forward GATE-SPEC release-step gap is now #617.** It had survived at least one
  wholesale rewrite under its own instruction "file it if it should have one". Its claim of
  having "no tracker home … only this paragraph and the release notes" also omitted
  `plans/DECISIONS.md` D-0078 — and the "Known gap" block it points at lives in the
  `framework/v0.44.0` **GitHub release body**, in no repo file, so grepping for it finds
  nothing. Both corrected.
- **The DNS watch item is discharged** — it said "a fourth instance warrants an issue"; #613
  was filed *and closed* the same morning. One further self-recovering instance this session,
  recorded without re-filing.
- **Two durable facts graduated to `CLAUDE.md` § "Durable traps"**, since both were living only
  in a file designed to be deleted: that `call / verify` is a phrase check rather than a review
  gate, and that a direct push to `main` bypasses `GATE-SPEC` entirely (`2943bf3b`, still open
  in #609).
- GD-24's narrative is compressed to a pointer at its two owners (`framework/governance/DECISIONS.md`,
  `CHANGELOG.md`). The #614 trap is kept in full, because it nearly merged as precedent: "a tag
  is lineage" is **false** — `TAG_SYNTAX.md` registers `@chg:` as an explicitly non-lineage
  provenance tag.

## Review

One fresh-context review agent (read-only) audited every factual claim against source. Verdict
**CHANGES REQUESTED**: 1 P1 and 7 P2/P3, all folded. The P1 is the one worth naming — I had
written "that branch was never pushed" in both this file and the #606 comment, and
`git ls-remote` refutes it. PR #612's existence was itself proof; I asserted a negative without
running the command that settles it. [Corrected publicly](https://github.com/vladm3105/aidoc-flow-framework/issues/606#issuecomment-5494937333).

## Verification

Re-run on `main` at `29619057` (not carried forward), each number beside its command:

| Suite | Command | Result |
|---|---|---|
| Conformance | `python3 -m unittest discover -s tests/conformance -t tests/conformance` | 509 OK |
| Conformance | `python3 -m pytest tests/conformance -q` | 473 passed / 950 subtests |
| Acceptance | `python3 -m unittest discover -s tests/acceptance/deterministic -t .` | 64 OK |
| Unit | `python3 -m unittest discover -s tests/unit -t .` | 196 OK |
| Linter | `PYTHONPATH=tools python3 -m unittest discover -s tools/sdd_doc_lint/tests` | 6 OK |
| Hooks | `pre-commit run --all-files` | 19 passed, rc=0 (twice, to stability) |
| GATE-SPEC | `python3 tests/chg/spec_gate.py --base origin/main` | not a spec change, OK |

## Note on the file itself

markdownlint's autofix twice converted a line starting `#615` / `#507` into an H1 mid-draft —
the corruption documented in `CLAUDE.md` § "Durable traps". Repaired, and the parked list is
deliberately written without `#` prefixes with a one-line note saying why.

No code, spec or CI surface, so `GATE-SPEC` does not fire.
