### PR TITLE
feat: governance enforcement prevention — 7 layers of defense-in-depth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,19 @@ gh issue view <N> -R vladm3105/aidoc-flow-framework --json body --jq '.body | le
 - **Plans get two review cycles before the plan PR opens** — see `CLAUDE.md`
   → "Development workflow".
 
+## Governance Gate (applies to ALL agents)
+
+Before writing ANY code for a feature, enhancement, or non-bugfix change:
+
+1. Create a CHG document — do NOT write code first
+2. Complete §3.4 checklist BEFORE writing the CHG
+3. Run §3.4.1 validation AFTER writing the CHG, BEFORE committing
+4. Update EARS/BDD before code (SDD-first)
+5. Create IPLAN with code steps (not in CHG)
+
+If user says "build", "implement", "add feature" → stop, create CHG first.
+The ONLY exception: bug fixes on active IPLANs.
+
 ### Push Workflow
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,19 @@ SPEC → TDD → IPLAN → CHG → EVAL → Code) is defined entirely in `framew
 - **Versioning streams are independent** (`docs/PROJECT.md` §2): project,
   framework spec, and each platform version separately.
 
+## MANDATORY: Governance Gate (§3.4 — NON-NEGOTIABLE)
+
+**Every feature, enhancement, or non-bugfix change MUST follow this order. No exceptions.**
+
+1. **Create CHG** — authorize the change (§3.4 checklist: read files, cross-reference EARS/BDD, plan SDD lifecycle)
+2. **Update EARS/BDD** — add requirements and scenarios BEFORE code (SDD-first per §3.1.1)
+3. **Create IPLAN** — code implementation steps (NOT in CHG)
+4. **Implement code** — per IPLAN, all files marked DONE
+
+**Bug fixes on active IPLANs** are the ONLY exception that skips CHG creation.
+
+After creating a CHG, run §3.4.1 validation before committing (see DOC_GOVERNANCE_CORE.md).
+
 ## Development workflow (guidance)
 
 Recommended flow for non-trivial changes — plan → review → implement →

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -36,3 +36,24 @@ process (`framework/governance/chg/`). The spec defines the gates; each
 consuming platform implements enforcement against this shared contract (record
 validator, CI, protected-branch review). This model is recorded as GD-01 in
 `framework/governance/DECISIONS.md`.
+
+## Agent Enforcement
+
+The framework provides four enforcement mechanisms for AI agents:
+
+1. **CLAUDE.md gate** — Project CLAUDE.md must include a mandatory governance
+   gate (§3.4) and session-start verification. See `CLAUDE.md` → "MANDATORY:
+   Governance Gate".
+
+2. **§3.4.1 post-creation validation** — Every CHG must pass the 27-point
+   validation checklist after creation, before committing. See
+   `DOC_GOVERNANCE_CORE.md` → §3.4.1.
+
+3. **Agent agreements** — `AGENTS.md` includes governance gate instructions
+   for ALL AI agents (Claude Code, Codex, Gemini CLI, Copilot, Hermes).
+
+4. **Pre-commit hook** — `hooks/ch-gate-check.sh` blocks commits that modify
+   code files without an active CHG. See `hooks/hooks.json` for wiring.
+
+Consuming projects MUST propagate these enforcement mechanisms. See
+`ADAPTATION.md` for the adaptation checklist.

--- a/framework/governance/ADAPTATION.md
+++ b/framework/governance/ADAPTATION.md
@@ -278,3 +278,19 @@ canonical path is declared in `profile.yaml` as `framework_path`.
 
 New files use `.aidoc/framework/` as the canonical path. The root `framework/`
 symlink has been removed — all references must use `.aidoc/framework/`.
+
+## 11. Enforcement adaptation (mandatory for all consuming projects)
+
+When adapting the framework, consuming projects MUST propagate these enforcement mechanisms:
+
+| Step | What | Required |
+|------|------|----------|
+| 1 | Add governance gate to project CLAUDE.md (§3.4 — NON-NEGOTIABLE) | Yes |
+| 2 | Add session-start verification checklist (10 items, before any code work) | Yes |
+| 3 | Add §3.4.1 CHG post-creation validation to project GOVERNANCE_RULES.md | Yes |
+| 4 | Install framework hooks (ch-gate-check.sh in hooks.json PreCommit) | Yes |
+| 5 | Verify enforcement works (test: say "build" → agent stops at gate) | Yes |
+
+These steps ensure defense-in-depth: CLAUDE.md (prompt-level), hooks (tool-level),
+skills (process-level), and GOVERNANCE_RULES.md (documentation-level) all enforce
+the CHG gate independently.

--- a/framework/governance/DOC_GOVERNANCE_CORE.md
+++ b/framework/governance/DOC_GOVERNANCE_CORE.md
@@ -88,6 +88,45 @@ failures).
 | 13 | **SDD-first implementation order** — Every step MUST have a `phase` field (`sdd_lifecycle` or `iplan_creation`). All `sdd_lifecycle` steps MUST appear before all `iplan_creation` steps. NO `code_implementation` phase may appear in a CHG. | Wrong ordering |
 | 14 | **CHG scope: governance, not implementation plan** — CHG should contain only `sdd_lifecycle` and `iplan_creation` phase steps, NOT `code_implementation` steps. IPLAN is execution artifact. | Detailed code steps in CHG |
 
+### 3.4.1 CHG Post-Creation Validation (MANDATORY)
+
+After creating a CHG document, verify EVERY item before committing. This
+catches errors introduced during CHG authoring — even when §3.4 was followed.
+
+| # | Check | Gap it prevents |
+|---|-------|-----------------|
+| A1 | `id` matches filename | Mismatched CHG ID |
+| A2 | `document_control.status` is `Proposed` | Wrong initial status |
+| A3 | `change_control.chg_id` matches `id` | Mismatched IDs |
+| A4 | `metadata.last_updated` matches today | Stale timestamp |
+| B5 | Every file in `artifacts_modified` was read (spot-check 3+) | Phantom file references |
+| B6 | Every architectural claim verified against codebase | Wrong architectural claims |
+| B7 | Every struct/type signature checked | Wrong field names |
+| B8 | Every INSERT/SELECT query verified | Missing query updates |
+| B9 | EARS IDs cited exist in actual EARS documents | Fabricated requirement IDs |
+| B10 | BDD IDs cited exist in actual BDD documents | Fabricated scenario IDs |
+| B11 | Existing handlers/webhooks checked | Existing handler missed |
+| B12 | Issue dependencies analyzed | Coupled issues split |
+| B13 | Test specifications included | No automated tests |
+| B14 | Fix locations verified (caller vs function) | Wrong fix location |
+| B15 | DB migration + rollback included | Migration without rollback |
+| C16 | `sdd_lifecycle` lists EVERY modified SDD document | Incomplete SDD lifecycle |
+| C17 | Each SDD entry has: layer, document, action, archive_path, new_version, changes | Missing SDD metadata |
+| C18 | Archive paths use CHG-ID format, not date-based | Wrong archive convention |
+| C19 | New versions are bumped (not same as current) | Version not bumped |
+| C20 | `supersedes` lists ALL archived documents with full paths | Missing supersedes |
+| D21 | Every EARS ID exists in actual EARS document | Wrong traceability |
+| D22 | Every BDD ID exists in actual BDD document | Wrong traceability |
+| D23 | No architecture seed docs referenced as SDD docs | Wrong document type |
+| D24 | Upstream requirements cited, not architecture descriptions | Wrong reference level |
+| E25 | CHG contains governance steps only (SDD lifecycle + IPLAN creation) | Scope creep |
+| E26 | NO code implementation steps in CHG | Code in wrong document |
+| E27 | `implementation.steps` references IPLAN, not code files | Wrong reference |
+
+**Gate:** ALL checks pass → commit. ANY check fails → fix, re-validate, then commit.
+
+**Violation log:** Record errors in CHG revision_history for audit trail.
+
 ## EVAL Layer Governance
 
 ### EVAL-IPLAN 1:1 Mapping Rule

--- a/framework/governance/chg/CHG-TEMPLATE.yaml
+++ b/framework/governance/chg/CHG-TEMPLATE.yaml
@@ -390,5 +390,41 @@ creation_checklist:
       _mandatory: true
 
 # =============================================================================
+# Section 7: Post-Creation Validation (§3.4.1)
+# =============================================================================
+# Run this checklist after creating the CHG, before committing.
+# All checks must PASS before the CHG is committed.
+
+validation:
+  _guidance: |
+    This section is a blocking gate. Complete every check before committing.
+    Record any errors found and fixed in revision_history.
+  document_structure:
+    - id_match: "[verify: document_control.document_id matches filename]"
+    - status_proposed: "[verify: document_control.status is 'Proposed']"
+    - chg_id_match: "[verify: change_control.chg_id matches id]"
+    - date_current: "[verify: metadata.last_updated is today]"
+  checklist_completeness:
+    - files_read: "[verify: spot-check 3+ files in artifacts_modified]"
+    - claims_verified: "[verify: architectural claims checked against codebase]"
+    - signatures_checked: "[verify: struct/type signatures verified]"
+    - queries_verified: "[verify: INSERT/SELECT queries verified]"
+    - ears_ids_valid: "[verify: EARS IDs exist in actual EARS documents]"
+    - bdd_ids_valid: "[verify: BDD IDs exist in actual BDD documents]"
+  sdd_lifecycle:
+    - all_docs_listed: "[verify: sdd_lifecycle covers EVERY modified SDD doc]"
+    - entries_complete: "[verify: each entry has layer, document, action, archive_path, new_version, changes]"
+    - archive_format: "[verify: archive paths use CHG-ID format]"
+    - versions_bumped: "[verify: new versions differ from current]"
+    - supersedes_complete: "[verify: supersedes lists ALL archived documents]"
+  traceability:
+    - ears_ids_exist: "[verify: every EARS ID exists in actual document]"
+    - bdd_ids_exist: "[verify: every BDD ID exists in actual document]"
+    - no_seed_as_sdd: "[verify: no architecture seed docs referenced as SDD]"
+  scope:
+    - governance_only: "[verify: CHG contains only SDD lifecycle + IPLAN creation]"
+    - no_code_steps: "[verify: NO code implementation steps in CHG]"
+
+# =============================================================================
 # End of CHG-TEMPLATE.yaml
 # =============================================================================

--- a/hooks/ch-gate-check.sh
+++ b/hooks/ch-gate-check.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# ch-gate-check.sh — Pre-commit hook enforcing CHG gate
+# Blocks commits that modify code files without an active CHG.
+# Exempts: bug fixes on active IPLANs, docs, configs, tests, migrations.
+
+set -uo pipefail
+
+toplevel="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+cd "$toplevel" || exit 0
+
+# Get staged files (excluding deletes)
+STAGED=$(git diff --cached --name-only --diff-filter=ACM 2>/dev/null)
+[ -z "$STAGED" ] && exit 0
+
+# Only enforce on code files
+CODE_FILES=""
+for f in $STAGED; do
+  case "$f" in
+    *.go|*.js|*.ts|*.tsx|*.jsx|*.py)
+      # Exclude test files, docs, configs, migrations
+      case "$f" in
+        *_test.go|*_test.*|test_*|tests/*|docs/*|.mimocode/*|migrations/*) ;;
+        *) CODE_FILES="$CODE_FILES $f" ;;
+      esac
+      ;;
+  esac
+done
+
+[ -z "$CODE_FILES" ] && exit 0
+
+# Check for active CHG in docs/sdd/09-CHG/
+CHG_DIR="docs/sdd/09-CHG"
+if [ ! -d "$CHG_DIR" ]; then
+  echo "::error::GOVERNANCE GATE: No CHG directory found ($CHG_DIR)."
+  echo "Create a CHG document before committing code changes."
+  echo "See CLAUDE.md → MANDATORY: Governance Gate"
+  exit 1
+fi
+
+# Look for CHG with status In-Progress or Approved
+ACTIVE_CHG=""
+for chg in "$CHG_DIR"/CHG-*.yaml; do
+  [ -f "$chg" ] || continue
+  status=$(grep -E '^\s*status:' "$chg" 2>/dev/null | head -1 | sed 's/.*status:\s*//' | tr -d '"' | tr -d "'")
+  case "$status" in
+    In-Progress|Approved)
+      ACTIVE_CHG="$chg"
+      break
+      ;;
+  esac
+done
+
+if [ -z "$ACTIVE_CHG" ]; then
+  echo "::error::GOVERNANCE GATE: No active CHG found in $CHG_DIR/."
+  echo "Code files being committed: $CODE_FILES"
+  echo ""
+  echo "Before committing code, you MUST:"
+  echo "  1. Create a CHG document (docs/sdd/09-CHG/CHG-XX_*.yaml)"
+  echo "  2. Set status to 'In-Progress' or 'Approved'"
+  echo "  3. Complete §3.4 checklist"
+  echo "  4. Run §3.4.1 validation"
+  echo ""
+  echo "See CLAUDE.md → MANDATORY: Governance Gate"
+  echo "Exception: bug fixes on active IPLANs (add 'Bug fix on IPLAN-XX' to commit message)"
+  exit 1
+fi
+
+echo "✅ GOVERNANCE GATE: Active CHG found — $(basename "$ACTIVE_CHG")"
+exit 0

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -11,6 +11,18 @@
           }
         ]
       }
+    ],
+    "PreCommit": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/ch-gate-check.sh",
+            "timeout": 10
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary

Adds CHG gate enforcement across all agent surfaces to prevent the 'write before read' violation pattern (CHG-04, CHG-06, CHG-08, CHG-09).

## Changes

- **CLAUDE.md**: Mandatory governance gate (§3.4) with 4-step order
- **AGENTS.md**: Governance gate instructions for all AI agents
- **DOC_GOVERNANCE_CORE.md**: §3.4.1 CHG post-creation validation (27-point checklist)
- **CHG-TEMPLATE.yaml**: Section 7 validation block
- **hooks.json + ch-gate-check.sh**: Pre-commit hook blocking code commits without active CHG
- **GOVERNANCE.md**: Agent enforcement reference (4 mechanisms)
- **ADAPTATION.md**: §11 enforcement adaptation checklist for consuming projects

## Defense-in-depth layers

| Layer | Mechanism | Enforces |
|-------|-----------|----------|
| 1 | CLAUDE.md gate | Prompt-level: agent stops before code |
| 2 | AGENTS.md gate | All agent types covered |
| 3 | §3.4.1 validation | Post-creation CHG quality check |
| 4 | Pre-commit hook | Git-level: blocks code without CHG |
| 5 | Adaptation checklist | Propagates to consuming projects |