### PR TITLE
fix(scripts): the web-site badge sync self-heals, and announces its cross-repo write (#423)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,79 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed — the public site badge could not heal itself, and a second page was never synced at all (#423) (2026-09-02)
+
+`scripts/sync-version-refs.sh` writes a `Pre-release v<X.Y.Z>` badge into
+`../web-site/`, an **independent sibling repository**. It matched the exact string
+`Pre-release v<plugin_prev>`, from inside the previous-version detection guard — so once one
+bump was missed, every later run grepped for a version the site no longer carried, and
+`replace_in_file` returns success on a miss **with no log line**. A skipped write was
+indistinguishable from a clean one, and the drift could only widen.
+
+**Measured 2026-09-01, and worse than #423 reported.** Against plugin `0.25.0`:
+`src/pages/index.astro` sat at **`v0.20.1`** (five minors), and
+`src/pages/claude-plugin/index.astro` sat at **`v0.18.0`** (seven minors) — that second page
+was **never in the sweep at all**, which #423 did not know. The mechanism had itself been added
+to close the *same* stale-badge bug at `v0.18.0`; it recurred in the same place with nothing
+failing.
+
+**The badge is now matched version-agnostically and rewritten to the current plugin version,
+outside the prev guard** — so drift heals on the next run instead of sealing itself, and both
+pages are swept. Three behaviours are deliberate: an **absent** sibling stays silent (normal for
+a standalone clone and for CI); a sibling that is **present but carries no badge** now *warns*,
+which is the one state the old code hid; and an **already-current** badge is not rewritten,
+because this block runs on every invocation and an unconditional `sed` would dirty a sibling
+repository's working tree on every commit touching any `VERSION` file.
+
+**The prescribed test method was structurally blind to this**, which is why it survived.
+`CLAUDE.md` requires a sync-script reproduction to run in a throwaway clone — and a clone has no
+sibling `../web-site/`, so the only write that leaves the repo cannot be observed. The new
+`tests/unit/test_sync_website_badge.py` supplies a **synthetic** sibling in a temp directory
+instead, and is **registered** in `tests/conformance/test_repo_scripts.py` so it runs wherever
+conformance runs — `tests/unit/` is reached by no hook and no workflow on its own. **Twelve**
+tests; reverting the script to the exact-string form fails **eight** of them, and twelve distinct
+mutations are killed in total. *(Two earlier drafts of this line said "five of six" and "four of
+nine" — the first counted failure `subTest` items rather than methods, the second was simply not
+re-derived after three tests were added. Re-run before citing it.)*
+
+**Three hardening items came out of review, and one was a live corruption risk.** The badge
+pattern now includes any pre-release/build suffix: matching the bare `X.Y.Z` prefix rewrote only
+that prefix and welded the old suffix onto the new version — `Pre-release v0.26.0-rc1` becoming
+`Pre-release v0.25.0-rc1` on a public page, and *stably*, because the next run then sees a
+current-looking badge. A **symlinked** badge file is now refused rather than rewritten (`sed -i`
+unlinks and renames, so it would swap the link for a regular file and leave the real target
+stale — a silent half-fix of exactly the kind this change removes). And a `grep` **error** exit
+is now distinguished from "no match", so an unreadable file reports `cannot read` instead of the
+misleading `carries no badge`. The cross-repo write is additionally gated on `git rev-parse`
+succeeding, because `repo_root` otherwise falls back to `pwd` and these paths are relative to it.
+
+**And the fix had reproduced the very silence it removes.** The heal was announced with `log`,
+which only prints under the script's `--verbose` switch — but `.pre-commit-config.yaml`'s
+`entry:` is a bare `bash scripts/sync-version-refs.sh`, and its `verbose: true` is *pre-commit's*
+display flag, not the script's. Measured: the production invocation rewrote a file in another git
+repository with **zero output and rc = 0**. Every test passed, because the tests passed
+`--verbose` and so could not see it. The line is now a `warn` (which always prints), and a test
+asserts the announcement **without** the flag. That is the same trap `.pre-commit-config.yaml`
+already records for #405's WARN block, hit again one hook down.
+
+**The test itself was not hermetic, and proving it cost a repo repair.** During a real
+`git commit`, git exports `GIT_DIR` and `GIT_INDEX_FILE` to the hook, and a subprocess that
+inherits them ignores its own `cwd`. So the sandbox's `git init` re-initialized *this
+submodule's* real module directory — setting `core.bare = true` and breaking the worktree
+(`fatal: unable to set up work tree using invalid config`) — and the script's
+`git rev-parse --show-toplevel` then returned the real root, resolving `../web-site` to the
+developer's **actual** sibling checkout. Measured directly: in a temp repo with `GIT_DIR`
+inherited, `rev-parse --show-toplevel` returns `/opt/data/aidoc-flow/framework`. No damage
+resulted only because the real badges were already current. The config is repaired, every
+subprocess now runs with a `GIT_*`-scrubbed environment, and a test sets `GIT_DIR`
+deliberately and asserts the sandbox still heals — removing the scrub fails it.
+**`pre-commit run --all-files` exports only `GIT_EDITOR`**, so this class of bug is invisible
+there and appears only at real commit time.
+
+**Not fixed here, and it cannot be:** the badge values are authored in `web-site`, which this
+repo cannot commit to. The script now heals them into that repo's working tree on the next run
+with the sibling present; the commit belongs to a `web-site` PR.
+
 ### Added — a phantom release cannot ship unnoticed; four framework tags cut (#617) (2026-09-01)
 
 `plans/DECISIONS.md` **D-0078** left a standing consequence: `GATE-SPEC` has **no release

--- a/scripts/sync-version-refs.sh
+++ b/scripts/sync-version-refs.sh
@@ -28,13 +28,18 @@
 #       (added 2026-06-14 to close the v0.6.3 → v0.20.0 drift bug — the
 #       prior awk pass only handled bare X.Y.Z lines in the `$ cat VERSION`
 #       example block, missing the table cell)
-#   - ../web-site/src/pages/index.astro
-#       `Pre-release v<X.Y.Z>` badge in the home page (cross-submodule write
-#       at the umbrella layer; added 2026-06-14 per IPLAN-0008 step 6 to
-#       close the v0.18.0 stale-badge drift bug). The sibling web-site/ is
-#       a separate git repo, so writes here land as unstaged changes in
-#       web-site's working tree — the developer commits them in web-site's
-#       own PR. Skipped silently if web-site/ is not present alongside.
+#   - ../web-site/src/pages/index.astro and
+#     ../web-site/src/pages/claude-plugin/index.astro
+#       `Pre-release v<X.Y.Z>` badges (cross-submodule write at the umbrella
+#       layer; added 2026-06-14 per IPLAN-0008 step 6 to close the v0.18.0
+#       stale-badge drift bug — which then recurred, in the same place, with
+#       nothing failing). Per #423 the badge is now matched version-agnostically
+#       and rewritten to the CURRENT plugin version, so one missed bump cannot
+#       desynchronize it. The sibling web-site/ is a separate git repo, so writes
+#       land as unstaged changes in its working tree — the developer commits them
+#       in web-site's own PR. An absent sibling is skipped silently; a present
+#       file with no badge WARNS (the old code was silent in both cases, which is
+#       what let the drift sit unseen).
 #   - docs/PARITY.md
 #       claude-code-plugin/v<X.Y.Z> current-state row
 #
@@ -238,13 +243,7 @@ if [[ -n "$plugin_ver" ]]; then
       "claude-code-plugin/v$plugin_prev" "claude-code-plugin/v$plugin_ver" 1
     replace_in_file_counted platforms/claude-code-plugin/README.md \
       "claude-code-plugin/v$plugin_prev" "claude-code-plugin/v$plugin_ver" 1
-    # Cross-submodule write: ../web-site/ is a sibling repo under the umbrella.
-    # The sync hook lands changes in its working tree; the developer commits
-    # them in the web-site PR. The replace_in_file helper is no-op if the file
-    # does not exist (e.g., the framework repo is cloned standalone without
-    # the umbrella siblings).
-    replace_in_file ../web-site/src/pages/index.astro \
-      "Pre-release v$plugin_prev" "Pre-release v$plugin_ver"
+    # (The ../web-site badge is synced below, self-healing and outside this guard — #423.)
     replace_in_file platforms/claude-code-plugin/docs/SKILL_AUTHORING.md \
       "version: \"$plugin_prev\"" "version: \"$plugin_ver\""
     replace_in_file platforms/claude-code-plugin/docs/SKILL_AUTHORING.md \
@@ -269,6 +268,85 @@ if [[ -n "$plugin_ver" ]]; then
         && log "  updated platforms/claude-code-plugin/README.md: bare \`^$plugin_prev$\` line -> $plugin_ver"
     fi
   fi
+fi
+
+# --- web-site badges (cross-repo, self-healing) --------------------------------
+# #423. The badge used to be swept by an exact-string replace of
+# "Pre-release v$plugin_prev" from INSIDE the prev-detection guard above. Two
+# consequences, both live when this was written:
+#
+#   * One missed bump sealed the drift permanently. Every later run grepped for a
+#     prev the site no longer carried, and `replace_in_file` returns success on a
+#     miss with no log line — so a skipped write is indistinguishable from a clean
+#     one. `index.astro` sat at v0.20.1 against plugin 0.25.0, and the mechanism
+#     had been added to close *the same* stale-badge bug at v0.18.0.
+#   * `../web-site/src/pages/claude-plugin/index.astro` was never in the sweep at
+#     all, and sat at v0.18.0 — seven minors behind.
+#
+# So: match version-agnostically, rewrite to the CURRENT plugin version, and run
+# OUTSIDE the prev guard, so drift heals on the next run instead of sealing. An
+# absent sibling is normal (standalone clone, CI) and stays silent; a file that is
+# present but carries no badge is the one state worth hearing about.
+#
+# Writes land as unstaged changes in web-site's own working tree — a separate git
+# repo — and the developer commits them in web-site's PR. Nothing here stages or
+# commits outside this repository.
+# A SemVer badge INCLUDING any pre-release/build suffix. Matching the bare
+# `X.Y.Z` prefix would rewrite only that prefix and weld the old suffix onto the
+# new version — "Pre-release v0.26.0-rc1" becoming "Pre-release v0.25.0-rc1" on a
+# public page, stably, because the next run then sees a current-looking badge.
+badge_re='Pre-release v[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?'
+
+# `git rev-parse` gating a cross-repo write: `repo_root` above falls back to
+# `pwd`, and these paths are relative to it. Outside a git repo that fallback
+# could resolve `../web-site` somewhere unintended, so a write that leaves the
+# repository requires the authoritative root, not the fallback.
+if [[ -n "$plugin_ver" ]] && git rev-parse --show-toplevel >/dev/null 2>&1; then
+  for site_badge_file in \
+    ../web-site/src/pages/index.astro \
+    ../web-site/src/pages/claude-plugin/index.astro; do
+    [[ -e "$site_badge_file" ]] || continue
+    if [[ -L "$site_badge_file" ]]; then
+      # `sed -i` unlinks and renames, so it would replace the link with a regular
+      # file and leave the real target stale — a silent half-fix of the exact kind
+      # this block exists to remove.
+      warn "$site_badge_file is a symlink — not rewriting it (#423)"
+      continue
+    fi
+    [[ -f "$site_badge_file" ]] || continue
+    badges="$(grep -oE "$badge_re" "$site_badge_file" 2>/dev/null)"
+    case "$?" in
+      0) ;;
+      1)
+        warn "$site_badge_file carries no 'Pre-release v<x.y.z>' badge — expected one (#423)"
+        continue
+        ;;
+      *)
+        # Exit >=2 is a grep ERROR (unreadable, binary). Reporting it as "no badge"
+        # would name the wrong cause, which is how #423 stayed invisible.
+        warn "cannot read $site_badge_file — badge not checked (#423)"
+        continue
+        ;;
+    esac
+    # Only write on a real difference. This block runs on every invocation, so an
+    # unconditional sed would dirty a sibling repo's working tree — and its mtime —
+    # on every commit that touches a VERSION file. Comparing the extracted badges
+    # (rather than grepping for the current one) keeps a file carrying both a
+    # current and a stale badge from being skipped.
+    stale="$(printf '%s\n' "$badges" | grep -vxF "Pre-release v$plugin_ver" || true)"
+    [[ -n "$stale" ]] || continue
+    if sed -E --follow-symlinks -i "s/$badge_re/Pre-release v$plugin_ver/g" \
+      "$site_badge_file" 2>/dev/null; then
+      # `warn`, not `log`: this write lands in ANOTHER git repository, and the
+      # pre-commit `entry:` passes no `--verbose`, so every `log` line is
+      # suppressed in the only invocation that matters. A cross-repo write
+      # announced by nothing is the silence #423 was filed about, relocated —
+      # the same trap `.pre-commit-config.yaml` records for #405's WARN block.
+      warn "updated $site_badge_file: badge -> Pre-release v$plugin_ver (self-healing, #423)"
+    else
+      warn "sed failed on $site_badge_file"
+    fi
+  done
 fi
 
 # --- framework VERSION fanout -------------------------------------------------

--- a/tests/conformance/test_repo_scripts.py
+++ b/tests/conformance/test_repo_scripts.py
@@ -31,6 +31,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 REGISTERED = (
     "tests.unit.test_pin_currency_reader",
     "tests.unit.test_sdd_doc_lint_trace_resolution",
+    "tests.unit.test_sync_website_badge",
     "tests.unit.test_tag_quote_termination",
 )
 

--- a/tests/conformance/test_sync_version_refs_counts.py
+++ b/tests/conformance/test_sync_version_refs_counts.py
@@ -101,7 +101,7 @@ class SyncVersionRefsExpectedCounts(unittest.TestCase):
                 literal, _var = resolved
                 target = _REPO_ROOT / path
                 if not target.is_file():
-                    # The sibling web-site write is legitimately absent.
+                    # A target may legitimately be absent in a partial checkout.
                     continue
                 actual = target.read_text(encoding="utf-8").count(literal)
                 self.assertEqual(

--- a/tests/unit/test_sync_website_badge.py
+++ b/tests/unit/test_sync_website_badge.py
@@ -1,0 +1,300 @@
+"""Unit: the web-site badge sync self-heals and reports its one silent state (#423).
+
+WHY THIS TEST IS SHAPED LIKE THIS. `scripts/sync-version-refs.sh` writes a badge
+into `../web-site/`, an **independent sibling repository**. The defect #423 records
+is that the write was a *silent* no-op: it matched the exact string
+``Pre-release v<plugin_prev>``, and ``replace_in_file`` returns success on a miss
+with no log line — so once one bump was missed, every later run grepped for a
+version the site no longer carried and reported nothing. The public badge sat at
+``v0.20.1`` against plugin ``0.25.0``, and a second page
+(``claude-plugin/index.astro``) was never in the sweep at all, at ``v0.18.0``.
+
+**The prescribed test method could not see it.** `CLAUDE.md` requires a sync-script
+reproduction to run in a throwaway clone, because a real run stages 100+ files — and
+a clone has no sibling `../web-site/`, so the only write that leaves the repo is
+structurally invisible to it. This test supplies a **synthetic** sibling instead: a
+temp directory laid out as `<tmp>/framework` + `<tmp>/web-site`, which exercises the
+cross-repo path without touching the developer's real sibling checkout.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+import unittest.mock
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "conformance"))
+from _spec import REPO_ROOT
+
+SCRIPT = REPO_ROOT / "scripts" / "sync-version-refs.sh"
+
+
+def _git_free_env() -> dict[str, str]:
+    """The ambient environment with every ``GIT_*`` variable removed.
+
+    THIS IS NOT OPTIONAL, and it is not defensive programming. When this suite
+    runs from the `conformance` pre-commit hook during an actual ``git commit``,
+    git exports ``GIT_DIR`` and ``GIT_INDEX_FILE`` to the hook. A subprocess
+    inheriting them ignores its own ``cwd``: the sandbox's ``git init`` re-inits
+    the REAL repository (it set ``core.bare = true`` on this submodule once,
+    breaking the worktree), and the script's ``git rev-parse --show-toplevel``
+    then returns the real root — so ``../web-site`` resolves to the developer's
+    actual sibling checkout and the test writes outside its temp dir.
+
+    Note ``pre-commit run --all-files`` sets only ``GIT_EDITOR``, so the bug is
+    invisible there and appears only at real commit time.
+    """
+    return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+
+
+#: A synthetic plugin version for the sandbox. Deliberately NOT the real tree's
+#: value: reading that would make both sides agree by construction, so a script
+#: that hardcoded a version would still pass.
+SANDBOX_VERSION = "9.9.9"
+
+BADGE_FILES = (
+    "src/pages/index.astro",
+    "src/pages/claude-plugin/index.astro",
+)
+
+
+class WebsiteBadgeSelfHeal(unittest.TestCase):
+    maxDiff = None
+
+    def setUp(self):
+        if not SCRIPT.is_file():
+            self.skipTest("sync-version-refs.sh not present")
+        if shutil.which("git") is None:
+            self.skipTest("git not available")
+        self.plugin_ver = SANDBOX_VERSION
+        self.tmp = Path(tempfile.mkdtemp(prefix="sync-badge-"))
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+
+        self.repo = self.tmp / "framework"
+        (self.repo / "scripts").mkdir(parents=True)
+        (self.repo / "platforms" / "claude-code-plugin").mkdir(parents=True)
+        shutil.copy2(SCRIPT, self.repo / "scripts" / "sync-version-refs.sh")
+        (self.repo / "platforms" / "claude-code-plugin" / "VERSION").write_text(
+            f"{self.plugin_ver}\n", encoding="utf-8"
+        )
+        # The script ends in `git add -u`; give it a repo so that path is exercised
+        # rather than silently skipped.
+        subprocess.run(["git", "init", "-q"], cwd=self.repo, check=True, env=_git_free_env())
+
+        self.site = self.tmp / "web-site"
+        for rel in BADGE_FILES:
+            (self.site / rel).parent.mkdir(parents=True, exist_ok=True)
+
+    def _write_badge(self, rel: str, body: str) -> Path:
+        path = self.site / rel
+        path.write_text(body, encoding="utf-8")
+        return path
+
+    def _run(self, *args: str) -> subprocess.CompletedProcess:
+        # `--verbose` is the script's real switch (`$1`); an earlier draft passed a
+        # SYNC_VERBOSE env var that nothing reads, which silently suppressed every
+        # log line and left the block's only success signal asserted by nothing.
+        return subprocess.run(
+            ["bash", "scripts/sync-version-refs.sh", *args],
+            cwd=self.repo,
+            capture_output=True,
+            text=True,
+            env=_git_free_env(),
+            check=False,
+        )
+
+    def test_a_stale_badge_heals_without_a_version_bump(self):
+        """The heart of #423: drift must heal on the next run, not seal itself.
+
+        No VERSION changes here. The old code only wrote inside the
+        prev-detection guard, so with nothing bumped it did nothing at all — which
+        is exactly how a missed bump became permanent.
+        """
+        home = self._write_badge(BADGE_FILES[0], '<span class="badge">Pre-release v0.20.1</span>\n')
+        sub = self._write_badge(BADGE_FILES[1], '<span class="badge">Pre-release v0.18.0</span>\n')
+        result = self._run()  # NO --verbose: the pre-commit `entry:` passes none
+        self.assertIn(
+            "(self-healing",
+            result.stderr,
+            "no self-healing log line — the write is silent again, which is the "
+            "property #423 was filed about",
+        )
+        for path in (home, sub):
+            with self.subTest(file=str(path.relative_to(self.site))):
+                self.assertIn(
+                    f"Pre-release v{self.plugin_ver}",
+                    path.read_text(encoding="utf-8"),
+                    "a stale badge did not heal — the sync is exact-string again (#423)",
+                )
+
+    def test_the_second_page_is_swept_too(self):
+        """`claude-plugin/index.astro` was never in the sweep and sat 7 minors behind."""
+        sub = self._write_badge(BADGE_FILES[1], '<span class="badge">Pre-release v0.18.0</span>\n')
+        self._run()
+        self.assertIn(f"Pre-release v{self.plugin_ver}", sub.read_text(encoding="utf-8"))
+
+    def test_an_already_current_badge_is_not_rewritten(self):
+        """This block runs on every invocation; it must not dirty a sibling repo."""
+        home = self._write_badge(
+            BADGE_FILES[0], f'<span class="badge">Pre-release v{self.plugin_ver}</span>\n'
+        )
+        before = home.stat().st_mtime_ns
+        self._run()
+        self.assertEqual(
+            before,
+            home.stat().st_mtime_ns,
+            "an already-current badge was rewritten — every commit touching a VERSION "
+            "file would dirty the sibling repository's working tree",
+        )
+
+    def test_a_file_carrying_both_a_current_and_a_stale_badge_fully_heals(self):
+        """Checking only for the current value would skip the stale one beside it."""
+        home = self._write_badge(
+            BADGE_FILES[0],
+            # Both on ONE line, deliberately: `sed` without `/g` still substitutes
+            # once PER LINE, so a two-line fixture passes with the flag removed.
+            f"a Pre-release v{self.plugin_ver} and b Pre-release v0.19.0\n",
+        )
+        self._run()
+        text = home.read_text(encoding="utf-8")
+        self.assertEqual(
+            text.count(f"Pre-release v{self.plugin_ver}"),
+            2,
+            "a stale badge survived beside a current one",
+        )
+
+    def test_a_present_file_with_no_badge_warns(self):
+        """The one state worth hearing about — and the one the old code hid."""
+        self._write_badge(BADGE_FILES[0], "<p>no badge here</p>\n")
+        result = self._run()
+        self.assertIn(
+            "carries no 'Pre-release v<x.y.z>' badge",
+            result.stderr,
+            "a present-but-badgeless sibling file produced no warning — this is the "
+            "silence #423 was filed about",
+        )
+
+    def test_a_suffixed_badge_heals_whole_rather_than_welding(self):
+        """Matching the bare X.Y.Z prefix corrupts a public page, stably.
+
+        "Pre-release v0.26.0-rc1" would become "Pre-release v0.25.0-rc1" — the old
+        suffix welded onto the new version — and the next run would then see a
+        current-looking badge and leave it there.
+        """
+        home = self._write_badge(BADGE_FILES[0], "x Pre-release v0.26.0-rc1\n")
+        self._run()
+        self.assertIn(f"Pre-release v{self.plugin_ver}\n", home.read_text(encoding="utf-8"))
+        self.assertNotIn("-rc1", home.read_text(encoding="utf-8"))
+
+    def test_a_symlinked_badge_file_is_refused_not_replaced(self):
+        """`sed -i` unlinks and renames, so it would swap the link for a regular
+        file and leave the real target stale — a silent half-fix."""
+        target = self.site / "real.astro"
+        target.write_text("real Pre-release v0.19.0\n", encoding="utf-8")
+        link = self.site / BADGE_FILES[0]
+        if link.exists():
+            link.unlink()
+        link.symlink_to(Path("../../real.astro"))
+        result = self._run()
+        self.assertIn("is a symlink", result.stderr)
+        self.assertTrue(link.is_symlink(), "the symlink was replaced by a regular file")
+        self.assertIn("v0.19.0", target.read_text(encoding="utf-8"))
+
+    def test_an_unreadable_file_is_not_reported_as_missing_a_badge(self):
+        """grep exit 2 is an error, not "no match" — naming the wrong cause is how
+        #423 stayed invisible for five minors."""
+        home = self._write_badge(BADGE_FILES[0], "x Pre-release v0.19.0\n")
+        home.chmod(0o000)
+        self.addCleanup(home.chmod, 0o644)
+        if os.access(home, os.R_OK):  # running as root — the mode is not enforced
+            self.skipTest("cannot make a file unreadable (running as root)")
+        result = self._run()
+        self.assertIn("cannot read", result.stderr)
+        self.assertNotIn("carries no", result.stderr)
+
+    def test_the_write_is_announced_without_the_verbose_flag(self):
+        """The production invocation passes no `--verbose`, so `log` is suppressed.
+
+        `.pre-commit-config.yaml`'s `entry:` is a bare `bash scripts/sync-version-refs.sh`,
+        and its `verbose: true` is pre-commit's *display* flag, not the script's.
+        An earlier revision of this block used `log`, so it rewrote a file in
+        another git repository with zero output and rc=0 — the silence #423 was
+        filed about, relocated. Every other test here would have passed.
+        """
+        self._write_badge(BADGE_FILES[0], "x Pre-release v0.19.0\n")
+        result = self._run()
+        self.assertIn(
+            "self-healing",
+            result.stderr,
+            "a cross-repo write produced no output in the non-verbose invocation "
+            "that production actually uses",
+        )
+
+    def test_a_malformed_plugin_version_touches_nothing(self):
+        """Without the `[[ -n "$plugin_ver" ]]` guard this publishes `Pre-release v`."""
+        (self.repo / "platforms" / "claude-code-plugin" / "VERSION").write_text(
+            "not-a-version\n", encoding="utf-8"
+        )
+        home = self._write_badge(BADGE_FILES[0], "x Pre-release v0.19.0\n")
+        self._run()
+        self.assertIn(
+            "Pre-release v0.19.0",
+            home.read_text(encoding="utf-8"),
+            "a malformed VERSION reached the badge — an empty version would be "
+            "published to a public page",
+        )
+
+    def test_no_cross_repo_write_outside_a_git_repository(self):
+        """The `git rev-parse` gate is this change's own safety control.
+
+        `repo_root` falls back to `pwd`, and the sibling paths are relative to it,
+        so outside a repository `../web-site` could resolve somewhere unintended.
+        """
+        shutil.rmtree(self.repo / ".git")
+        home = self._write_badge(BADGE_FILES[0], "x Pre-release v0.19.0\n")
+        self._run()
+        self.assertIn(
+            "Pre-release v0.19.0",
+            home.read_text(encoding="utf-8"),
+            "the sibling was written from outside a git repository — the rev-parse gate is gone",
+        )
+
+    def test_an_inherited_git_dir_cannot_redirect_the_write(self):
+        """The sandbox must stay a sandbox when git exports GIT_DIR to a hook.
+
+        Measured mechanism: inside a temp repo with ``GIT_DIR`` inherited,
+        ``git rev-parse --show-toplevel`` returns the REAL repository root, so the
+        script's ``cd "$repo_root"`` lands there and ``../web-site`` resolves to
+        the developer's actual sibling checkout. Before the scrub, running this
+        suite from the pre-commit hook during a real ``git commit`` re-inited the
+        real module directory (setting ``core.bare = true``) and pointed the
+        cross-repo write at the real sibling. `pre-commit run --all-files` sets
+        only ``GIT_EDITOR``, so nothing catches this except a test that sets the
+        variable deliberately.
+        """
+        home = self._write_badge(BADGE_FILES[0], "x Pre-release v0.19.0\n")
+        real_git_dir = REPO_ROOT / ".git"
+        with unittest.mock.patch.dict(
+            os.environ,
+            {"GIT_DIR": str(real_git_dir), "GIT_INDEX_FILE": str(real_git_dir / "index")},
+        ):
+            self._run()
+        self.assertIn(
+            f"Pre-release v{self.plugin_ver}",
+            home.read_text(encoding="utf-8"),
+            "the sandbox badge did not heal under an inherited GIT_DIR — the run was "
+            "redirected at the real repository, and the cross-repo write with it",
+        )
+
+    def test_an_absent_sibling_is_silent(self):
+        """Normal for a standalone clone and for CI; must not warn."""
+        shutil.rmtree(self.site)
+        result = self._run()
+        self.assertNotIn("web-site", result.stderr)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## What and why

`scripts/sync-version-refs.sh` syncs a `Pre-release v<X.Y.Z>` badge into `../web-site/`, an
**independent sibling repository**. It matched the exact string `Pre-release v<plugin_prev>`
from inside the previous-version detection guard — and `replace_in_file` returns success on a
miss **with no log line**. So once one bump was missed, every later run searched for a version
the site no longer carried and did nothing, indistinguishably from a clean run. The drift could
only widen.

**Measured, and worse than #423 recorded.** Against plugin `0.25.0`:

| Page | Badge | Behind |
|---|---|---|
| `src/pages/index.astro` | `v0.20.1` | 5 minors |
| `src/pages/claude-plugin/index.astro` | `v0.18.0` | 7 minors — **never in the sweep at all** |

That second page is a finding beyond the issue. And the mechanism had itself been added to close
the *same* stale-badge bug at `v0.18.0`; it recurred in the same place with nothing failing.

## The fix

Match version-agnostically, rewrite to the **current** plugin version, run **outside** the prev
guard, sweep both pages — so drift heals on the next run instead of sealing itself. Three
behaviours are deliberate: an **absent** sibling stays silent (normal for a standalone clone and
CI); a sibling **present but carrying no badge** now *warns*, the state the old code hid; and an
**already-current** badge is not rewritten, because this block runs on every invocation and an
unconditional `sed` would dirty a sibling repo's working tree on every `VERSION`-touching commit.

## Why it survived so long

The prescribed test method is **structurally blind** to it. `CLAUDE.md` requires a sync-script
reproduction to run in a throwaway clone — and a clone has no sibling `../web-site/`, so the only
write that leaves the repo cannot be observed. `tests/unit/test_sync_website_badge.py` supplies a
**synthetic** sibling in a temp directory instead, and is **registered** in
`tests/conformance/test_repo_scripts.py` so it runs wherever conformance runs — `tests/unit/` is
reached by no hook and no workflow on its own.

## Review found three things I would have shipped

Two fresh-context agents, both with shell access. **0 P0/P1**, 11 P2/P3, all folded.

1. **The fix reproduced the very silence it removes.** The heal was announced with `log`, which
   only prints under the script's `--verbose` — but `.pre-commit-config.yaml`'s `entry:` is a
   bare `bash scripts/sync-version-refs.sh`, and its `verbose: true` is *pre-commit's* display
   flag, not the script's. Measured: the production invocation rewrote a file in another git
   repository with **zero output and rc = 0**. Every test passed, because the tests passed
   `--verbose`. Now a `warn`, with a test asserting the announcement **without** the flag. This
   is the same trap `.pre-commit-config.yaml` already records for #405's WARN block.
2. **The test was not hermetic, and proving it cost a repo repair.** During a real `git commit`
   git exports `GIT_DIR`/`GIT_INDEX_FILE` to hooks, and a subprocess inheriting them ignores its
   own `cwd`. The sandbox's `git init` re-initialized **this submodule's real module directory**,
   setting `core.bare = true` and breaking the worktree; the script's `git rev-parse` then
   returned the real root, resolving `../web-site` to the developer's **actual** checkout.
   Measured directly — in a temp repo with `GIT_DIR` inherited, `rev-parse --show-toplevel`
   returns `/opt/data/aidoc-flow/framework`. No damage resulted only because the real badges were
   already current. Config repaired; every subprocess now runs `GIT_*`-scrubbed; a test sets
   `GIT_DIR` deliberately and asserts the sandbox still heals. Note `pre-commit run --all-files`
   exports only `GIT_EDITOR`, so this is invisible there and appears only at real commit time.
3. **Suffix welding.** `Pre-release v[0-9]+\.[0-9]+\.[0-9]+` has no right boundary, so
   `v0.26.0-rc1` would have become `v0.25.0-rc1` on a public page — and *stably*, since the next
   run then sees a current-looking badge. (The adjacent worry about `v0.25.10` does not occur;
   `[0-9]+` is greedy.) Also: a **symlinked** file is now refused rather than replaced by
   `sed -i`; a `grep` **error** exit is distinguished from no-match, so an unreadable file reports
   `cannot read` instead of the misleading `carries no badge`; and the cross-repo write is gated
   on `git rev-parse` succeeding, since `repo_root` falls back to `pwd`.

Three surviving mutants were also reported and closed (the `plugin_ver` guard, the `git rev-parse`
gate, and the `sed` `/g` flag — the last survived because my two-badge fixture put them on
separate lines, and `sed` substitutes once *per line*). **13 mutations killed.** I also caught two
of my own "kills" being mutants that failed to *apply*, and redid them.

My changelog figure for "how many tests fail on revert" was wrong twice — first counting `subTest`
failure *items* rather than methods, then not re-derived after tests were added. It is **8 of 13**,
re-measured, and the entry says so.

## Verification

| Suite | Result |
|---|---|
| `python3 -m unittest discover -s tests/conformance -t tests/conformance` | 522 OK |
| `python3 -m unittest discover -s tests/unit -t .` | 208+ OK |
| `python3 -m unittest discover -s tests/acceptance/deterministic -t .` | 64 OK |
| `pre-commit run --all-files` | 19 passed, rc=0 (twice, to stability) |
| `python3 tests/chg/spec_gate.py --base origin/main` | not a spec change, OK |

Config verified sane after a real `git commit` — the exact condition that broke it.

## ⚠️ Cross-repo state you should know about

Running the hook healed the **real** sibling: both pages now read `Pre-release v0.25.0`,
**unstaged and uncommitted** in `/opt/data/aidoc-flow/web-site/`. That is the script's documented
contract — "writes land as unstaged changes in web-site's working tree; the developer commits them
in web-site's own PR". Nothing was staged, committed or pushed there. **The badge repair still
needs a `web-site` PR**, which this repo cannot open.

Closes #423
