### PR TITLE
fix(ci): re-enable ai-review and record D-0087; the disable silenced a working reviewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,49 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed — CI: `ai-review` is re-enabled after a two-day silent window nothing recorded (D-0087, closes #623) (2026-09-03)
+
+`ai-review` was **`disabled_manually`** from 2026-09-01 to 2026-09-03. It is now `active` again.
+In that window it produced no run, no verdict and no check-run on any PR — including
+PRs #619, #622, #624 and #625, all merged to `main` — and nothing recorded the disable:
+no decision entry, no issue, no comment. It was found by noticing `ai-review` absent from
+PR #622's check rollup.
+
+**`composition` read `active` for the whole window and was equally silent**, because its only
+PR-side triggers are `pull_request_review` and a `workflow_run` chained off **`ai-review`**
+completing. Disabling the parent silences the child while `gh workflow list` still shows the
+child healthy — and that listing is the first thing an auditor reaches for.
+
+**Why re-enable rather than delete.** On 2026-09-01, four `ai-review` runs **succeeded** across
+three branches between 02:45 and 03:12, and the three failures that preceded the disable were all
+on **one** branch (`fix/606-ai-review-schema-pin`, PR #612). Run `33465218619` was inspected
+step-wise rather than trusted from its conclusion — `call / trust` success, `call / ai-review`
+success, `call / autofix` skipped: a real review job. So the reviewer was working when it was
+switched off, and silencing it repo-wide cost every other PR its verdict. Deleting the callers
+(#623's alternative, on D-0085's "retire by deleting, not disabling") was rejected because
+re-enabling closes the same disabled-caller hazard by the other route: the workflow runs again,
+so a stale Dependabot pin surfaces instead of merging green unopposed.
+
+**This entry is a successor to the `0.48.0`-era D-0084 entry below, which is left as written.**
+That entry states *"Both workflows still run and still post verdicts; only the merge-blocking is
+gone."* True on 2026-08-31, falsified on 2026-09-01 by an action D-0084 did not authorize. It
+also calls the failure **intermittent**; the evidence above narrows that to *branch-confined and
+deterministic on the branch it hits*. Neither statement is edited — a changelog entry is a record
+of what shipped, at its date — so this is the correction a reader following that entry needs.
+
+**The upstream diagnosis does not fit either.** `aidoc-flow-ci#543` reports the failure as
+deterministic on a **many-file** diff (179 files) and its own follow-up retracts the file-count
+mechanism, concluding only that the 400,000-byte input cap does not bound the failure. **PR #612
+is 5 files, +313/−40** — small on every axis — and failed three times. So neither file count,
+line count nor the input cap explains it; the discriminator is unmeasured and upstream-owned.
+Filed there as a comment. Not blocking: `ai-review` is still not a required context, so a red
+verdict leaves a PR `UNSTABLE`.
+
+**One channel does reopen:** every PR resumes LiteLLM spend, and this proxy is separately known
+for HTTP 402 on an exhausted balance. If the disable was a spend decision rather than a flake
+response, that reason is recorded nowhere — `plans/DECISIONS.md` **D-0087** says so, and carries
+the one-command reverse.
+
 ### Changed — Framework Spec `0.49.0 → 0.50.0` — IPLAN `code_inventory` gains a `planned` status and is seeded at Draft instead of left empty (GD-25, #601, #609) (2026-09-02)
 
 `IPLAN-TEMPLATE.yaml` §6 `traceability.code_inventory` declared two statuses until
@@ -362,6 +405,13 @@ of which canon states plainly that `--repin` cannot deliver.
 **Both workflows still run and still post verdicts; only the merge-blocking is gone.** Branch
 protection is server state that lives in no repo — `plans/DECISIONS.md` **D-0084** is the record
 and carries the exact one-call restore.
+
+> ⚠️ **Superseded on one point, 2026-09-03.** The bolded sentence above was true at this date and
+> was falsified two days later, when `ai-review` was set `disabled_manually` without a record and
+> neither workflow ran for two days. The "intermittent" characterisation below is also narrowed by
+> later evidence to branch-confined. See the D-0087 entry at the top of this file. Nothing here is
+> edited: a changelog entry records what shipped, at its date. The gating change itself — the four
+> required contexts and D-0084's restore command — is unaffected and still current.
 
 **Why.** `ai-review` fails **intermittently** with `ResponseShapeError` (upstream
 [aidoc-flow-ci#543](https://github.com/vladm3105/aidoc-flow-ci/issues/543)) — often enough that

--- a/plans/DECISIONS.md
+++ b/plans/DECISIONS.md
@@ -10,6 +10,107 @@ graduation.
 
 ---
 
+## D-0087 — `ai-review` is re-enabled; the disable was a repo-wide response to one branch's failures, and it silenced a reviewer that was working
+
+**Date:** 2026-09-03 · **Issues:** #623 · upstream `aidoc-flow-ci#543` · **Decider:** founder
+(in session, "fix this" on #623)
+
+**This records a change to SERVER STATE that exists in no git repository**, on the D-0084
+precedent. `gh workflow enable ai-review.yml` — reversible with `gh workflow disable
+ai-review.yml`, and the treated artifact is that command pair, not this prose.
+
+### What was true, and for how long
+
+`ai-review` was `disabled_manually` from **2026-09-01** until **2026-09-03**. In that window it
+produced no run, no verdict and no check-run on any PR — including #619, #622, #624 and #625,
+all merged to `main`. `composition` remained `active` and was equally silent, because its only
+PR-side triggers are `pull_request_review` and a `workflow_run` chained off **`ai-review`**
+completing: disabling the parent silences the child, and `gh workflow list` shows the child as
+`active` throughout. **Reading that listing alone is misleading, and it is the first thing an
+auditor reaches for.**
+
+Nothing recorded the disable — no decision entry, no issue, no comment. It was found by noticing
+`ai-review` absent from PR #622's check rollup, against a handoff that asserted it would be
+present.
+
+### The evidence that decides it: the reviewer was working
+
+`gh run list --workflow=ai-review.yml` for 2026-09-01:
+
+| Time (UTC) | Branch | Result |
+|---|---|---|
+| 02:45:40 | `fix/main-iplan-bundle-drift` | success |
+| 02:53:31 | `fix/604-claude-md-pin-census` | success |
+| 03:10:07 | `chore/handoff-refresh-post-604` | success |
+| 03:12:04 | `chore/handoff-refresh-post-604` | success (`pull_request_review`) |
+| **05:43:25** | **`fix/606-ai-review-schema-pin`** | **failure** |
+| **06:04:28** | **`fix/606-ai-review-schema-pin`** | **failure** |
+| **06:13:49** | **`fix/606-ai-review-schema-pin`** | **failure** |
+
+Four successes across three branches, then three failures **all on one branch**, then a
+repo-wide disable. Run `33465218619` was inspected rather than trusted from its conclusion:
+`call / trust` success, `call / ai-review` success, `call / autofix` skipped — a real review job,
+not a skip reporting green.
+
+**So the reviewer was not broken when it was switched off.** Silencing it repo-wide is a much
+larger response than one branch's failures support, and the cost was every other PR's verdict.
+**Decision: re-enable.** It also restores D-0084's own stated intent from the day before — "a
+gating change, not a teardown" — which no later decision revised.
+
+### What re-enabling does and does not expose
+
+- **It cannot block a merge.** `ai-review` is not a required context (D-0084) and canon submits
+  `COMMENT`, never `REQUEST_CHANGES`. A red verdict leaves a PR `UNSTABLE`.
+- **It cannot auto-merge.** `auto-merge-ai-prs` is `active`, but canon refuses for this repo at
+  `auto-merge-ai-prs.yml:301` and again at the `auto_merge.repos` allowlist.
+- **The fork surface is unchanged and was vetted before.** `pull_request_target` on a public repo
+  with self-hosted runners is safe here because a fork PR reaches only the no-PR-code trust job
+  (`CLAUDE.md` § "Unified CI"). Re-enabling restores a configuration that ran for months, not a
+  new one.
+- **A cost channel does reopen.** Every PR resumes LiteLLM spend, and this proxy is separately
+  known for HTTP 402 on an exhausted balance. If the disable was a spend decision rather than a
+  flake response, that reason is recorded nowhere and this entry is wrong on motive — but not on
+  outcome, because the reverse command is one line.
+
+### Why deleting the callers was rejected
+
+Issue 623 offered deletion as the alternative, on D-0085's reasoning that a
+disabled-but-undeleted workflow removes the signal and not the surface. That reasoning is sound and the hazard is real
+here — `.github/workflows/ai-review.yml` still pins `@ci/v3.0.0`, so Dependabot still opens bumps
+against it and they would merge green with nothing running to contradict them. **Re-enabling
+closes that hazard by the other route**: the workflow now runs, so a bad pin surfaces. Deletion
+is irreversible and would discard a reviewer whose findings this repo has measured as substantive
+(upstream #543 records it catching a real defect four human-directed passes had missed).
+`.github/dependabot.yml:77-82` additionally holds `semver-major` on `vladm3105/aidoc-flow-ci/*`,
+so the exact #603 shape could not have arrived unattended in the interim.
+
+### What is NOT settled
+
+**Upstream `aidoc-flow-ci#543` is open, and its stated diagnosis does not fit the failures that
+preceded the disable.** #543 reports the failure as deterministic on a **many-file** diff (179
+files) and its own follow-up comment retracts the file-count mechanism, concluding only that the
+400,000-byte input cap "does not bound the failure it exists to prevent." **PR #612 is 5 files,
++313/−40** — small on every axis — and failed three times. So neither file count nor line count
+nor the input cap explains it, and the discriminator remains unmeasured. That evidence is filed
+as a comment on #543; it is upstream-owned and does not gate this decision, because the failure
+is confined and non-blocking.
+
+**#596 is affected.** Its items 1 and 2 were written on the premise that `ai-review` still runs;
+that premise is true again as of this entry, so those items revert to their original form rather
+than resolving by deletion.
+
+- **Restore command**, if the disable is ever wanted back:
+
+  ```sh
+  gh workflow disable ai-review.yml -R vladm3105/aidoc-flow-framework
+  ```
+
+- **Authority:** `plans/DECISIONS.md` **D-0084** (the gating change this supersedes on one point
+  only), **D-0085** (retire by deleting, not disabling), `CLAUDE.md` § "Unified CI" (the fork
+  surface), `.github/dependabot.yml:77-82`, upstream `aidoc-flow-ci#543`.
+
+---
+
 ## D-0086 — The `hermes/v0.1.1` phantom is accepted as permanent, on D-0078's reasoning, because a release tag cannot be moved
 
 **Date:** 2026-09-01 · **Issue:** #617 · **Decider:** in-session, applying D-0078's precedent
@@ -289,6 +390,13 @@ object cannot see. Everything outside that object was diffed and is byte-identic
 
 **Both workflows still run.** This is a gating change, not a teardown: `ai-review` still submits
 its verdict and `composition` still evaluates. Only the *blocking* is gone.
+
+> ⚠️ **That paragraph was true on 2026-08-31 and was falsified two days later by an action this
+> entry did not authorize.** `ai-review` was set `disabled_manually` on 2026-09-01, so from then
+> until 2026-09-03 neither workflow ran on any PR. **D-0087 records that window and the
+> re-enable; nothing above is rewritten**, because a decision is accurate as of its date and the
+> correction belongs in the entry that supersedes it. The gating half of this entry — the four
+> required contexts and the restore command below — was never affected and still holds.
 
 ### Scope of "nothing blocks" — three channels, only one of which was changed
 

--- a/plans/HANDOFF.md
+++ b/plans/HANDOFF.md
@@ -8,8 +8,10 @@ never repeated here.
 **State:** framework spec **`0.50.0`**, plugin `0.25.0`, Hermes `0.12.1`; both platform
 `FRAMEWORK_SPEC_VERSION` pins read `0.50.0`. `0.45.0` was **skipped** and never became a value
 of `framework/VERSION` (`plans/DECISIONS.md` D-0082). Tag high-water mark is
-**`framework/v0.49.0`**; **`v0.50.0` is NOT cut** — re-derive with
-`git ls-remote --tags origin 'refs/tags/framework/*'`.
+**`framework/v0.50.0`**, cut 2026-09-03 at `07b52e02` — re-derive with
+`git ls-remote --tags origin 'refs/tags/framework/*'`. **A cut tag is not a published Release
+here:** `framework/v0.44.0` is the newest framework Release and so still shows as *Latest* while
+the spec is `0.50.0`; `v0.46.0`–`v0.50.0` are tag-only.
 
 **Verified 2026-09-03 on `main` at `07b52e02`** (run, not asserted): conformance **494 passed /
 1034 subtests** via `python3 -m pytest tests/conformance -q`, and **543** via
@@ -22,8 +24,10 @@ regen; use `--skip-lint-smoke`.
 
 ## What this session did
 
-**One merge: #622 (closes #601), framework spec `0.49.0 → 0.50.0`, squashed as `07b52e02`.**
-Three issues filed — **#620**, **#621**, **#623** — and **#613 reopened**.
+**Four merges.** PR #622 (closes #601, framework spec `0.49.0 → 0.50.0`, squashed as
+`07b52e02`); PRs #624 and #625 (handoff + tagging docs); and this one, closing #623. Three
+issues filed — **#620**, **#621**, **#623** — **#613 reopened**, and **`framework/v0.50.0` cut
+and pushed**.
 
 **IPLAN `code_inventory` became a three-value lifecycle seeded at Draft.** Vocabulary is
 `planned | created | modified`; a Draft `code_build`/`combined` IPLAN carries one `planned`
@@ -58,34 +62,37 @@ skips ruff, markdownlint, yamllint, detect-secrets and both sync hooks — so **
 `pre-commit run --all-files` immediately after and confirm green**, which is what #622 did and
 recorded in its PR body. Fix shape is on **#620**.
 
-## ⚠️ #623 — `ai-review` does not run at all, and D-0084 says it does
+## `ai-review` is RE-ENABLED as of 2026-09-03 (D-0087, closes #623)
 
-**`gh workflow list --all` reports `ai-review` as `disabled_manually`.** It is not merely
-non-gating: no run, no verdict, no check-run. On #622's rollup the count of check-runs matching
-`ai-review|composition` is **0**. Last run was `2026-09-01T06:13:49Z` on
-`fix/606-ai-review-schema-pin` — the third consecutive `ResponseShapeError` failure, the one that
-killed PR #612 — and nothing has run since, including PRs #619 and #622, both merged to `main`.
+**It was `disabled_manually` from 2026-09-01 to 2026-09-03** and produced no run, no verdict and
+no check-run on any PR in that window — including #619, #622, #624 and #625, all merged to
+`main`. Nothing recorded the disable. **Read `plans/DECISIONS.md` D-0087 rather than this
+summary**; the evidence that decided it is that four `ai-review` runs succeeded on three
+branches between 02:45 and 03:12 on 2026-09-01, and the three failures that preceded the disable
+were **all on one branch** (`fix/606-ai-review-schema-pin`, PR #612).
 
-`plans/DECISIONS.md` **D-0084** states *"Both workflows still run. This is a gating change, not a
-teardown."* That was true at its date and is false now; **D-0084 is not rewritten**, because a
-decision record is accurate as of when it was made. `composition` shows `active` but is equally
-silent — its only PR-side triggers are `pull_request_review` and a `workflow_run` chained off
-**`ai-review`** completing, so disabling the parent silences the child. Reading
-`gh workflow list` alone is misleading here.
+**Two traps from that window are worth keeping even though the state is fixed:**
 
-Re-derive before trusting either statement: `gh workflow list --all` ·
-`gh run list --workflow=ai-review.yml --limit 5`.
+- **`gh workflow list` showed `composition` as `active` throughout, and it was silent.** Its only
+  PR-side triggers are `pull_request_review` and a `workflow_run` chained off **`ai-review`**
+  completing, so disabling the parent silences the child while the listing still reads healthy.
+  Check the child's *runs*, not its status.
+- **D-0084 asserts "Both workflows still run", and that sentence was falsified two days after it
+  was written.** It is annotated in place, not rewritten — a decision is accurate as of its date.
+  Its gating half (the four required contexts, the restore command) was never affected.
 
-**The disable itself has no decision entry.** Whether it is permanent is the founder's call,
-and issue 623 carries both paths. Note the disabled-caller hazard:
-`.github/workflows/ai-review.yml` still pins `@ci/v3.0.0`, so Dependabot still opens bumps against it and those merge green because
-nothing runs to contradict them — the `doc-maintainer.yml` failure (D-0085, #603). **Narrower
-here:** `.github/dependabot.yml:77-82` holds `semver-major` on `vladm3105/aidoc-flow-ci/*`, so
-the #603 shape cannot arrive unattended; a **minor/patch** bump still can.
+Re-derive rather than trusting either: `gh workflow list --all` ·
+`gh run list --workflow=ai-review.yml --limit 8`.
 
-**#596 is the adjacent issue and its premise moved.** It enumerates statements falsified *by*
-D-0084 on the assumption `ai-review` still runs; a comment there records the shift, and its
-items 1 and 2 may resolve by deletion rather than correction.
+**Expect intermittent red, and it does not block.** `ai-review` is not a required context, so a
+failure leaves a PR `UNSTABLE`. Upstream `aidoc-flow-ci#543` is **open** and its diagnosis does
+not fit: it reports the failure as deterministic on a **many-file** diff and its own follow-up
+retracts the file-count mechanism, but PR #612 is **5 files, +313/−40** and failed three times.
+Neither file count, line count, nor the 400,000-byte input cap explains it. That evidence is now
+a comment on #543; the discriminator is unmeasured and upstream-owned.
+
+**#596's premise is restored.** Its items 1 and 2 were written assuming `ai-review` still runs;
+that is true again, so they revert to their original form rather than resolving by deletion.
 
 ## CI gating — the branch-protection half of D-0084 still holds
 
@@ -158,22 +165,21 @@ do not re-file.
 
 ## What to do next — prioritized
 
-1. **Decide #623** — is `ai-review` permanently disabled? Both author-side AI review signals are
-   currently absent from every PR, and the disable is recorded nowhere. Re-enable, or delete both
-   callers per D-0085's reasoning; either way record it in `plans/DECISIONS.md`. Settling this
-   also decides whether #596's items 1 and 2 are edited or deleted.
-2. **Decide #606's disposition** — the only item where the record and `main` disagree. Cheapest
-   correct path: re-submit the branch. Per #623, the `ai-review` flake that killed PR #612 cannot
-   even run today, so nothing blocks it.
-3. **#620** — fix the phantom-release guard so a spec release can pass its own pre-commit. Every
+1. **Decide #606's disposition** — the only item where the record and `main` disagree. Cheapest
+   correct path: re-submit the branch. ⚠️ **`ai-review` now runs again (D-0087), and PR #612 is
+   the one branch it failed on** — three times, deterministically. Expect that failure to recur
+   on a resubmission; it is non-blocking (`ai-review` is not a required context), and reproducing
+   it deliberately would be useful evidence for upstream `aidoc-flow-ci#543`, whose stated
+   diagnosis does not fit a 5-file diff.
+2. **#620** — fix the phantom-release guard so a spec release can pass its own pre-commit. Every
    future framework bump pays the `--no-verify` cost until it lands, and that is the change class
    where skipping the other hooks is least acceptable.
-4. **#621** — decide what a Draft's `sessions:` carries, and bring both engines onto it.
-5. **#613** — reopened; the fix is host-side resolver work, not a repo change. Not blocking.
-6. **#614** — does the seed tier get a registered `@seed:` provenance tag on the `@chg:`
+3. **#621** — decide what a Draft's `sessions:` carries, and bring both engines onto it.
+4. **#613** — reopened; the fix is host-side resolver work, not a repo change. Not blocking.
+5. **#614** — does the seed tier get a registered `@seed:` provenance tag on the `@chg:`
    precedent? Suggested default is **no** unless a second `real-use` report arrives; the point of
    the issue is that the *reason* must be scope, never "a tag is lineage". Not blocking anything.
-7. **#393 / `plans/CI-CANON-V4-MIGRATION-PLAN.md`** — still **BLOCKED** on two founder /
+6. **#393 / `plans/CI-CANON-V4-MIGRATION-PLAN.md`** — still **BLOCKED** on two founder /
    infrastructure prerequisites (runner labels `ci`/`ephemeral` do not exist; `LLM_URL` /
    `LLM_API_KEY` do not exist and the caller still forwards three `LITELLM_*` names v4
    un-declares). ⚠️ **Its stated `--repin` remedy is insufficient**, not unsafe — the plan
@@ -181,13 +187,13 @@ do not re-file.
    repo's word for `--update` (risk R2). Read the plan, not the issue body. If #606 is
    re-submitted, its `$schema` edit and this plan's step 6 / verification V3b must stay
    consistent.
-8. **#588** — the identity-carrier split. Not startable alone; it is `OKF-CONFORMANCE-001`
+7. **#588** — the identity-carrier split. Not startable alone; it is `OKF-CONFORMANCE-001`
    D1's to settle.
-9. **#546** — **parked**, and splitting it is what unparks it. The `_required: false` half of
+8. **#546** — **parked**, and splitting it is what unparks it. The `_required: false` half of
    the `STY02` defect is independently shippable and does not wait on the parked subtype
    decision; the correction that establishes this is in the issue's own comments. Re-title or
    split before picking it up, and drop `parked` from the shippable half.
 
-Cutting `framework/v0.50.0` is **not** on this list: `docs/TAGGING.md` records the tag-cut lag as
-a known backlog, and 77 of 89 framework versions are untagged. Cut it only as part of a
-deliberate tagging pass.
+`framework/v0.50.0` was cut this session and is off this list. `docs/TAGGING.md` still records
+the tag-cut lag as a sanctioned backlog — **77 of 90** values untagged, all of them older than
+`v0.46.0` — so the *older* backlog stays deferred; only the contiguous recent run is maintained.


### PR DESCRIPTION
## What and why

`ai-review` was **`disabled_manually`** from 2026-09-01 to 2026-09-03. In that window it produced
no run, no verdict and no check-run on any PR — including #619, #622, #624 and #625, all merged
to `main`. Nothing recorded it: no decision entry, no issue, no comment. It was found by noticing
`ai-review` absent from PR #622's check rollup, against a handoff that asserted it would be there.

**Done:** `gh workflow enable ai-review.yml`, verified `active`.

## The evidence that decided it

`gh run list --workflow=ai-review.yml` for 2026-09-01:

| Time (UTC) | Branch | Result |
|---|---|---|
| 02:45:40 | `fix/main-iplan-bundle-drift` | success |
| 02:53:31 | `fix/604-claude-md-pin-census` | success |
| 03:10:07 | `chore/handoff-refresh-post-604` | success |
| 03:12:04 | `chore/handoff-refresh-post-604` | success (`pull_request_review`) |
| **05:43:25** | **`fix/606-ai-review-schema-pin`** | **failure** |
| **06:04:28** | **`fix/606-ai-review-schema-pin`** | **failure** |
| **06:13:49** | **`fix/606-ai-review-schema-pin`** | **failure** |

Four successes across three branches, then three failures **all on one branch**, then a repo-wide
disable. Run `33465218619` was inspected rather than trusted from its conclusion — `call / trust`
success, `call / ai-review` success, `call / autofix` skipped: a real review job, not a skip
reporting green.

**So the reviewer was working when it was switched off.** Silencing it repo-wide is a much larger
response than one branch's failures support, and the cost was every other PR's verdict.
Re-enabling also restores D-0084's own stated intent from the day before — *"a gating change, not
a teardown"* — which no later decision revised.

## Why deletion was rejected

#623 offered deletion as the alternative, on D-0085's reasoning that a disabled-but-undeleted
workflow removes the signal and not the surface. That reasoning is sound and the hazard was real:
`.github/workflows/ai-review.yml` still pins `@ci/v3.0.0`, so Dependabot still opens bumps
against it and they would merge green with nothing running to contradict them. **Re-enabling
closes that hazard by the other route** — the workflow now runs, so a bad pin surfaces — and
deletion is irreversible, discarding a reviewer this repo has measured as substantive (upstream
#543 records it catching a real defect four human-directed passes had missed).

## D-0084 is annotated, not rewritten

Its *"Both workflows still run"* paragraph was true on 2026-08-31 and falsified two days later by
an action it did not authorize. A decision is accurate as of its date, so the correction belongs
in the entry that supersedes it (**D-0087**), with a pointer left in place. D-0084's gating half —
the four required contexts and its restore command — was never affected and still holds.

## New evidence for upstream `aidoc-flow-ci#543`, which does not fit its own diagnosis

#543 reports the failure as deterministic on a **many-file** diff (179 files), and its own
follow-up comment retracts the file-count mechanism, keeping only that the 400,000-byte input cap
"does not bound the failure it exists to prevent."

**PR #612 is 5 files, +313/−40** — small on every axis — and failed three times. So neither file
count, line count, nor the input cap explains it, and the discriminator remains unmeasured. Filed
as a comment on #543. Upstream-owned, and it does not gate this change: the failure is confined to
one branch and `ai-review` is not a required context, so a red verdict leaves a PR `UNSTABLE`.

## What re-enabling does and does not expose

- **Cannot block a merge** — not a required context (D-0084), and canon submits `COMMENT`, never
  `REQUEST_CHANGES`.
- **Cannot auto-merge** — `auto-merge-ai-prs` is active but canon refuses for this repo at
  `auto-merge-ai-prs.yml:301` and again at the `auto_merge.repos` allowlist.
- **Fork surface unchanged and previously vetted** — `pull_request_target` on a public repo with
  self-hosted runners is safe here because a fork PR reaches only the no-PR-code trust job
  (`CLAUDE.md` § "Unified CI"). This restores a configuration that ran for months.
- ⚠️ **A cost channel reopens.** Every PR resumes LiteLLM spend, and this proxy is separately known
  for HTTP 402 on an exhausted balance. **If the disable was a spend decision rather than a flake
  response, that reason is recorded nowhere and D-0087 is wrong on motive** — but not on outcome:
  `gh workflow disable ai-review.yml` reverses it in one command, and D-0087 carries that command.

## Also in this change

- **`composition` read `active` throughout the window and was silent.** Its only PR-side triggers
  are `pull_request_review` and a `workflow_run` chained off **`ai-review`** completing, so
  disabling the parent silences the child while `gh workflow list` still shows the child healthy.
  Recorded as a trap in both files, since that listing is the first thing an auditor reaches for.
- **#596's premise is restored** — its items 1 and 2 were written assuming `ai-review` still runs,
  so they revert to their original form rather than resolving by deletion.
- **HANDOFF**: tag high-water mark moves to `framework/v0.50.0` (cut this session at `07b52e02`),
  #623 leaves the next-steps list, and #606's entry gains the warning that its branch is the one
  `ai-review` actually failed on — expect that failure to recur on a resubmission, non-blocking,
  and useful evidence for #543.

## Verification

`pre-commit run --all-files` green (conformance suite included). Two `#NNN`-at-line-start
markdownlint corruptions caught pre-push and reworded — the documented trap in `CLAUDE.md`
§ "Durable traps".

**This PR is itself the live test.** `ai-review` should now run on it; whatever it reports is the
first verdict since 2026-09-01. Two doc surfaces, C2. Merge is human-only on this repo; no
auto-merge attempted.

Closes #623
