### PR TITLE
feat(conformance): a documented release that never existed now fails the suite (#617)

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -32,6 +32,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Full history so test_release_record_integrity can read the VERSION
+          # files' history (#617). actions/checkout defaults to depth 1, which
+          # would make that guard measure nothing rather than fail. chg-gate.yml
+          # sets this for the same class of reason.
+          fetch-depth: 0
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,52 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added — a phantom release cannot ship unnoticed; four framework tags cut (#617) (2026-09-01)
+
+`plans/DECISIONS.md` **D-0078** left a standing consequence: `GATE-SPEC` has **no release
+step**: none of `E001`–`E008` looks beyond the current tree — `E005`/`E008` at the PR diff,
+`E006`/`E007` at HEAD, `E001`–`E004` at the change record — so nothing checks that a version
+the changelog documents was ever real. That is what produced #558 — `framework/VERSION` moved
+`0.41.3 → 0.43.0` in one commit while `CHANGELOG.md` documents a `0.41.3 → 0.42.0` release
+and GD-14 is ratified against it. Spec `0.42.0` was never a value of the file.
+
+**`tests/conformance/test_release_record_integrity.py` is that missing check**, over all
+three version streams: every version a changelog names as a release must have been a value
+of its `VERSION` file at some point in history. It runs in the conformance suite, which is
+a required context — not as a warning-only weekly annotation, because this repo has already
+learned that such an annotation has no reader.
+
+**The check found a second, worse instance while being written.** `hermes/v0.1.1` is a cut,
+pushed release tag on a commit whose `platforms/hermes/VERSION` reads `0.1.0` — precisely the
+option D-0078 rejected ("a tag on a commit whose `VERSION` file reads `0.41.3` — accurate to
+the changelog, false to the tree"), already in the tree and unnoticed. It is not a
+predates-the-file artifact: the file existed from 2026-05-20 holding `0.1.0`. Both it and
+framework `0.42.0` are permanent — D-0078 chose correct-forward, and release tags are
+immutable — so each is a **named, cited exception**, and a test asserts each is still a real
+phantom, so the allowlist cannot outlive its defect and quietly license the next one.
+
+**The originally-proposed fix was withdrawn on measurement.** #617 first proposed a
+tag-currency check. Measured, **77 of 89** framework versions are untagged and
+`docs/TAGGING.md` already calls the tag-cut lag "a known backlog" — so that check would have
+emitted dozens of findings against a sanctioned state. Tags are deliberately out of scope of
+the guard.
+
+**`conformance.yml` now sets `fetch-depth: 0`.** `actions/checkout` defaults to depth 1, in
+which the guard would measure nothing rather than fail. Because the suite also runs inside
+the reusable `pre-commit` workflow, whose checkout this repo does not own, the
+history-dependent tests **skip** when the clone is shallow and a separate assertion — which
+needs no history, so it runs everywhere — requires `conformance.yml` to keep the setting.
+Deleting it reddens the suite in every runner rather than silently disarming it.
+
+**Four framework tags cut**, on founder decision: `framework/v0.46.0` (`62928a28`),
+`v0.47.0` (`e9bd5055`), `v0.48.0` (`eb82b0bb`), `v0.49.0` (`29619057`) — each annotated, on
+the squash-merge commit that bumped `framework/VERSION`, each verified to carry that version with
+both platform `FRAMEWORK_SPEC_VERSION` pins matching and a green `Framework + platform
+conformance` on its PR. `docs/TAGGING.md`'s inventory preamble is corrected with it: it had
+named `framework/v0.21.0` as the high-water mark "as of 2026-08-02" when `v0.41.2`, `v0.41.3`
+and `v0.44.0` had since been cut, and it now separates the sanctioned tag backlog from the
+phantom-version defect, which are different things.
+
 ### Changed — Framework Spec `0.48.0 → 0.49.0` — the ADR `alternatives` block stops mandating a cost estimate per option, and gains a way to cite an existing survey (GD-24, #602) (2026-09-01)
 
 `ADR-TEMPLATE.yaml`'s `alternatives` block demanded a cost estimate and a fit rating on

--- a/docs/TAGGING.md
+++ b/docs/TAGGING.md
@@ -96,10 +96,34 @@ names and make `git tag -l '<prefix>/*'` an effective per-stream filter.
 > Each row is a version assigned to a shipped change. A git **tag** is cut
 > separately, and the tag-cut has lagged the version stream (a known backlog —
 > see the HANDOFF). To see which tags are *actually* cut, run `git tag -l` /
-> `git ls-remote --tags origin`; as of 2026-08-02 the cut high-water marks are
-> `v1.1.0` (project), `framework/v0.21.0`, `claude-code-plugin/v0.25.0`, and
-> `hermes/v0.1.1`. Rows above those points are version assignments whose tag has
-> not yet been cut. Do not assume a row here means the tag exists.
+> `git ls-remote --tags origin`; **re-derive rather than trusting the figures
+> below, which are a snapshot.** Normalize whitespace when you do — one commit
+> wrote `framework/VERSION` with no trailing newline, so the obvious one-liner
+> concatenates two values and reports 88 rather than 89:
+>
+> ```sh
+> git log --format=%H main -- framework/VERSION \
+>   | while read -r s; do git show "$s:framework/VERSION" | tr -d '[:space:]'; echo; done \
+>   | sort -u | grep -c .
+> ``` As of **2026-09-01** the cut high-water marks
+> are `v1.1.0` (project), **`framework/v0.49.0`**, `claude-code-plugin/v0.25.0`,
+> and `hermes/v0.1.1`. Rows above those points are version assignments whose tag
+> has not yet been cut. Do not assume a row here means the tag exists.
+>
+> Scale, so the backlog is not mistaken for a defect: **77 of the 89 values
+> `framework/VERSION` has held are untagged** (measured 2026-09-01, after
+> `v0.46.0`–`v0.49.0` were cut), and the plugin stream is exactly
+> current (`0.25.0` tagged, `VERSION` = `0.25.0`) while **Hermes has the largest
+> gap** (`hermes/v0.1.1` against `VERSION` = `0.12.1`). Lagging is the norm here,
+> not an error state.
+>
+> **A missing tag is not the same defect as a phantom version.** A version
+> documented as released that `VERSION` never actually held cannot be tagged at
+> all without putting a tag on a commit that contradicts it — see
+> `plans/DECISIONS.md` D-0078 (#558) and the guard
+> `tests/conformance/test_release_record_integrity.py` (#617), which fails on any
+> new one. Two already exist and are permanent: framework `0.42.0`, and
+> `hermes/v0.1.1`, whose tag sits on a commit whose `VERSION` reads `0.1.0`.
 
 | Version / tag | Commit | Marks |
 |-----|--------|-------|
@@ -174,12 +198,12 @@ names and make `git tag -l '<prefix>/*'` an effective per-stream filter.
 | `framework/v0.3.1` | CHG-D2 (`3753de2`) | Framework spec — governance decision register, GD-01 |
 | `v1.1.0` | PR #2 merge (`3974daa`) | Post-cutover feature release — skill-set revision + adaptation overlay + CHG GATE-SPEC |
 
-> All Phase 0–5 milestone tags (`v0.1.0`–`v0.5.0`, `v1.0.0`, `v1.1.0`,
-> `framework/v0.1.0`–`v0.3.1`, `framework/v0.21.0`, `hermes/v0.1.0`–`v0.1.1`,
-> `claude-code-plugin/v0.1.0`–`v0.20.1`) are **published on the remote**. The
-> per-package version streams have since moved ahead of the cut tags (the
-> tag-cut backlog noted at the top of this section). Verify any tag's
-> publication via `git ls-remote --tags origin`.
+> **Every tag named in this document is published on the remote, and the
+> authoritative list is `git ls-remote --tags origin` — not this file.** A
+> hand-maintained enumeration here previously listed the Phase 0–5 milestones and
+> went stale by seven tags, contradicting the high-water marks at the top of this
+> same section; two disagreeing censuses in one file is worse than none. The
+> per-package version streams run ahead of the cut tags (the backlog noted above).
 
 ## In-container push restrictions
 

--- a/plans/DECISIONS.md
+++ b/plans/DECISIONS.md
@@ -10,6 +10,41 @@ graduation.
 
 ---
 
+## D-0086 — The `hermes/v0.1.1` phantom is accepted as permanent, on D-0078's reasoning, because a release tag cannot be moved
+
+**Date:** 2026-09-01 · **Issue:** #617 · **Decider:** in-session, applying D-0078's precedent
+
+**The state.** Building #617's phantom-version guard surfaced a second instance of the defect
+D-0078 records, in a stream neither D-0078 nor #617 had looked at. `hermes/v0.1.1` is a cut,
+pushed, **annotated release tag** on commit `0ca860b3`, whose `platforms/hermes/VERSION` reads
+**`0.1.0`**. `0.1.1` is not one of the 19 distinct values that file has ever held.
+
+**It is not a predates-the-file artifact**, which was the first thing checked: the file was
+created 2026-05-20 by `884c84ec` holding `0.1.0`, a day before the tag. The provenance is
+visible in `plans/MIGRATION_TODO.md:360`, which scripts `git tag -a hermes/v0.1.1` with no
+accompanying VERSION bump.
+
+**Decision — accept it as permanent and name it, on D-0078's reasoning.** D-0078 rejected
+retroactive tagging because it "would put a tag on a commit whose `VERSION` file reads `0.41.3`
+— accurate to the changelog, false to the tree." That is precisely the state `hermes/v0.1.1`
+is already in. It is **strictly worse than framework `0.42.0`**: that one is only a changelog
+entry, whereas this is a published tag, and `docs/TAGGING.md` §1 makes release tags immutable
+("Never move or force-push one; to correct a mistake, cut a new version"). There is nothing to
+correct forward *to* — the Hermes stream has since reached `0.12.1` — so the honest action is
+to record it rather than to leave a test-file string literal as its only justification.
+
+**Consequences.** `tests/conformance/test_release_record_integrity.py` carries it as one of two
+named `ACCEPTED_PHANTOMS`, each with its reason, and a companion test asserts each is *still* a
+real phantom so the allowlist cannot outlive its defect and quietly license a third. A **new**
+phantom is still cheap to fix at the PR that introduces it, and the guard fails on one; that
+asymmetry — permanent-and-named versus fixable-and-blocked — is the point of the allowlist, not
+an exemption anyone may extend.
+
+**Authority:** `docs/TAGGING.md` §1 (immutability), **D-0078** (#558, correct-forward),
+`tests/conformance/test_release_record_integrity.py`, `plans/MIGRATION_TODO.md:360`.
+
+---
+
 ## D-0085 — `doc-maintainer` is eliminated, not paused; and canon majors stop arriving via Dependabot
 
 **Date:** 2026-09-01 · **Issues:** #603 (this repo), #393 · **Decider:** founder (in session)

--- a/tests/conformance/test_release_record_integrity.py
+++ b/tests/conformance/test_release_record_integrity.py
@@ -1,0 +1,330 @@
+"""Conformance: every version a CHANGELOG documents as released must actually
+have been a value of its stream's ``VERSION`` file (#617, D-0078).
+
+**The defect this catches is a phantom version, not a missing tag.** D-0078:
+
+    ``framework/VERSION`` moved ``0.41.3 → 0.43.0`` in one commit. Spec ``0.42.0``
+    was **never a value of the file**, yet ``CHANGELOG.md`` documents a
+    ``0.41.3 → 0.42.0`` release and GD-14 is ratified against it.
+
+That is a documented release that never existed in the tree, and D-0078 records
+the standing consequence that ``GATE-SPEC`` cannot see it: ``E001``–``E008`` are
+all diff-local, so nothing checks that a superseded version was ever published.
+This module is that check.
+
+**Why it is not a tag-currency check.** An earlier framing of #617 proposed
+comparing shipped versions against cut tags. Measured, 77 of 89 framework
+versions are untagged, and ``docs/TAGGING.md`` declares the tag-cut lag *"a known
+backlog"* — so such a check would emit dozens of findings against a sanctioned
+state. Tags are deliberately out of scope here.
+
+**Two accepted phantoms exist and are named below.** Both are permanent by
+decision: D-0078 chose to correct forward rather than rewrite a published record,
+and release tags are immutable once pushed. The guard therefore documents them
+and fails on any *new* one.
+
+**Three authoring details are load-bearing, each because review caught the
+opposite choice failing:**
+
+* Release versions are read from **heading lines only**. An unanchored scan of
+  the file body turns a narrative sentence ("Planned next: Framework Spec
+  ``0.49.0 → 0.50.0``") into a phantom and reddens a required context on correct
+  work — and ``CHANGELOG.md`` is written in exactly that long-prose style.
+* The framework changelog has used **three** heading forms over its life
+  (backticked transition, unbackticked transition, and ``## [0.21.2] — Framework
+  Spec — …``). A pattern matching only the current one measured 22 of 48 and left
+  the older forms as a green corridor for a new phantom, while the
+  "did the pattern match anything?" canary stayed satisfied by the 22.
+* The history walk passes ``--full-history``. Default ``git log`` simplification
+  prunes a TREESAME side at each merge — 42 of 131 commits here — so a value that
+  existed only on the pruned side reads as a phantom. That losing shape has
+  already occurred: D-0082 records three PRs each claiming ``0.45.0``.
+"""
+
+from __future__ import annotations
+
+import functools
+import re
+import subprocess
+import unittest
+
+import yaml
+from _spec import REPO_ROOT, platform_dirs
+
+_SEMVER = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+")
+_HEADING = re.compile(r"^\#{2,3} .*$", re.MULTILINE)
+
+
+def _framework_releases(text: str) -> set[str]:
+    """Every version named on a ``Framework Spec`` heading, both sides of a transition.
+
+    Taking *every* SemVer in the segment rather than one capture group covers all
+    three historical heading forms at once, and closes the case where a version
+    appears only as the ``from`` side of a transition it never reached.
+
+    **Scoped to the ``Framework Spec`` segment, because 14 of the 55 headings are
+    combined** — ``… Framework Spec 0.15.0 → 0.15.1 + Plugin 0.10.2 → 0.11.0``.
+    Reading the whole line attributes the *plugin's* versions to the framework
+    stream; that produced a false phantom (``0.10.2``) on correct history, and the
+    other 13 were hidden only by the coincidence that those plugin versions
+    happen to also be real framework values. Streams are separated by ``+``.
+    """
+    releases: set[str] = set()
+    for line in _HEADING.findall(text):
+        for segment in line.split("+"):
+            if "Framework Spec" in segment:
+                releases.update(_SEMVER.findall(segment))
+    return releases
+
+
+def _leading_version_releases(text: str) -> set[str]:
+    """Platform changelogs: the version that opens the heading (``## [0.25.0] - …``)."""
+    return set(re.findall(r"^\#\# \[?([0-9]+\.[0-9]+\.[0-9]+)", text, re.MULTILINE))
+
+
+#: (stream, VERSION path, CHANGELOG path, extractor).
+STREAMS = (
+    ("framework", "framework/VERSION", "CHANGELOG.md", _framework_releases),
+    (
+        "claude-code-plugin",
+        "platforms/claude-code-plugin/VERSION",  # pragma: allowlist secret
+        "platforms/claude-code-plugin/CHANGELOG.md",
+        _leading_version_releases,
+    ),
+    (
+        "hermes",
+        "platforms/hermes/VERSION",
+        "platforms/hermes/CHANGELOG.md",
+        _leading_version_releases,
+    ),
+)
+
+#: Phantoms that already shipped and are permanent by decision. Each entry needs
+#: the reason, because an unexplained allowlist entry is indistinguishable from a
+#: silenced defect — and this is the file a future session will read to decide
+#: whether a new phantom may join them. The answer is no: both of these are
+#: immutable, whereas a new phantom is still fixable at the PR that introduces it.
+ACCEPTED_PHANTOMS = {
+    (
+        "framework",
+        "0.42.0",
+    ): "D-0078 (#558) — spec 0.42.0 is documented and GD-14 is ratified against it, "
+    "but VERSION jumped 0.41.3 → 0.43.0. The founder chose to correct forward in the "
+    "next real release rather than rewrite a published CHANGELOG entry.",
+    (
+        "hermes",
+        "0.1.1",
+    ): "D-0086 (#617) — hermes/v0.1.1 was cut as a release tag on a commit whose "
+    "platforms/hermes/VERSION reads 0.1.0 (not a predates-the-file artifact: the file "
+    "existed a day earlier holding 0.1.0). Worse than the framework case, because "
+    "docs/TAGGING.md makes release tags immutable so it cannot be corrected in place.",
+}
+
+
+def _git(*args: str) -> str:
+    proc = subprocess.run(
+        ["git", *args], cwd=REPO_ROOT, capture_output=True, text=True, check=False
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} failed: {proc.stderr.strip()}")
+    return proc.stdout
+
+
+def _cannot_measure() -> str | None:
+    """Why history is unreadable here, or ``None`` when it is readable.
+
+    Covers both degraded contexts the same way: a shallow CI checkout, and a
+    source export with no ``.git`` at all (the suite is documented as the runnable
+    contract a platform consumer executes, so that is a real context). Neither may
+    raise — an ERROR here would be indistinguishable from a real defect.
+    """
+    try:
+        if _git("rev-parse", "--is-inside-work-tree").strip() != "true":
+            return "not a git work tree"
+        if _git("rev-parse", "--is-shallow-repository").strip() == "true":
+            return "shallow clone"
+    except (RuntimeError, OSError) as exc:
+        return f"git unavailable ({exc})"
+    return None
+
+
+@functools.cache
+def _version_values(path: str) -> frozenset[str]:
+    """Every distinct value ``path`` has held across HEAD's full history.
+
+    ``HEAD``, never a branch name: on a PR the checkout is a detached merge ref
+    and ``main`` may not exist locally. ``--full-history`` for the reason in the
+    module docstring.
+    """
+    values: set[str] = set()
+    for sha in _git("log", "--full-history", "--format=%H", "HEAD", "--", path).split():
+        blob = subprocess.run(
+            ["git", "show", f"{sha}:{path}"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if blob.returncode == 0 and blob.stdout.strip():
+            values.add(blob.stdout.strip())
+    return frozenset(values)
+
+
+def _declared(stream_spec) -> set[str]:
+    _, _, changelog_path, extractor = stream_spec
+    return extractor((REPO_ROOT / changelog_path).read_text("utf-8"))
+
+
+class DeepCheckoutIsConfigured(unittest.TestCase):
+    """At least one runner of this suite must have full history.
+
+    The suite runs in **three** CI places with different, and partly unownable,
+    checkout depths: ``conformance.yml`` and ``chg-gate.yml`` (both ours, both
+    deep — but ``chg-gate`` is ``pull_request``-only, so it covers no ``push``
+    run), and the reusable ``pre-commit`` workflow, whose checkout belongs to the
+    canon repo and sets no depth at all. ``actions/checkout`` defaults to
+    ``fetch-depth: 1``, so the phantom check cannot measure anything in a shallow
+    clone.
+
+    Failing on shallow would redden a **required** context we do not configure.
+    Skipping silently would be the false all-clear this repo has been bitten by.
+    So the history-dependent tests skip when history is unreadable, and this
+    assertion — which needs no history, and therefore runs everywhere — guarantees
+    the blocking runner is configured deep.
+    """
+
+    WORKFLOW = REPO_ROOT / ".github" / "workflows" / "conformance.yml"
+    JOB = "conformance"
+
+    def test_conformance_job_fetches_full_history(self):
+        workflow = yaml.safe_load(self.WORKFLOW.read_text("utf-8"))
+        self.assertIn(
+            self.JOB,
+            workflow["jobs"],
+            f"conformance.yml declares no {self.JOB!r} job — this guard no longer knows "
+            "which job runs the suite",
+        )
+        # Scoped to the job that runs the suite: an unrelated job in the same file
+        # may legitimately use a shallow checkout.
+        steps = [
+            step
+            for step in (workflow["jobs"][self.JOB].get("steps") or [])
+            if str(step.get("uses", "")).startswith("actions/checkout")
+        ]
+        self.assertTrue(steps, f"the {self.JOB!r} job has no actions/checkout step")
+        for step in steps:
+            self.assertEqual(
+                # `or {}` not a default: an emptied `with:` block parses as None,
+                # which would raise AttributeError and report as an ERROR — losing the
+                # actionable message at exactly the moment it is needed.
+                str((step.get("with") or {}).get("fetch-depth")),
+                "0",
+                f"the {self.JOB!r} job's checkout does not set `fetch-depth: 0`, so the "
+                "suite's only deep runner on `push` became shallow and "
+                "test_no_undocumented_phantom_release now measures nothing "
+                "(see .github/workflows/chg-gate.yml for the same setting)",
+            )
+
+
+class StreamCoverage(unittest.TestCase):
+    """A stream removed from ``STREAMS`` is a silent narrowing, not a failure."""
+
+    def test_every_platform_is_covered(self):
+        covered = {s[0] for s in STREAMS} - {"framework"}
+        on_disk = {p.name for p in platform_dirs()}
+        self.assertEqual(
+            covered,
+            on_disk,
+            f"STREAMS covers {sorted(covered)} but platforms/ holds {sorted(on_disk)} — an "
+            "uncovered stream can ship a phantom release with the suite green",
+        )
+
+    def test_framework_headings_all_yield_a_version(self):
+        """The canary with teeth.
+
+        ``assertTrue(declared)`` cannot catch a *new* heading form: the 22 entries
+        in the current form keep it satisfied forever. This asserts instead that
+        every heading claiming to be a Framework Spec release parses — so a fourth
+        form fails the moment it is introduced, rather than opening a green
+        corridor for a phantom written in it.
+        """
+        text = (REPO_ROOT / "CHANGELOG.md").read_text("utf-8")
+        for line in _HEADING.findall(text):
+            if "Framework Spec" in line:
+                with self.subTest(heading=line[:70]):
+                    self.assertTrue(
+                        _SEMVER.findall(line),
+                        "a 'Framework Spec' heading names no version, so this heading form "
+                        "is invisible to the phantom check",
+                    )
+
+
+class GitHistoryAvailable(unittest.TestCase):
+    def setUp(self):
+        reason = _cannot_measure()
+        if reason:
+            self.skipTest(f"{reason} — guaranteed elsewhere by DeepCheckoutIsConfigured")
+
+    def test_version_history_covers_every_documented_release(self):
+        """The precondition the phantom check needs, stated as the bar.
+
+        A `> 1` bar passed on a two-commit clone and then let the phantom check
+        emit a wall of false findings telling the author to fix correct work.
+        """
+        for spec in STREAMS:
+            stream, version_path = spec[0], spec[1]
+            with self.subTest(stream=stream):
+                self.assertGreaterEqual(
+                    len(_version_values(version_path)),
+                    len(_declared(spec)) - len(ACCEPTED_PHANTOMS),
+                    f"{version_path} holds fewer historical values than {spec[2]} documents "
+                    "releases — history is truncated, and the phantom check below would "
+                    "report correct work as defective",
+                )
+
+
+class ReleaseRecordIntegrity(unittest.TestCase):
+    def setUp(self):
+        reason = _cannot_measure()
+        if reason:
+            self.skipTest(f"{reason} — guaranteed elsewhere by DeepCheckoutIsConfigured")
+
+    def test_no_undocumented_phantom_release(self):
+        """Every documented release existed; anything else is named and cited."""
+        for spec in STREAMS:
+            stream, version_path, changelog_path = spec[0], spec[1], spec[2]
+            with self.subTest(stream=stream):
+                declared = _declared(spec)
+                self.assertTrue(
+                    declared,
+                    f"{changelog_path} yielded no release versions — the heading form changed "
+                    "and this guard silently stopped measuring the stream",
+                )
+                phantoms = declared - _version_values(version_path)
+                unexplained = sorted(p for p in phantoms if (stream, p) not in ACCEPTED_PHANTOMS)
+                self.assertEqual(
+                    unexplained,
+                    [],
+                    f"{changelog_path} documents {unexplained} as released, but "
+                    f"{version_path} never held those values. A release that exists only in "
+                    "the changelog is the D-0078 phantom (#558): the version cannot be tagged "
+                    "without putting a tag on a commit that contradicts it. Fix the version "
+                    "bump or the entry in THIS PR — it is cheap now and permanent later.",
+                )
+
+    def test_accepted_phantoms_are_still_real(self):
+        """An allowlist outliving its defect quietly licenses the next one."""
+        for (stream, version), reason in ACCEPTED_PHANTOMS.items():
+            with self.subTest(stream=stream, version=version):
+                spec = next(s for s in STREAMS if s[0] == stream)
+                self.assertIn(
+                    version,
+                    _declared(spec) - _version_values(spec[1]),
+                    f"{stream} {version} is allowlisted as an accepted phantom but is no longer "
+                    "one — drop the entry rather than leaving it to excuse a future phantom",
+                )
+                self.assertGreater(len(reason), 80, "an allowlist entry needs its reason")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## What and why

`plans/DECISIONS.md` **D-0078** left a standing consequence: `GATE-SPEC` has **no release
step**. None of `E001`–`E008` looks beyond the current tree — `E005`/`E008` at the PR diff,
`E006`/`E007` at HEAD, `E001`–`E004` at the change record — so nothing catches a **phantom
version**. That is what #558 was: `framework/VERSION` moved `0.41.3 → 0.43.0` in one commit
while `CHANGELOG.md` documents a `0.41.3 → 0.42.0` release, with GD-14 ratified against it.

`tests/conformance/test_release_record_integrity.py` is that missing check, over all three
version streams: **every version a changelog names as a release must have been a value of its
`VERSION` file.** It lives in the required conformance suite, not in a warning-only weekly
annotation — this repo has already learned such an annotation has no reader.

## The issue's own proposed fix was withdrawn on measurement

#617 originally proposed a tag-currency check. Measured, **77 of 89** framework versions are
untagged and `docs/TAGGING.md` already declares the tag-cut lag *"a known backlog"* — so it
would have emitted dozens of findings against a sanctioned state. Withdrawn publicly on the
issue before any code was written. Tags are deliberately out of scope of the guard.

## Building it found a second, worse instance

`hermes/v0.1.1` is a cut, pushed, **annotated** release tag on commit `0ca860b3`, whose
`platforms/hermes/VERSION` reads `0.1.0` — precisely the option D-0078 *rejected* ("a tag on a
commit whose `VERSION` file reads `0.41.3` — accurate to the changelog, false to the tree").
Not a predates-the-file artifact: the file was created a day earlier holding `0.1.0`, and
`plans/MIGRATION_TODO.md:360` scripts the tag with no VERSION bump. Recorded as **D-0086**.

Both phantoms are **named, cited exceptions**, and a companion test asserts each is *still* a
real phantom so the allowlist cannot outlive its defect and license a third.

## The CI wiring is the risky part

`actions/checkout` defaults to depth 1, in which a history-based guard measures nothing rather
than failing. `conformance.yml` now sets `fetch-depth: 0` (precedent: `chg-gate.yml`). But the
suite also runs inside the reusable `pre-commit` workflow, whose checkout this repo does not
own and which feeds the **required** `call / Lint / format / security hooks` context — so:

- history-dependent tests **skip** when history is unreadable (shallow clone, or no `.git` at
  all — the suite is documented as a runnable contract for consumers);
- a **history-free** assertion, which therefore runs everywhere, requires the `conformance`
  job to keep `fetch-depth: 0`.

Delete the setting and the suite reddens in *every* runner rather than silently disarming.
Verified against a real `git clone --depth 1`: 3 skips, the static assertion still runs, and
with the setting also removed it fails correctly in the shallow clone.

## Four framework tags cut (founder decision)

`framework/v0.46.0` (`62928a28`), `v0.47.0` (`e9bd5055`), `v0.48.0` (`eb82b0bb`), `v0.49.0`
(`29619057`) — annotated, each on the squash-merge commit that bumped `framework/VERSION`,
each verified for VERSION + both `FRAMEWORK_SPEC_VERSION` pins + a green conformance run at
the tagged SHA *before* the tag was created. `docs/TAGGING.md`'s inventory is corrected with
it: the high-water mark was stale (`framework/v0.21.0` "as of 2026-08-02"), and a second,
hand-maintained tag census 90 lines below contradicted it by seven tags — that list is now a
`git ls-remote --tags origin` pointer. The re-derivation one-liner is also fixed: one commit
wrote `framework/VERSION` with no trailing newline, so the obvious command reports 88, not 89.

## Review

Two fresh-context agents (both with shell access, so the mutation work was actually executed).
Verdict **CHANGES REQUESTED** — 3 P1 + 8 P2/P3, all folded. The P1s, all confirmed by me
against source before folding:

1. **The framework pattern was locked to one of three heading forms this changelog has used**
   (22 backticked; 23 unbackticked; 3 `## [0.21.2] — Framework Spec —`). A phantom in either
   older form shipped green — and the `assertTrue(declared)` canary meant to catch that was
   *vacuous*, since the 22 current-form entries satisfy it forever. Now all forms parse (55
   versions, up from 22), and the canary has teeth: **every** heading claiming a Framework Spec
   release must yield a version.
2. **The pattern was unanchored**, so a narrative sentence (`Planned next: Framework Spec
   \`0.49.0 → 0.50.0\``) manufactured a phantom and would have reddened a required context on
   correct work. Now heading-anchored, matching the two platform patterns.
3. **`git log` default history simplification** prunes a TREESAME side at each merge — 42 of
   131 commits here — so a value living only on a pruned side reads as a phantom. That shape
   has already occurred: D-0082 records three PRs each claiming `0.45.0`. Now `--full-history`.

Fixing (1) introduced a false positive of my own: 14 of 55 headings are *combined*
(`Framework Spec 0.15.0 → 0.15.1 + Plugin 0.10.2 → 0.11.0`), and reading the whole line
attributed the plugin's versions to framework. It surfaced as a live failure on `0.10.2`; the
other 13 were hidden only by the coincidence that those plugin versions are also real framework
values. Extraction is now scoped to the `Framework Spec` segment.

**16 mutations killed**, including all seven that survived the first round: phantoms in each of
the three heading forms, a from-side-only phantom, the D-0082 `0.45.0` case, a new heading form
yielding no version, deleting a whole stream *plus* its allowlist entry, each allowlist
mutation, and removing `fetch-depth`. Two false-positive controls stay green: prose mentions and
combined headings. One earlier "kill" turned out to be a syntax error rather than a detection,
and was redone validly.

## Verification

| Suite | Command | Result |
|---|---|---|
| Conformance | `python3 -m unittest discover -s tests/conformance -t tests/conformance` | 515 OK (was 509) |
| Acceptance | `python3 -m unittest discover -s tests/acceptance/deterministic -t .` | 64 OK |
| Unit | `python3 -m unittest discover -s tests/unit -t .` | 196 OK |
| Linter | `PYTHONPATH=tools python3 -m unittest discover -s tools/sdd_doc_lint/tests` | 6 OK |
| Hooks | `pre-commit run --all-files` | 19 passed, rc=0 (twice, to stability) |
| GATE-SPEC | `python3 tests/chg/spec_gate.py --base origin/main` | not a spec change, OK |

No `framework/**` edit, so no spec version bump is owed.

## Note on `plans/HANDOFF.md`

It still says `framework/v0.44.0` is the most recent tag and lists "tag the untagged releases"
as next-action 1 — both discharged by this PR. That file is owned by the still-open **#616**,
so I corrected it there rather than create a conflict between two open PRs.

Closes #617
