### PR TITLE
docs(tagging): record framework/v0.50.0 and refresh the high-water snapshot

### DIFF
--- a/docs/TAGGING.md
+++ b/docs/TAGGING.md
@@ -105,17 +105,34 @@ names and make `git tag -l '<prefix>/*'` an effective per-stream filter.
 > git log --format=%H main -- framework/VERSION \
 >   | while read -r s; do git show "$s:framework/VERSION" | tr -d '[:space:]'; echo; done \
 >   | sort -u | grep -c .
-> ``` As of **2026-09-01** the cut high-water marks
-> are `v1.1.0` (project), **`framework/v0.49.0`**, `claude-code-plugin/v0.25.0`,
+> ``` As of **2026-09-03** the cut high-water marks
+> are `v1.1.0` (project), **`framework/v0.50.0`**, `claude-code-plugin/v0.25.0`,
 > and `hermes/v0.1.1`. Rows above those points are version assignments whose tag
 > has not yet been cut. Do not assume a row here means the tag exists.
 >
-> Scale, so the backlog is not mistaken for a defect: **77 of the 89 values
-> `framework/VERSION` has held are untagged** (measured 2026-09-01, after
-> `v0.46.0`–`v0.49.0` were cut), and the plugin stream is exactly
+> Scale, so the backlog is not mistaken for a defect: **77 of the 90 values
+> `framework/VERSION` has held are untagged** (measured 2026-09-03, after
+> `v0.50.0` was cut at `07b52e02`), and the plugin stream is exactly
 > current (`0.25.0` tagged, `VERSION` = `0.25.0`) while **Hermes has the largest
 > gap** (`hermes/v0.1.1` against `VERSION` = `0.12.1`). Lagging is the norm here,
 > not an error state.
+>
+> **The framework stream's recent run is contiguous, and that is the part worth
+> preserving.** `v0.46.0`, `v0.47.0`, `v0.48.0`, `v0.49.0` and `v0.50.0` are each
+> cut on the squash-merge commit whose `framework/VERSION` reads that exact
+> version. The 77 untagged values are all older than `v0.46.0`; nothing in the
+> current run is missing. Verify a tag's target rather than assuming it — the
+> check is one command, and a tag is immutable once pushed:
+>
+> ```sh
+> git show framework/vX.Y.Z:framework/VERSION   # must equal X.Y.Z
+> ```
+>
+> **A cut tag does not imply a published GitHub Release, and here it usually does
+> not.** `framework/v0.44.0` is the newest framework **Release** and therefore
+> still shows as *Latest* on the releases page, while the spec is at `0.50.0`;
+> `v0.46.0`–`v0.50.0` are tags with no Release. Read `git tag -l`, never the
+> releases page, to answer "what is the current spec version".
 >
 > **A missing tag is not the same defect as a phantom version.** A version
 > documented as released that `VERSION` never actually held cannot be tagged at


### PR DESCRIPTION
## What and why

`framework/v0.50.0` was cut and pushed on 2026-09-03 at **`07b52e02`** — the squash-merge of
PR #622, whose `framework/VERSION` reads `0.50.0`. **Tag only**, matching how `v0.46.0`–`v0.49.0`
were cut; no GitHub Release.

`docs/TAGGING.md`'s snapshot block is the one surface the cut falsified. This PR is that
correction, plus two facts a reader currently has to discover the hard way.

## Why this tag is safe to have cut

The D-0086 hazard is an immutable tag on a commit whose `VERSION` disagrees (`hermes/v0.1.1`).
Verified before pushing, not after:

```sh
$ git rev-list -n1 framework/v0.50.0
07b52e0225c737b8a99427f0e3be2e102daf9117
$ git show framework/v0.50.0:framework/VERSION
0.50.0
$ git ls-remote --tags origin 'refs/tags/framework/v0.50.0^{}'
07b52e02...  refs/tags/framework/v0.50.0^{}
```

Target is on `origin/main`, annotated, and the remote tag object dereferences to the same commit.

## Figures re-derived, not incremented

Using the file's own prescribed whitespace-stripping command — the one that exists because a
commit wrote `framework/VERSION` with no trailing newline:

| Figure | Before | After | Source |
|---|---|---|---|
| Framework high-water | `v0.49.0` (2026-09-01) | `v0.50.0` (2026-09-03) | `git tag -l 'framework/v*'` |
| Untagged / total | 77 of 89 | 77 of 90 | 90 distinct values, 13 tags |
| Project | `v1.1.0` | `v1.1.0` | re-checked, unchanged |
| Plugin | `claude-code-plugin/v0.25.0` | unchanged | `VERSION` = `0.25.0`, exactly current |
| Hermes | `hermes/v0.1.1` | unchanged | `VERSION` = `0.12.1`, largest gap |

**The count lands on 77 again by coincidence** — one new value and one new tag. That is exactly
the shape that gets copied forward as "unchanged", so it is stated with its date and its command
rather than carried.

## Two paragraphs added

- **The recent run is contiguous, and that is the part worth preserving.** `v0.46.0` through
  `v0.50.0` are each cut on the squash-merge commit whose `framework/VERSION` reads that exact
  version; all 77 untagged values predate `v0.46.0`. Without this, the "77 untagged" figure reads
  as though the current stream were also lagging. Includes the one-command target check, since a
  tag is immutable once pushed.
- **A cut tag does not imply a published Release, and here it usually does not.**
  `framework/v0.44.0` is the newest framework **Release** and therefore still shows as *Latest*
  on the releases page while the spec is at `0.50.0`; `v0.46.0`–`v0.50.0` are tags with no
  Release. Anyone answering "what is the current spec version" from the releases page gets an
  answer six minors stale. The paragraph says to read `git tag -l` instead.

## What this PR does NOT do

- **No GitHub Release for `0.50.0`**, and no change to the *Latest* marker on `v0.44.0`. That was
  offered as an alternative and declined in favour of matching the last four cuts; it stays open
  as a separate call.
- **No new row in the per-version table.** That table stopped at `framework/0.21.0` and has not
  been maintained for this stream — `v0.44.0` and `v0.46.0`–`v0.49.0` were all cut without rows,
  so adding one only for `0.50.0` would imply a convention that is not in force.
- **No change to the backlog policy.** `docs/TAGGING.md` still says lagging is the norm, not an
  error state, and nothing here makes tagging obligatory.

## Verification

`pre-commit run --all-files` green (conformance suite included, 543 OK). One doc surface, C1.
Merge is human-only on this repo per `.github/ai-review/config.json`; no auto-merge attempted.
